### PR TITLE
Better checkpoints

### DIFF
--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -27,8 +27,8 @@ model:
     distributed_timeout: 60.0
     training_dtype: float32
 pretrained:
-  path: null
-  format: distributed
+  pretrained_checkpoint_path: null
+  pretrained_checkpoint_type: distributed
 batch:
   micro_batch_size: 1
   depth_first_micro_batches: 1
@@ -42,13 +42,13 @@ data:
   - 969.0
   - 30.0
   - 1.0
-  format: list
-  path:
+  dataset_source: list
+  data_path:
   - fkgtiu
   data_sample_warn_time_ms: 1000.0
 profiling:
-  cuda: false
-  ranks: []
+  profile_cuda: false
+  profile_ranks: []
 optimizer:
   weight_decay: 0.01
   initial_loss_scale: 65536.0

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -27,8 +27,8 @@ model:
     distributed_timeout: 60.0
     training_dtype: float32
 pretrained:
-  pretrained_checkpoint_path: null
-  pretrained_checkpoint_type: distributed
+  path: null
+  format: distributed
 batch:
   micro_batch_size: 1
   depth_first_micro_batches: 1
@@ -42,13 +42,13 @@ data:
   - 969.0
   - 30.0
   - 1.0
-  dataset_source: list
-  data_path:
+  format: list
+  path:
   - fkgtiu
   data_sample_warn_time_ms: 1000.0
 profiling:
-  profile_cuda: false
-  profile_ranks: []
+  cuda: false
+  ranks: []
 optimizer:
   weight_decay: 0.01
   initial_loss_scale: 65536.0

--- a/fast_llm/config.py
+++ b/fast_llm/config.py
@@ -278,7 +278,7 @@ class Config:
     __class_validated__: typing.ClassVar[bool] = True
     _abstract: typing.ClassVar[bool] = False
     _validated: bool = Field(init=False, repr=False)
-    _unknown_fields: dict[str] = Field(init=False, repr=False)
+    _unknown_fields: dict[str, typing.Any] = Field(init=False, repr=False)
 
     def __post_init__(self):
         """
@@ -629,7 +629,7 @@ class Config:
     @classmethod
     def from_dict(
         cls,
-        default: typing.Union["Config", dict[str]],
+        default: typing.Union["Config", dict[str, typing.Any]],
         *updates: typing.Union["Config", dict[str | tuple[str, ...], typing.Any]],
         strict: bool = True,
     ):
@@ -654,7 +654,7 @@ class Config:
     @classmethod
     def from_flat_dict(
         cls,
-        default: dict[str],
+        default: dict[str, typing.Any],
         strict: bool = True,
     ):
         # TODO v0.2: Remove flat format
@@ -663,7 +663,7 @@ class Config:
     @classmethod
     def _from_dict(
         cls,
-        default: dict[str],
+        default: dict[str, typing.Any],
         strict: bool = True,
         flat: bool = False,
     ):
@@ -776,7 +776,7 @@ class Config:
         return {key: cls._from_dict_nested(value_, args[1], strict) for key, value_ in value.items()}
 
     @classmethod
-    def _handle_renamed_field(cls, default: dict[str], old_name: str, new_name: str):
+    def _handle_renamed_field(cls, default: dict[str, typing.Any], old_name: str, new_name: str):
         if old_name in default:
             warnings.warn(f"Field `{old_name}` is deprecated in class {get_type_name(cls)}, use `{new_name}` instead.")
             default[new_name] = default.pop(old_name)

--- a/fast_llm/engine/base_model/config.py
+++ b/fast_llm/engine/base_model/config.py
@@ -4,7 +4,7 @@ from fast_llm.config import Config, config_class
 
 if typing.TYPE_CHECKING:
     from fast_llm.engine.config_utils.tensor_space import TensorSpace
-    from fast_llm.engine.multi_stage.conversion import ModelConverter
+    from fast_llm.engine.multi_stage.conversion import ExternalModelConverter
 
 
 @config_class()
@@ -30,7 +30,7 @@ class BaseModelArchitectureConfig(Config):
         return self.get_architecture().compare(model_config.get_architecture(), log_fn)
 
     @classmethod
-    def get_converter_class(cls, model_type: str | None = None) -> type["ModelConverter"]:
+    def get_converter_class(cls, model_type: str | None = None) -> type["ExternalModelConverter"]:
         raise NotImplementedError()
 
 

--- a/fast_llm/engine/config_utils/checkpoint.py
+++ b/fast_llm/engine/config_utils/checkpoint.py
@@ -2,6 +2,7 @@
 import enum
 import logging
 import pathlib
+import typing
 import warnings
 
 from fast_llm.config import Config, Field, FieldHint, check_field, config_class
@@ -15,7 +16,7 @@ CHECKPOINT_VERSION = "0.1"
 KNOWN_CHECKPOINT_VERSIONS = ("0", "0.1")
 
 
-class CheckpointType(str, enum.Enum):
+class CheckpointFormat(str, enum.Enum):
     # Distributed checkpoint for fast checkpointing and resuming.
     distributed = "distributed"
     # Model state dict, for safe long-term storage in Fast-LLM format.
@@ -56,8 +57,8 @@ class CheckpointPathConfigBase(Config):
 @config_class()
 class CheckpointConfigBase(Config):
     _abstract = True
-    format: CheckpointType = Field(
-        default=CheckpointType.distributed,
+    format: CheckpointFormat = Field(
+        default=CheckpointFormat.distributed,
         desc="Format of the checkpoint.",
         hint=FieldHint.core,
     )
@@ -70,14 +71,14 @@ class CheckpointConfigBase(Config):
     @classmethod
     def _from_dict(
         cls,
-        default: dict[str],
+        default: dict[str, typing.Any],
         strict: bool = True,
         flat: bool = False,
     ):
         # TODO v0.2: Remove.
         if default.get("format", None) == "huggingface":
             warnings.warn(f"`huggingface` checkpoint format has been renamed to `external`.")
-            default["format"] = CheckpointType.external.value
+            default["format"] = CheckpointFormat.external.value
         cls._handle_renamed_field(default, "imported_type", "model_type")
         return super()._from_dict(default, strict, flat)
 
@@ -91,7 +92,7 @@ class CheckpointStateConfigBase(Config):
     @classmethod
     def _from_dict(
         cls,
-        default: dict[str],
+        default: dict[str, typing.Any],
         strict: bool = True,
         flat: bool = False,
     ):

--- a/fast_llm/engine/config_utils/checkpoint.py
+++ b/fast_llm/engine/config_utils/checkpoint.py
@@ -66,11 +66,6 @@ class CheckpointConfigBase(Config):
         desc="Model type for external models (ex. Huggingace model name).",
         hint=FieldHint.feature,
     )
-    fast_llm_config: bool = Field(
-        default=False,
-        desc="Save/load the full fast-llm model configuration, including the distributed and multi-stage configurations.",
-        hint=FieldHint.feature,
-    )
 
     @classmethod
     def _from_dict(

--- a/fast_llm/engine/config_utils/checkpoint.py
+++ b/fast_llm/engine/config_utils/checkpoint.py
@@ -1,0 +1,117 @@
+# TODO: Use packaging.version? (Safer but extra requirement)
+import enum
+import logging
+import pathlib
+
+from fast_llm.config import Config, Field, FieldHint, check_field, config_class
+from fast_llm.engine.config_utils.data_type import DataType
+from fast_llm.utils import Assert
+
+logger = logging.getLogger(__name__)
+
+# TODO: Use packaging.version? (Safer but extra requirement)
+CHECKPOINT_VERSION = "0.1"
+KNOWN_CHECKPOINT_VERSIONS = ("0", "0.1")
+
+
+class CheckpointType(str, enum.Enum):
+    # Distributed checkpoint for fast checkpointing and resuming.
+    distributed = "distributed"
+    # Model state dict, for safe long-term storage in Fast-LLM format.
+    state_dict = "state_dict"
+    # A checkpoint format external to Fast-LLM.
+    external = "external"
+
+
+@config_class()
+class CheckpointPathConfigBase(Config):
+    _abstract = True
+    path: pathlib.Path | None = Field(
+        default=None,
+        desc="Location of the checkpoint.",
+        hint=FieldHint.core,
+    )
+
+
+@config_class()
+class CheckpointConfigBase(Config):
+    _abstract = True
+    format: CheckpointType = Field(
+        default=CheckpointType.distributed,
+        desc="Format of the checkpoint.",
+        hint=FieldHint.core,
+    )
+    model_type: str | None = Field(
+        default=None,
+        desc="Model type for external models (ex. Huggingace model name).",
+        hint=FieldHint.feature,
+    )
+    architecture_config: bool = Field(
+        default=False,
+        desc="Save/load the model architecture configuration.",
+        hint=FieldHint.feature,
+    )
+    base_model_config: bool = Field(
+        default=False,
+        desc="Save/load the full base model configuration, including the non-architecture fields.",
+        hint=FieldHint.feature,
+    )
+    fast_llm_config: bool = Field(
+        default=False,
+        desc="Save/load the full fast-llm model configuration, including the distributed and multi-stage configurations.",
+        hint=FieldHint.feature,
+    )
+
+    @property
+    def compare_log_fn(self):
+        return logger.warning if self.architecture_config else ValueError
+
+    def _validate(self):
+        if self.fast_llm_config:
+            self.base_model_config = True
+        if self.base_model_config:
+            self.architecture_config = True
+        super()._validate()
+
+
+@config_class()
+class CheckpointStateConfigBase(Config):
+    _abstract = True
+    model_weights: bool = Field(default=True, desc="Save/load the model weights.", hint=FieldHint.feature)
+    optimizer_state: bool = Field(default=False, desc="Save/load the optimizer state.", hint=FieldHint.feature)
+
+
+@config_class()
+class CheckpointSaveConfigBase(Config):
+    _abstract = True
+    parameters_per_file: int = Field(
+        default=2**32,
+        desc="Limit the number of parameters saved in each file.",
+        hint=FieldHint.feature,
+        valid=check_field(Assert.geq, 2**20),
+    )
+    data_type: DataType | None = Field(
+        default=None,
+        desc="Data type to save the checkpoint.",
+        hint=FieldHint.feature,
+    )
+
+
+@config_class()
+class CheckpointMetadataConfig(CheckpointPathConfigBase, CheckpointConfigBase):
+    _abstract = False
+
+
+@config_class()
+class CheckpointSaveConfig(CheckpointMetadataConfig, CheckpointStateConfigBase, CheckpointSaveConfigBase):
+    _abstract = False
+
+
+@config_class()
+class CheckpointLoadConfig(CheckpointMetadataConfig, CheckpointStateConfigBase):
+    _abstract = False
+
+
+# @config_class()
+# class TrainingExportConfig(CheckpointConfigBase, CheckpointStateConfigBase, CheckpointSaveConfigBase):
+#    _abstract=False

--- a/fast_llm/engine/config_utils/run.py
+++ b/fast_llm/engine/config_utils/run.py
@@ -127,7 +127,6 @@ class Run:
     """
 
     _experiment_dir: pathlib.Path | None
-    _checkpoint_dir: pathlib.Path | None
 
     def __init__(
         self,
@@ -153,10 +152,7 @@ class Run:
         if self._config.experiment_dir is not None:
             self._experiment_directory = self._config.experiment_dir.resolve()
             self.dataset_cache_dir = self._experiment_directory / "dataset_cache"
-            self._checkpoint_dir = self._experiment_directory / "checkpoints"
-            self._export_dir = self._experiment_directory / "export"
             if self._is_main_rank:
-                self._checkpoint_dir.mkdir(exist_ok=True, parents=True)
                 (self._experiment_directory / "runs").mkdir(exist_ok=True, parents=True)
                 run = len(list((self._experiment_directory / "runs").iterdir()))
                 (self._experiment_directory / "runs" / str(run)).mkdir()
@@ -170,7 +166,7 @@ class Run:
             self._artifact_dir = run_dir / "artifacts" / str(self._distributed_config.rank)
             log_dir = run_dir / "logs"
         else:
-            _experiment_directory, self._checkpoint_dir, self._artifact_dir, log_dir = None, None, None, None
+            _experiment_directory, self._artifact_dir, log_dir = None, None, None
             self.dataset_cache_dir = None
             self.index = None
 

--- a/fast_llm/engine/huggingface/config.py
+++ b/fast_llm/engine/huggingface/config.py
@@ -5,7 +5,7 @@ import typing
 
 import transformers
 
-from fast_llm.engine.config_utils.checkpoint import CheckpointMetadataConfig, CheckpointType
+from fast_llm.engine.config_utils.checkpoint import CheckpointLoadMetadataConfig, CheckpointType
 from fast_llm.engine.multi_stage.config import FastLLMModelConfig
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,9 @@ class HuggingfaceModelConfig(transformers.PretrainedConfig):
             transformers.configuration_utils.CONFIG_NAME = _backup
 
     @classmethod
-    def _get_config_dict(cls, pretrained_model_name_or_path: str | os.PathLike | CheckpointMetadataConfig, **kwargs):
+    def _get_config_dict(
+        cls, pretrained_model_name_or_path: str | os.PathLike | CheckpointLoadMetadataConfig, **kwargs
+    ):
         # TODO: Support download from hub/url
 
         # Unused arguments, remove to avoid warnings.
@@ -56,13 +58,13 @@ class HuggingfaceModelConfig(transformers.PretrainedConfig):
 
         # Get the pretrained config.
         if "pretrained" in kwargs:
-            assert isinstance(kwargs["pretrained"], CheckpointMetadataConfig)
+            assert isinstance(kwargs["pretrained"], CheckpointLoadMetadataConfig)
             assert kwargs["pretrained"].path == pretrained_model_name_or_path
             pretrained = kwargs.pop("pretrained")
-        elif isinstance(pretrained_model_name_or_path, CheckpointMetadataConfig):
+        elif isinstance(pretrained_model_name_or_path, CheckpointLoadMetadataConfig):
             pretrained = pretrained_model_name_or_path
         else:
-            pretrained = CheckpointMetadataConfig(
+            pretrained = CheckpointLoadMetadataConfig(
                 path=pathlib.Path(pretrained_model_name_or_path),
                 format=CheckpointType.state_dict,
             )

--- a/fast_llm/engine/huggingface/config.py
+++ b/fast_llm/engine/huggingface/config.py
@@ -5,7 +5,8 @@ import typing
 
 import transformers
 
-from fast_llm.engine.multi_stage.config import CheckpointType, FastLLMModelConfig, PretrainedConfig
+from fast_llm.engine.config_utils.checkpoint import CheckpointMetadataConfig, CheckpointType
+from fast_llm.engine.multi_stage.config import FastLLMModelConfig
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ class HuggingfaceModelConfig(transformers.PretrainedConfig):
             transformers.configuration_utils.CONFIG_NAME = _backup
 
     @classmethod
-    def _get_config_dict(cls, pretrained_model_name_or_path: str | os.PathLike | PretrainedConfig, **kwargs):
+    def _get_config_dict(cls, pretrained_model_name_or_path: str | os.PathLike | CheckpointMetadataConfig, **kwargs):
         # TODO: Support download from hub/url
 
         # Unused arguments, remove to avoid warnings.
@@ -55,13 +56,13 @@ class HuggingfaceModelConfig(transformers.PretrainedConfig):
 
         # Get the pretrained config.
         if "pretrained" in kwargs:
-            assert isinstance(kwargs["pretrained"], PretrainedConfig)
+            assert isinstance(kwargs["pretrained"], CheckpointMetadataConfig)
             assert kwargs["pretrained"].path == pretrained_model_name_or_path
             pretrained = kwargs.pop("pretrained")
-        elif isinstance(pretrained_model_name_or_path, PretrainedConfig):
+        elif isinstance(pretrained_model_name_or_path, CheckpointMetadataConfig):
             pretrained = pretrained_model_name_or_path
         else:
-            pretrained = PretrainedConfig(
+            pretrained = CheckpointMetadataConfig(
                 path=pathlib.Path(pretrained_model_name_or_path),
                 format=CheckpointType.state_dict,
             )

--- a/fast_llm/engine/huggingface/config.py
+++ b/fast_llm/engine/huggingface/config.py
@@ -5,7 +5,7 @@ import typing
 
 import transformers
 
-from fast_llm.engine.config_utils.checkpoint import CheckpointLoadMetadataConfig, CheckpointType
+from fast_llm.engine.config_utils.checkpoint import CheckpointFormat, CheckpointLoadMetadataConfig
 from fast_llm.engine.multi_stage.config import FastLLMModelConfig
 
 logger = logging.getLogger(__name__)
@@ -66,7 +66,7 @@ class HuggingfaceModelConfig(transformers.PretrainedConfig):
         else:
             pretrained = CheckpointLoadMetadataConfig(
                 path=pathlib.Path(pretrained_model_name_or_path),
-                format=CheckpointType.state_dict,
+                format=CheckpointFormat.state_dict,
             )
         metadata = cls.model_config_class.load_pretrained_metadata(pretrained)
         updates = {}

--- a/fast_llm/engine/huggingface/model.py
+++ b/fast_llm/engine/huggingface/model.py
@@ -5,9 +5,10 @@ import typing
 import transformers.modeling_outputs
 
 from fast_llm.config import NoAutoValidate
+from fast_llm.engine.config_utils.checkpoint import CheckpointLoadConfig, CheckpointType
 from fast_llm.engine.distributed.config import PhaseType
 from fast_llm.engine.huggingface.config import HuggingfaceModelConfig
-from fast_llm.engine.multi_stage.config import CheckpointType, PretrainedCheckpointConfig, PretrainedConfig, StageMode
+from fast_llm.engine.multi_stage.config import StageMode
 from fast_llm.engine.multi_stage.fast_llm_model import FastLLMModel
 from fast_llm.engine.schedule.config import BatchConfig, ScheduleConfig
 from fast_llm.engine.schedule.runner import ScheduleRunner
@@ -58,14 +59,14 @@ class HuggingfacePreTrainedModel(transformers.PreTrainedModel):
     @classmethod
     def from_pretrained(
         cls,
-        pretrained_model_name_or_path: str | os.PathLike | PretrainedCheckpointConfig,
+        pretrained_model_name_or_path: str | os.PathLike | CheckpointLoadConfig,
         *,
         mode: StageMode = StageMode.inference,
         **kwargs,
     ):
         # Pretrained config.
-        if not isinstance(pretrained_model_name_or_path, PretrainedConfig):
-            pretrained_model_name_or_path = PretrainedCheckpointConfig(
+        if not isinstance(pretrained_model_name_or_path, CheckpointLoadConfig):
+            pretrained_model_name_or_path = CheckpointLoadConfig(
                 path=pathlib.Path(pretrained_model_name_or_path),
                 format=CheckpointType.state_dict,
             )

--- a/fast_llm/engine/huggingface/model.py
+++ b/fast_llm/engine/huggingface/model.py
@@ -5,7 +5,7 @@ import typing
 import transformers.modeling_outputs
 
 from fast_llm.config import NoAutoValidate
-from fast_llm.engine.config_utils.checkpoint import CheckpointLoadConfig, CheckpointType
+from fast_llm.engine.config_utils.checkpoint import CheckpointFormat, CheckpointLoadConfig
 from fast_llm.engine.distributed.config import PhaseType
 from fast_llm.engine.huggingface.config import HuggingfaceModelConfig
 from fast_llm.engine.multi_stage.config import StageMode
@@ -68,7 +68,7 @@ class HuggingfacePreTrainedModel(transformers.PreTrainedModel):
         if not isinstance(pretrained_model_name_or_path, CheckpointLoadConfig):
             pretrained_model_name_or_path = CheckpointLoadConfig(
                 path=pathlib.Path(pretrained_model_name_or_path),
-                format=CheckpointType.state_dict,
+                format=CheckpointFormat.state_dict,
             )
 
         config_updates = {}

--- a/fast_llm/engine/multi_stage/checkpoint.py
+++ b/fast_llm/engine/multi_stage/checkpoint.py
@@ -1,0 +1,110 @@
+import json
+import logging
+
+import safetensors.torch
+import torch
+import yaml
+
+from fast_llm.core.distributed import safe_barrier
+from fast_llm.engine.config_utils.checkpoint import CheckpointSaveConfig
+from fast_llm.engine.distributed.distributed import Distributed
+
+logger = logging.getLogger(__name__)
+
+
+def _export_safetensors_metadata(metadata):
+    """
+    Safetensor only accepts string entries, so we convert to string explicitly.
+    We use yaml rather than json because json requires explicit quotation marks on strings, which breaks things.
+    (ex. "format": "pt" becomes '"pt"' which breaks huggingface models.)
+    We avoid using safe_dump for scalars because it adds junk ("\n...\n") at the end of the string
+    (decoding is unaffected.)
+    """
+    return {
+        key: str(value) if isinstance(value, (str, int, float, bool)) else yaml.safe_dump(value)
+        for key, value in metadata.items()
+    }
+
+
+class StateDictSaver:
+    def __init__(
+        self,
+        config: CheckpointSaveConfig,
+        *,
+        distributed: Distributed,
+        metadata,
+        base_file_name: str,
+    ):
+        self._config = config
+        self._metadata = metadata
+        self.distributed = distributed
+        self._distributed_config = distributed.config
+        self.base_file_name = (
+            base_file_name
+            if self._distributed_config.pipeline_parallel == 1
+            else f"{base_file_name}_{self._distributed_config.pipeline_rank}"
+        )
+        # All ranks reconstruct the pipeline-parallel state (for simplicity), but only one saves it.
+        self._do_save = self._distributed_config.data_rank == self._distributed_config.tensor_rank == 0
+
+    def add_tensor(self, name: str, tensor: torch.Tensor):
+        assert name not in self.tensors
+        self.tensors[name] = tensor
+        self.param_count += tensor.numel()
+        if self.param_count >= self._config.parameters_per_file:
+            self._save_next_file()
+
+    def __enter__(self):
+        self.file_count = 0
+        self.param_count = 0
+        self.tensors = {}
+        self.index = {}
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.tensors:
+            # Save the last file.
+            self._save_next_file()
+
+        if self._do_save and self._distributed_config.pipeline_parallel != 1:
+            # Combine the indexes from all pipeline ranks.
+            logger.info(f"Merging pipeline-parallel indexes.")
+            json.dump(
+                self.index, (self._config.path / f"index_{self._distributed_config.pipeline_rank}.json").open("w")
+            )
+            safe_barrier(self.distributed.pipeline_group, "save state dict")
+            if self._distributed_config.pipeline_rank == 0:
+                self.index = {}
+                for rank in range(self._distributed_config.pipeline_parallel):
+                    file_name = self._config.path / f"index_{rank}.json"
+                    local_index = json.load(file_name.open("r"))
+                    for key, value in local_index.items():
+                        assert key not in self.index, key
+                        self.index[key] = value
+                    file_name.unlink()
+
+        if self._distributed_config.rank == 0:
+            path = self._config.path / f"{self.base_file_name}.safetensors.index.json"
+            logger.info(f"Saving index to {path}")
+            # Save the index.
+            json.dump(
+                {"metadata": self._metadata, "weight_map": self.index},
+                path.open("w"),
+                indent=4,
+            )
+
+    def _save_next_file(self):
+        file_name = f"{self.base_file_name}_{self.file_count}.safetensors"
+        if self._do_save:
+            logger.info(f"Saving tensors to {self._config.path / file_name}")
+            safetensors.torch.save_file(
+                tensors=self.tensors,
+                filename=self._config.path / file_name,
+                metadata=_export_safetensors_metadata(self._metadata),
+            )
+        for name_ in self.tensors:
+            assert name_ not in self.index
+            self.index[name_] = file_name
+        self.file_count += 1
+        self.param_count = 0
+        self.tensors = {}

--- a/fast_llm/engine/multi_stage/config.py
+++ b/fast_llm/engine/multi_stage/config.py
@@ -9,7 +9,7 @@ from fast_llm.engine.config_utils.checkpoint import (
     CHECKPOINT_VERSION,
     KNOWN_CHECKPOINT_VERSIONS,
     CheckpointLoadConfig,
-    CheckpointMetadataConfig,
+    CheckpointLoadMetadataConfig,
     CheckpointType,
 )
 from fast_llm.engine.distributed.config import DistributedConfig
@@ -211,7 +211,7 @@ class FastLLMModelConfig(Config):
     @classmethod
     def from_pretrained(
         cls,
-        pretrained: CheckpointMetadataConfig,
+        pretrained: CheckpointLoadMetadataConfig,
         default: "FastLLMModelConfig" = None,
     ):
         # TODO: Add *updates?
@@ -222,7 +222,7 @@ class FastLLMModelConfig(Config):
     @classmethod
     def from_metadata(
         cls,
-        pretrained: CheckpointMetadataConfig,
+        pretrained: CheckpointLoadMetadataConfig,
         metadata: dict,
         default: "FastLLMModelConfig" = None,
         updates: dict[str | tuple[str, ...], typing.Any] | None = None,
@@ -261,7 +261,7 @@ class FastLLMModelConfig(Config):
     @classmethod
     def _from_metadata_v0(
         cls,
-        pretrained: CheckpointMetadataConfig,
+        pretrained: CheckpointLoadMetadataConfig,
         metadata: dict,
         default: "FastLLMModelConfig" = None,
         updates: dict[str | tuple[str, ...], typing.Any] | None = None,
@@ -301,7 +301,7 @@ class FastLLMModelConfig(Config):
         return config
 
     @classmethod
-    def load_pretrained_metadata(cls, pretrained: CheckpointMetadataConfig):
+    def load_pretrained_metadata(cls, pretrained: CheckpointLoadMetadataConfig):
         import yaml
 
         base_model_config_cls = cls.get_base_model_config_cls()

--- a/fast_llm/engine/multi_stage/config.py
+++ b/fast_llm/engine/multi_stage/config.py
@@ -1,12 +1,17 @@
 import enum
 import json
 import logging
-import pathlib
 import typing
 
 from fast_llm.config import Config, Field, FieldHint, NoAutoValidate, check_field, config_class, skip_valid_if_none
 from fast_llm.engine.base_model.config import BaseModelConfig
-from fast_llm.engine.config_utils.data_type import DataType
+from fast_llm.engine.config_utils.checkpoint import (
+    CHECKPOINT_VERSION,
+    KNOWN_CHECKPOINT_VERSIONS,
+    CheckpointLoadConfig,
+    CheckpointMetadataConfig,
+    CheckpointType,
+)
 from fast_llm.engine.distributed.config import DistributedConfig
 from fast_llm.utils import Assert
 
@@ -174,98 +179,6 @@ class MultiStageConfig(StageConfig):
 # TODO: Does this matter? Best value?
 SHARD_PAD_TO_MULTIPLE = 32
 
-# TODO: Use packaging.version? (Safer but extra requirement)
-CHECKPOINT_VERSION = "0.1"
-_KNOWN_CHECKPOINT_VERSIONS = ("0", "0.1")
-
-
-class CheckpointType(str, enum.Enum):
-    distributed = "distributed"
-    # TODO: Rename
-    huggingface = "huggingface"
-    # Model state dict, mostly for debug.
-    state_dict = "state_dict"
-
-
-@config_class()
-class PretrainedConfig(Config):
-    path: pathlib.Path | None = Field(
-        default=None,
-        desc="Path to the checkpoint.",
-        hint=FieldHint.core,
-    )
-    format: CheckpointType = Field(
-        default=CheckpointType.distributed,
-        desc="Format of the checkpoint.",
-        hint=FieldHint.core,
-    )
-    imported_type: str | None = Field(
-        default=None,
-        desc="Model type for external models (ex. Huggingace type).",
-        hint=FieldHint.feature,
-    )
-    override_architecture: bool = Field(
-        default=False,
-        desc="Ignore the base model architecture from the pretrained checkpoint and use the provided one instead."
-        " May have unintended consequences.",
-        hint=FieldHint.feature,
-    )
-    load_full_base_model_config: bool = Field(
-        default=False,
-        desc="Load the non-architecture model config from the checkpoint.",
-        hint=FieldHint.feature,
-    )
-    load_full_fast_llm_config: bool = Field(
-        default=False,
-        desc="Load the distributed and multi-stage config from the checkpoint.",
-        hint=FieldHint.feature,
-    )
-
-    def _validate(self):
-        if self.load_full_fast_llm_config:
-            self.load_full_base_model_config = True
-        super()._validate()
-
-    @property
-    def compare_log_fn(self):
-        return logger.warning if self.override_architecture else ValueError
-
-
-@config_class()
-class PretrainedCheckpointConfig(PretrainedConfig):
-    # Load weights from path (if applicable),
-    # otherwise reinitialize them (i.e. load the config only.)
-    load_weights: bool = Field(default=True, desc="Load model weights from the checkpoint.", hint=FieldHint.feature)
-    load_optimizer: bool = Field(
-        default=False, desc="Load the optimizer state from the checkpoint.", hint=FieldHint.feature
-    )
-
-
-@config_class()
-class CheckpointConfig(Config):
-    # TODO: Merge/match with PretrainedConfig?
-    checkpoint_path: pathlib.Path = Field(desc="Path to the checkpoint.", hint=FieldHint.core)
-    checkpoint_type: CheckpointType = Field(
-        default=CheckpointType.distributed, desc="Format of the checkpoint.", hint=FieldHint.core
-    )
-    exported_model_type: str | None = Field(
-        default=None, desc="Model type for external models (ex. Huggingace type).", hint=FieldHint.feature
-    )
-    save_optimizer: bool = Field(
-        default=True, desc="Save the optimizer state from the checkpoint.", hint=FieldHint.feature
-    )
-    target_params_per_file: int = Field(
-        default=2**32,
-        desc="Limit the number of parameters saved in each file.",
-        hint=FieldHint.feature,
-        valid=check_field(Assert.geq, 2**20),
-    )
-    dtype: DataType | None = Field(
-        default=None,
-        desc="Data type to save the checkpoint.",
-        hint=FieldHint.feature,
-    )
-
 
 @config_class()
 class FastLLMModelConfig(Config):
@@ -298,7 +211,7 @@ class FastLLMModelConfig(Config):
     @classmethod
     def from_pretrained(
         cls,
-        pretrained: PretrainedConfig,
+        pretrained: CheckpointMetadataConfig,
         default: "FastLLMModelConfig" = None,
     ):
         # TODO: Add *updates?
@@ -309,7 +222,7 @@ class FastLLMModelConfig(Config):
     @classmethod
     def from_metadata(
         cls,
-        pretrained: PretrainedConfig,
+        pretrained: CheckpointMetadataConfig,
         metadata: dict,
         default: "FastLLMModelConfig" = None,
         updates: dict[str | tuple[str, ...], typing.Any] | None = None,
@@ -320,22 +233,22 @@ class FastLLMModelConfig(Config):
             # TODO python 3.12: Assert.incl(metadata["checkpoint_type"], CheckpointType)
             CheckpointType(metadata["checkpoint_type"])
         version = metadata["checkpoint_version"]
-        if version not in _KNOWN_CHECKPOINT_VERSIONS:
+        if version not in KNOWN_CHECKPOINT_VERSIONS:
             raise ValueError(f"Unrecognised checkpoint version: {version}")
         if version == "0":
             return cls._from_metadata_v0(pretrained, metadata, default, updates)
 
         pretrained_config = cls.from_dict(metadata["fast_llm_config"])
-        if pretrained.override_architecture:
+        if pretrained.architecture_config:
             assert default is not None
             config = default.to_copy()
             config.base_model.compare_architecture(pretrained_config.base_model, pretrained.compare_log_fn)
-        elif pretrained.load_full_fast_llm_config:
+        elif pretrained.fast_llm_config:
             config = pretrained_config
         else:
             with NoAutoValidate():
                 config = cls() if default is None else default.to_copy()
-            if pretrained.load_full_base_model_config:
+            if pretrained.base_model_config:
                 config.base_model = pretrained_config.base_model
             else:
                 config.base_model = config.base_model.to_copy(pretrained_config.base_model.get_architecture())
@@ -348,7 +261,7 @@ class FastLLMModelConfig(Config):
     @classmethod
     def _from_metadata_v0(
         cls,
-        pretrained: PretrainedConfig,
+        pretrained: CheckpointMetadataConfig,
         metadata: dict,
         default: "FastLLMModelConfig" = None,
         updates: dict[str | tuple[str, ...], typing.Any] | None = None,
@@ -361,22 +274,22 @@ class FastLLMModelConfig(Config):
 
         with NoAutoValidate():
             if default is None:
-                assert not pretrained.override_architecture
+                assert not pretrained.architecture_config
                 config = cls(base_model=base_model_config_cls())
             else:
                 config = default.to_copy()
 
-        if pretrained.override_architecture:
+        if pretrained.architecture_config:
             config.validate()
             architecture_config.compare_architecture(default.base_model, pretrained.compare_log_fn)
         else:
-            if pretrained.load_full_base_model_config:
+            if pretrained.base_model_config:
                 # Replace the whole config
                 config.base_model = base_model_config_cls.from_flat_dict(metadata["model_config"])
             else:
                 # Replace the architecture parts of the config.
                 config.base_model = config.base_model.to_copy(architecture_config)
-            if pretrained.load_full_fast_llm_config:
+            if pretrained.fast_llm_config:
                 config.multi_stage = MultiStageConfig.from_flat_dict(metadata["multi_stage_config"])
                 config.distributed = DistributedConfig.from_flat_dict(
                     metadata["distributed_config"],
@@ -388,7 +301,7 @@ class FastLLMModelConfig(Config):
         return config
 
     @classmethod
-    def load_pretrained_metadata(cls, pretrained):
+    def load_pretrained_metadata(cls, pretrained: CheckpointMetadataConfig):
         import yaml
 
         base_model_config_cls = cls.get_base_model_config_cls()
@@ -396,12 +309,12 @@ class FastLLMModelConfig(Config):
             return yaml.safe_load((pretrained.path / "metadata.yaml").open("r"))
         elif pretrained.format == CheckpointType.state_dict:
             return json.load((pretrained.path / f"state_dict.safetensors.index.json").open("r"))["metadata"]
-        elif pretrained.format == CheckpointType.huggingface:
-            converter_class = base_model_config_cls.get_converter_class(pretrained.imported_type)
+        elif pretrained.format == CheckpointType.external:
+            converter_class = base_model_config_cls.get_converter_class(pretrained.model_type)
             imported_model_config = converter_class.import_config(converter_class.load_config(pretrained.path), True)
             return {
                 "fast_llm_config": {"base_model": imported_model_config.to_serialized()},
-                "checkpoint_type": CheckpointType.huggingface.value,
+                "checkpoint_type": CheckpointType.external.value,
                 "checkpoint_version": CHECKPOINT_VERSION,
             }
         else:
@@ -415,8 +328,8 @@ class PretrainedFastLLMModelConfig(Config):
     model: FastLLMModelConfig = Field(
         default_factory=FastLLMModelConfig, desc="Configuration for the Fast-LLM model.", hint=FieldHint.core
     )
-    pretrained: PretrainedCheckpointConfig = Field(
-        default_factory=PretrainedCheckpointConfig,
+    pretrained: CheckpointLoadConfig = Field(
+        default_factory=CheckpointLoadConfig,
         desc="Configuration for loading the configuration and state of a pretrained model.",
         hint=FieldHint.feature,
     )

--- a/fast_llm/engine/multi_stage/config.py
+++ b/fast_llm/engine/multi_stage/config.py
@@ -8,9 +8,9 @@ from fast_llm.engine.base_model.config import BaseModelConfig
 from fast_llm.engine.config_utils.checkpoint import (
     CHECKPOINT_VERSION,
     KNOWN_CHECKPOINT_VERSIONS,
+    CheckpointFormat,
     CheckpointLoadConfig,
     CheckpointLoadMetadataConfig,
-    CheckpointType,
 )
 from fast_llm.engine.distributed.config import DistributedConfig
 from fast_llm.utils import Assert
@@ -231,7 +231,7 @@ class FastLLMModelConfig(Config):
         # TODO: Standardize to *updates?
         if "checkpoint_type" in metadata:
             # TODO python 3.12: Assert.incl(metadata["checkpoint_type"], CheckpointType)
-            CheckpointType(metadata["checkpoint_type"])
+            CheckpointFormat(metadata["checkpoint_type"])
         version = metadata["checkpoint_version"]
         if version not in KNOWN_CHECKPOINT_VERSIONS:
             raise ValueError(f"Unrecognised checkpoint version: {version}")
@@ -305,16 +305,16 @@ class FastLLMModelConfig(Config):
         import yaml
 
         base_model_config_cls = cls.get_base_model_config_cls()
-        if pretrained.format == CheckpointType.distributed:
+        if pretrained.format == CheckpointFormat.distributed:
             return yaml.safe_load((pretrained.path / "metadata.yaml").open("r"))
-        elif pretrained.format == CheckpointType.state_dict:
+        elif pretrained.format == CheckpointFormat.state_dict:
             return json.load((pretrained.path / f"state_dict.safetensors.index.json").open("r"))["metadata"]
-        elif pretrained.format == CheckpointType.external:
+        elif pretrained.format == CheckpointFormat.external:
             converter_class = base_model_config_cls.get_converter_class(pretrained.model_type)
             imported_model_config = converter_class.import_config(converter_class.load_config(pretrained.path), True)
             return {
                 "fast_llm_config": {"base_model": imported_model_config.to_serialized()},
-                "checkpoint_type": CheckpointType.external.value,
+                "checkpoint_type": CheckpointFormat.external.value,
                 "checkpoint_version": CHECKPOINT_VERSION,
             }
         else:

--- a/fast_llm/engine/multi_stage/conversion.py
+++ b/fast_llm/engine/multi_stage/conversion.py
@@ -189,12 +189,12 @@ class ExternalModelConverter(ModelConverter):
 
     @classmethod
     @abc.abstractmethod
-    def load_config(cls, directory: pathlib.Path | str) -> dict[str]:
+    def load_config(cls, directory: pathlib.Path | str) -> dict[str, typing.Any]:
         pass
 
     @classmethod
     @abc.abstractmethod
-    def save_config(cls, directory: pathlib.Path | str, config: dict[str]):
+    def save_config(cls, directory: pathlib.Path | str, config: dict[str, typing.Any]):
         pass
 
     @abc.abstractmethod
@@ -204,7 +204,7 @@ class ExternalModelConverter(ModelConverter):
         pass
 
     @classmethod
-    def export_config(cls, config: BaseModelArchitectureConfig) -> dict[str]:
+    def export_config(cls, config: BaseModelArchitectureConfig) -> dict[str, typing.Any]:
         exported_config = {}
         for converter in cls._get_config_converters():
             value = converter.export_param(
@@ -218,7 +218,7 @@ class ExternalModelConverter(ModelConverter):
         return exported_config  # Noqa
 
     @classmethod
-    def import_config(cls, config: dict[str], architecture_only: bool = False):  # noqa
+    def import_config(cls, config: dict[str, typing.Any], architecture_only: bool = False):  # noqa
         kwargs = {}
         for converter in cls._get_config_converters():
             value = converter.import_param(
@@ -233,7 +233,7 @@ class ExternalModelConverter(ModelConverter):
         return config_class.from_dict({}, kwargs)
 
     @classmethod
-    def from_config(cls, config: dict[str], architecture_only: bool = False):
+    def from_config(cls, config: dict[str, typing.Any], architecture_only: bool = False):
         return cls(cls.import_config(config, architecture_only=architecture_only))
 
     def convert_state_dict(
@@ -291,11 +291,11 @@ class AutoModelConverter(ExternalModelConverter, abc.ABC):
     converter_map: dict[str, type[ExternalModelConverter]]
 
     @classmethod
-    def import_config(cls, config: dict[str], architecture_only: bool = False):
+    def import_config(cls, config: dict[str, typing.Any], architecture_only: bool = False):
         return cls.converter_map[config["model_type"]].import_config(config, architecture_only)
 
     @classmethod
-    def from_config(cls, config: dict[str], architecture_only: bool = False):
+    def from_config(cls, config: dict[str, typing.Any], architecture_only: bool = False):
         return cls.converter_map[config["model_type"]].from_config(config, architecture_only)
 
 
@@ -317,7 +317,7 @@ class HuggingfaceModelConverter(ExternalModelConverter, abc.ABC):
         return config
 
     @classmethod
-    def save_config(cls, directory: pathlib.Path | str, config: dict[str]):
+    def save_config(cls, directory: pathlib.Path | str, config: dict[str, typing.Any]):
         import transformers
 
         transformers.CONFIG_MAPPING[config["model_type"]].from_dict(config).save_pretrained(directory)

--- a/fast_llm/engine/training/config.py
+++ b/fast_llm/engine/training/config.py
@@ -214,7 +214,6 @@ class CheckpointConfig(CheckpointBaseConfig):
         return CheckpointSaveConfig(
             path=path,
             format=CheckpointType.distributed,
-            fast_llm_config=True,
             model_weights=True,
             optimizer_state=True,
         )

--- a/fast_llm/engine/training/config.py
+++ b/fast_llm/engine/training/config.py
@@ -42,7 +42,8 @@ class IntervalConfig(Config):
     )
 
     def _validate(self):
-        self.offset %= self.interval
+        if self.interval:
+            self.offset %= self.interval
         super()._validate()
 
     def enabled(self, iteration: int | None = None):
@@ -160,7 +161,9 @@ class ValidationConfig(IntervalConfig):
 
 @config_class()
 class CheckpointBaseConfig(IntervalConfig):
+    _abstract = True
     save_name: typing.ClassVar[str] = "save"
+    directory_name: typing.ClassVar[str] = "save"
     callback: CallbackConfig = Field(
         default_factory=CallbackConfig,
         desc="Callback (shell script).",
@@ -196,7 +199,10 @@ class CheckpointBaseConfig(IntervalConfig):
 
 @config_class()
 class CheckpointConfig(CheckpointBaseConfig):
+    _abstract = False
     save_name: typing.ClassVar[str] = "checkpoint"
+    # TODO v0.2: Rename to `checkpoint` so we don't need this extra variable?
+    directory_name = "checkpoints"
     interval = FieldUpdate(
         desc="The number of training iterations between each checkpoint." " Setting to None will disable checkpoints."
     )
@@ -216,7 +222,9 @@ class CheckpointConfig(CheckpointBaseConfig):
 
 @config_class()
 class ExportConfig(CheckpointBaseConfig, CheckpointConfigBase, CheckpointStateConfigBase, CheckpointSaveConfigBase):
+    _abstract = False
     save_name: typing.ClassVar[str] = "export"
+    directory_name = "export"
     interval = FieldUpdate(
         desc="The number of training iterations between each export." " Setting to None will disable exports."
     )

--- a/fast_llm/engine/training/config.py
+++ b/fast_llm/engine/training/config.py
@@ -1,11 +1,19 @@
 import argparse
 import os
+import pathlib
 import shlex
 import subprocess
 import typing
 
-from fast_llm.config import Config, Field, FieldHint, check_field, config_class, skip_valid_if_none
+from fast_llm.config import Config, Field, FieldHint, FieldUpdate, check_field, config_class, skip_valid_if_none
 from fast_llm.data.config import AbstractDataConfig
+from fast_llm.engine.config_utils.checkpoint import (
+    CheckpointConfigBase,
+    CheckpointSaveConfig,
+    CheckpointSaveConfigBase,
+    CheckpointStateConfigBase,
+    CheckpointType,
+)
 from fast_llm.engine.config_utils.run import ExperimentConfig
 from fast_llm.engine.multi_stage.config import PretrainedFastLLMModelConfig
 from fast_llm.engine.optimizer.config import OptimizerConfig
@@ -17,48 +25,56 @@ if typing.TYPE_CHECKING:
     from fast_llm.engine.training.trainer import Trainer
 
 
-def get_interval_config_class(desc: str, offset_desc: str | None = None):
-    # Intervals are a common pattern, so we standardize them with this helper.
-    @config_class()
-    class IntervalConfig(Config):
-        interval: int | None = Field(
-            default=None,
-            desc=f"The number of training iterations between each {desc}. Setting to None will disable.",
-            hint=FieldHint.feature,
-            valid=skip_valid_if_none(check_field(Assert.gt, 0)),
+@config_class()
+class IntervalConfig(Config):
+    # Intervals are a common pattern, so we standardize them with this base class.
+    interval: int | None = Field(
+        default=None,
+        desc="The number of training iterations between each interval. Setting to None will disable.",
+        hint=FieldHint.feature,
+        valid=skip_valid_if_none(check_field(Assert.gt, 0)),
+    )
+    offset: int = Field(
+        default=0,
+        desc="Offset for the first interval.",
+        hint=FieldHint.feature,
+        valid=check_field(Assert.geq, 0),
+    )
+
+    def _validate(self):
+        self.offset %= self.interval
+        super()._validate()
+
+    def enabled(self, iteration: int | None = None):
+        return self.interval and (iteration is None or (iteration - self.offset) % self.interval == 0)
+
+    def is_sub_interval(self, other: "IntervalConfig"):
+        if not self.enabled():
+            return True
+        elif not other.enabled():
+            return False
+        return self.interval % other.interval == 0 and (other.offset % other.interval) == (
+            self.offset % other.interval
         )
-        offset: int = Field(
-            default=0,
-            desc=f"Offset for the first {offset_desc or desc}.",
-            hint=FieldHint.feature,
-            valid=check_field(Assert.geq, 0),
-        )
 
-        def enabled(self, iteration: int | None = None):
-            return self.interval and (iteration is None or (iteration - self.offset) % self.interval == 0)
+    def assert_sub_interval(self, other: "IntervalConfig"):
+        assert self.is_sub_interval(other), f"{self} is not a sub-interval of {other}"
 
-        def is_sub_interval(self, other: "IntervalConfig"):
-            if not self.enabled():
-                return True
-            elif not other.enabled():
-                return False
-            return self.interval % other.interval == 0 and (other.offset % other.interval) == (
-                self.offset % other.interval
-            )
-
-        def assert_sub_interval(self, other: "IntervalConfig"):
-            assert self.is_sub_interval(other), f"{self} is not a sub-interval of {other}"
-
-    return IntervalConfig
+    def get_count(self, iteration):
+        # Number of times this interval was enabled after a given iteration.
+        return (iteration - self.offset) // self.interval + 1 if self.enabled() else 0
 
 
 @config_class()
-class WandbAlertConfig(
-    get_interval_config_class(
-        "Wandb status post (alert). Must be a multiple of the logging interval",
-        "Wandb status post (alert). Must be compatible with the logging offset",
+class WandbAlertConfig(IntervalConfig):
+    interval = FieldUpdate(
+        desc="The number of training iterations between each Wandb status post (alert)."
+        " Setting to None will disable iteration-based wandb alerts."
+        " Must be a sub-interval of the logging interval."
     )
-):
+    offset = FieldUpdate(
+        desc="Offset for the first Wandb status post (alert)." " Must be compatible with the logging offset.",
+    )
     status_updates: bool | None = Field(
         default=None,
         desc="Post wandb status updates on status changes (run begin/end). "
@@ -73,15 +89,21 @@ class WandbAlertConfig(
 
 
 @config_class()
-class MetricsLogsConfig(get_interval_config_class("metric logs")):
-    pass
+class MetricsLogsConfig(IntervalConfig):
+    interval = FieldUpdate(
+        default=100,
+        desc="The number of training iterations between each metric logs."
+        " Setting to None will disable metric logging.",
+    )
+    offset = FieldUpdate(desc="Offset for the first metric logs.")
 
 
 @config_class()
 class WandbConfig(Config):
     alert: WandbAlertConfig = Field(
         default_factory=WandbAlertConfig,
-        desc="Configuration for Wandb alerts. The alerts may be posted by email and/or slack depending on the Wandb account configuration.",
+        desc="Configuration for Wandb alerts."
+        " The alerts may be posted by email and/or slack depending on the Wandb account configuration.",
         hint=FieldHint.core,
     )
     group_name: str = Field(default="default", desc="A group name for Wandb", hint=FieldHint.feature)
@@ -90,7 +112,12 @@ class WandbConfig(Config):
 
 
 @config_class()
-class ValidationConfig(get_interval_config_class("validation")):
+class ValidationConfig(IntervalConfig):
+    interval = FieldUpdate(
+        desc="The number of training iterations between each validation phase."
+        " Setting to None will disable validation."
+    )
+    offset = FieldUpdate(desc="Offset for the first validation phase.")
     iterations: int | None = Field(
         default=None,
         desc="Number of iterations for each validation phase. Setting to None will disable.",
@@ -98,21 +125,38 @@ class ValidationConfig(get_interval_config_class("validation")):
         valid=skip_valid_if_none(check_field(Assert.gt, 0)),
     )
 
-    def get_completed_iterations(self, training_iterations: int, completed_validations: int = 0):
+    def get_iteration_count(self, training_iterations: int, extra_validations: int = 0):
         # Number of completed validation iterations
-        return (
-            (training_iterations // self.interval + completed_validations) * self.iterations if self.enabled() else 0
-        )
+        return (self.get_count(training_iterations) + extra_validations) * self.iterations if self.enabled() else 0
 
 
 @config_class()
-class CheckpointConfig(get_interval_config_class("checkpoint")):
+class CheckpointConfig(IntervalConfig):
+    interval = FieldUpdate(
+        desc="The number of training iterations between each checkpoint." " Setting to None will disable checkpoints."
+    )
+    offset = FieldUpdate(desc="Offset for the first checkpoint.")
     keep: int | None = Field(
         default=5,
         desc="The maximum number of checkpoints to keep. When exceeding this value, checkpoints are deleted starting from the older ones.",
         hint=FieldHint.feature,
         valid=skip_valid_if_none(check_field(Assert.gt, 0)),
     )
+    keep_every: int | None = Field(
+        default=None,
+        desc="Keep every nth checkpoint, i.e. Exclude it from the checkpoint count and deletion in `keep`.",
+        hint=FieldHint.feature,
+        valid=skip_valid_if_none(check_field(Assert.gt, 0)),
+    )
+
+    def get_save_config(self, path: pathlib.Path):
+        return CheckpointSaveConfig(
+            path=path,
+            format=CheckpointType.distributed,
+            fast_llm_config=True,
+            model_weights=True,
+            optimizer_state=True,
+        )
 
 
 def _validate_script(value):
@@ -144,17 +188,31 @@ class CallbackConfig(Config):
 
 
 @config_class()
-class ExportConfig(get_interval_config_class("export")):
+class ExportConfig(IntervalConfig, CheckpointConfigBase, CheckpointStateConfigBase, CheckpointSaveConfigBase):
+    interval = FieldUpdate(
+        desc="The number of training iterations between each export." " Setting to None will disable exports."
+    )
+    offset = FieldUpdate(desc="Offset for the first export.")
     callback: CallbackConfig = Field(
         default_factory=CallbackConfig,
         desc="Callback (shell script) to run after export.",
         hint=FieldHint.core,
     )
 
+    def get_save_config(self, path: pathlib.Path):
+        return CheckpointSaveConfig.from_dict(self, {"path": path}, strict=False)
+
 
 @config_class()
-class ShutdownConfig(get_interval_config_class("automated shutdown")):
-    pass
+class ShutdownConfig(IntervalConfig):
+    interval = FieldUpdate(
+        desc="The number of training iterations between each automated shutdown."
+        " Setting to None will disable automated shutdowns."
+        " Must be a sub-interval of the checkpoint interval."
+    )
+    offset = FieldUpdate(
+        desc="Offset for the first automated shutdown." " Must be compatible with the checkpoint offset."
+    )
 
 
 @config_class()
@@ -201,7 +259,6 @@ class TrainingConfig(Config):
 
     def _validate(self):
         super()._validate()
-        self.export.assert_sub_interval(self.checkpoint)
         self.shutdown.assert_sub_interval(self.checkpoint)
         self.wandb.alert.assert_sub_interval(self.logs)
 

--- a/fast_llm/engine/training/config.py
+++ b/fast_llm/engine/training/config.py
@@ -9,10 +9,10 @@ from fast_llm.config import Config, Field, FieldHint, FieldUpdate, check_field, 
 from fast_llm.data.config import AbstractDataConfig
 from fast_llm.engine.config_utils.checkpoint import (
     CheckpointConfigBase,
+    CheckpointFormat,
     CheckpointSaveConfig,
     CheckpointSaveConfigBase,
     CheckpointStateConfigBase,
-    CheckpointType,
 )
 from fast_llm.engine.config_utils.run import ExperimentConfig
 from fast_llm.engine.multi_stage.config import PretrainedFastLLMModelConfig
@@ -213,7 +213,7 @@ class CheckpointConfig(CheckpointBaseConfig):
     def get_save_config(self, path: pathlib.Path):
         return CheckpointSaveConfig(
             path=path,
-            format=CheckpointType.distributed,
+            format=CheckpointFormat.distributed,
             model_weights=True,
             optimizer_state=True,
         )

--- a/fast_llm/layers/common/config.py
+++ b/fast_llm/layers/common/config.py
@@ -54,7 +54,7 @@ class NormalizationArchitectureConfig(BaseModelArchitectureConfig):
     @classmethod
     def _from_dict(
         cls,
-        default: dict[str],
+        default: dict[str, typing.Any],
         strict: bool = True,
         flat: bool = False,
     ):
@@ -107,7 +107,7 @@ class NormalizationConfig(NormalizationArchitectureConfig, BaseModelConfig):
     @classmethod
     def _from_dict(
         cls,
-        default: dict[str],
+        default: dict[str, typing.Any],
         strict: bool = True,
         flat: bool = False,
     ):

--- a/fast_llm/layers/common/config.py
+++ b/fast_llm/layers/common/config.py
@@ -58,6 +58,7 @@ class NormalizationArchitectureConfig(BaseModelArchitectureConfig):
         strict: bool = True,
         flat: bool = False,
     ):
+        # TODO v0.2: Remove.
         cls._handle_renamed_field(default, "normalization_type", "type")
         cls._handle_renamed_field(default, "layer_norm_eps", "epsilon")
         cls._handle_renamed_field(default, "zero_centered_normalization", "zero_centered")

--- a/fast_llm/layers/language_model/config.py
+++ b/fast_llm/layers/language_model/config.py
@@ -1,4 +1,4 @@
-from fast_llm.config import Field, FieldHint, check_field, config_class, skip_valid_if_none
+from fast_llm.config import Field, FieldHint, FieldUpdate, check_field, config_class, skip_valid_if_none
 from fast_llm.engine.base_model.config import BaseModelArchitectureConfig, BaseModelConfig
 from fast_llm.engine.config_utils.tensor_space import TensorDim, TensorSpace
 from fast_llm.engine.distributed.config import DistributedDimNames
@@ -109,9 +109,7 @@ class LanguageModelBaseConfig(LanguageModelArchitectureConfig, BaseModelConfig):
 
     architecture_cls = LanguageModelArchitectureConfig
 
-    transformer: TransformerConfig = Field(
-        default_factory=TransformerConfig, desc="Configuration for the transformer.", hint=FieldHint.core
-    )
+    transformer: TransformerConfig = FieldUpdate(default_factory=TransformerConfig)
     init_method_std_embed: float = Field(
         default=None,
         desc="Initialization scale for the vocabulary embedding and output weights (logits).",

--- a/fast_llm/layers/language_model/config.py
+++ b/fast_llm/layers/language_model/config.py
@@ -1,3 +1,5 @@
+import typing
+
 from fast_llm.config import Field, FieldHint, FieldUpdate, check_field, config_class, skip_valid_if_none
 from fast_llm.engine.base_model.config import BaseModelArchitectureConfig, BaseModelConfig
 from fast_llm.engine.config_utils.tensor_space import TensorDim, TensorSpace
@@ -84,7 +86,7 @@ class LanguageModelArchitectureConfig(BaseModelArchitectureConfig):
     @classmethod
     def from_flat_dict(
         cls,
-        default: dict[str],
+        default: dict[str, typing.Any],
         strict: bool = True,
     ):
         # The backward compatibility fix in `NormalizationArchitectureConfig`

--- a/fast_llm/layers/transformer/config.py
+++ b/fast_llm/layers/transformer/config.py
@@ -3,7 +3,7 @@ import logging
 import math
 import warnings
 
-from fast_llm.config import Field, FieldHint, check_field, config_class, skip_valid_if_none
+from fast_llm.config import Field, FieldHint, FieldUpdate, check_field, config_class, skip_valid_if_none
 from fast_llm.engine.base_model.config import BaseModelArchitectureConfig, BaseModelConfig
 from fast_llm.engine.config_utils.data_type import DataType
 from fast_llm.engine.config_utils.tensor_space import CompositeTensorDim, TensorDim, TensorSpace
@@ -262,11 +262,7 @@ class TransformerArchitectureConfig(BaseModelArchitectureConfig):
 
 @config_class()
 class TransformerConfig(TransformerArchitectureConfig, BaseModelConfig):
-    normalization: NormalizationConfig = Field(
-        default_factory=NormalizationConfig,
-        desc="Configuration for the normalization layers.",
-        hint=FieldHint.core,
-    )
+    normalization: NormalizationConfig = FieldUpdate(default_factory=NormalizationConfig)
     # Default: hidden_size**-0.5
     # TODO: Allow custom initialization (InitializationConfig?)
     init_method_std: float = Field(

--- a/fast_llm/models/custom/config.py
+++ b/fast_llm/models/custom/config.py
@@ -1,4 +1,4 @@
-from fast_llm.config import Field, FieldHint, config_class
+from fast_llm.config import FieldUpdate, config_class
 from fast_llm.data.config import DataConfig
 from fast_llm.models.gpt.config import (
     GPTArchitectureConfig,
@@ -30,7 +30,7 @@ class CustomBaseModelConfig(GPTBaseModelConfig, CustomArchitectureConfig):
 @config_class()
 class CustomModelConfig(GPTModelConfig):
     # TODO: Add custom model config parameters, if any (typically none).
-    base_model: CustomBaseModelConfig = Field(default_factory=CustomBaseModelConfig)
+    base_model: CustomBaseModelConfig = FieldUpdate(default_factory=CustomBaseModelConfig)
 
     @classmethod
     def get_model_class(cls):
@@ -47,18 +47,14 @@ class CustomModelConfig(GPTModelConfig):
 
 @config_class()
 class PretrainedCustomModelConfig(PretrainedGPTModelConfig):
-    model: CustomModelConfig = Field(default_factory=CustomModelConfig)
+    model: CustomModelConfig = FieldUpdate(default_factory=CustomModelConfig)
 
 
 @config_class()
 class CustomTrainerConfig(PretrainedCustomModelConfig, GPTTrainerConfig):
     # TODO: Add custom trainer config parameters, if any (typically none).
 
-    data: CustomDataConfig = Field(
-        default_factory=CustomDataConfig,
-        desc="Configuration for the dataset and model-independent preprocessing.",
-        hint=FieldHint.core,
-    )
+    data: CustomDataConfig = FieldUpdate(default_factory=CustomDataConfig)
 
     @classmethod
     def get_trainer_class(cls):

--- a/fast_llm/models/gpt/config.py
+++ b/fast_llm/models/gpt/config.py
@@ -1,6 +1,6 @@
 import typing
 
-from fast_llm.config import Field, FieldHint, config_class
+from fast_llm.config import Field, FieldHint, FieldUpdate, config_class
 from fast_llm.data.config import DataConfig
 from fast_llm.engine.multi_stage.config import FastLLMModelConfig, PretrainedFastLLMModelConfig
 from fast_llm.engine.training.config import TrainerConfig
@@ -65,7 +65,7 @@ class GPTBaseModelConfig(LanguageModelBaseConfig, GPTArchitectureConfig):
 @config_class()
 class GPTModelConfig(FastLLMModelConfig):
     _abstract = False
-    base_model: GPTBaseModelConfig = Field(default_factory=GPTBaseModelConfig)
+    base_model: GPTBaseModelConfig = FieldUpdate(default_factory=GPTBaseModelConfig)
 
     @classmethod
     def get_model_class(cls):
@@ -83,17 +83,13 @@ class GPTModelConfig(FastLLMModelConfig):
 @config_class()
 class PretrainedGPTModelConfig(PretrainedFastLLMModelConfig):
     _abstract = False
-    model: GPTModelConfig = Field(default_factory=GPTModelConfig)
+    model: GPTModelConfig = FieldUpdate(default_factory=GPTModelConfig)
 
 
 @config_class()
 class GPTTrainerConfig(PretrainedGPTModelConfig, TrainerConfig):
 
-    data: DataConfig = Field(
-        default_factory=DataConfig,
-        desc="Configuration for the dataset and model-independent preprocessing.",
-        hint=FieldHint.core,
-    )
+    data: DataConfig = FieldUpdate(default_factory=DataConfig)
 
     def _setup(self):
         super()._setup()

--- a/fast_llm/models/gpt/config.py
+++ b/fast_llm/models/gpt/config.py
@@ -8,7 +8,7 @@ from fast_llm.layers.language_model.config import LanguageModelArchitectureConfi
 from fast_llm.models.gpt.megatron import set_megatron_distributed_seeds
 
 if typing.TYPE_CHECKING:
-    from fast_llm.engine.multi_stage.conversion import ModelConverter
+    from fast_llm.engine.multi_stage.conversion import ExternalModelConverter
 
 
 @config_class()
@@ -28,7 +28,7 @@ class GPTArchitectureConfig(LanguageModelArchitectureConfig):
         return super()._from_dict(default, strict, flat)
 
     @classmethod
-    def get_converter_class(cls, model_type: str | None = None) -> type["ModelConverter"]:
+    def get_converter_class(cls, model_type: str | None = None) -> type["ExternalModelConverter"]:
         from fast_llm.models.gpt.conversion import AutoGPTConverter
 
         return AutoGPTConverter if model_type is None else AutoGPTConverter.converter_map[model_type]

--- a/fast_llm/tools/convert.py
+++ b/fast_llm/tools/convert.py
@@ -7,15 +7,10 @@ import pathlib
 import typing
 
 from fast_llm.config import Field, config_class
+from fast_llm.engine.config_utils.checkpoint import CheckpointLoadConfig, CheckpointSaveConfig, CheckpointType
 from fast_llm.engine.config_utils.data_type import DataType
 from fast_llm.engine.config_utils.runnable import RunnableConfig
-from fast_llm.engine.multi_stage.config import (
-    CheckpointConfig,
-    CheckpointType,
-    FastLLMModelConfig,
-    PretrainedCheckpointConfig,
-    StageMode,
-)
+from fast_llm.engine.multi_stage.config import FastLLMModelConfig, StageMode
 from fast_llm.functional.config import TritonConfig
 from fast_llm.models.auto import model_registry
 from fast_llm.utils import Assert
@@ -62,10 +57,10 @@ class ConversionConfig(RunnableConfig):
     ):
         logger.info(f"Loading {self.input_type} checkpoint from {self.input_path}...")
         model = model_class.from_pretrained(
-            PretrainedCheckpointConfig(
+            CheckpointLoadConfig(
                 path=self.input_path,
                 format=self.input_type,
-                imported_type=self.model_type,
+                model_type=self.model_type,
             ),
             mode=StageMode.weights,
             use_cpu=self.use_cpu,
@@ -74,13 +69,13 @@ class ConversionConfig(RunnableConfig):
         logger.info(f"Saving {self.output_type} checkpoint to {output_path}...")
         output_path.mkdir(parents=True, exist_ok=self.exist_ok)
         model.save_checkpoint(
-            CheckpointConfig(
-                checkpoint_path=output_path,
-                checkpoint_type=self.output_type,
-                exported_model_type=self.model_type,
-                save_optimizer=False,
-                target_params_per_file=self.target_params_per_file,
-                dtype=self.dtype,
+            CheckpointSaveConfig(
+                path=output_path,
+                format=self.output_type,
+                model_type=self.model_type,
+                optimizer_state=False,
+                parameters_per_file=self.target_params_per_file,
+                data_type=self.dtype,
             )
         )
         (output_path / "ok").open("w")
@@ -106,15 +101,15 @@ class ConversionConfig(RunnableConfig):
             self._convert_model_partial(model_class, self.output_path)
         else:
             # TODO: Support other types?
-            assert self.output_type == CheckpointType.huggingface
+            assert self.output_type == CheckpointType.external
             logger.info(f">>> Loading model config")
             # Create a dummy version to determine the stage split.
             model = model_class.from_pretrained(
-                PretrainedCheckpointConfig(
+                CheckpointLoadConfig(
                     path=self.input_path,
                     format=self.input_type,
-                    imported_type=self.model_type,
-                    load_pretrained_weights=False,
+                    model_type=self.model_type,
+                    model_weights=False,
                 ),
                 mode=StageMode.off_device,
                 use_cpu=self.use_cpu,

--- a/fast_llm/tools/convert.py
+++ b/fast_llm/tools/convert.py
@@ -7,7 +7,7 @@ import pathlib
 import typing
 
 from fast_llm.config import Field, config_class
-from fast_llm.engine.config_utils.checkpoint import CheckpointLoadConfig, CheckpointSaveConfig, CheckpointType
+from fast_llm.engine.config_utils.checkpoint import CheckpointFormat, CheckpointLoadConfig, CheckpointSaveConfig
 from fast_llm.engine.config_utils.data_type import DataType
 from fast_llm.engine.config_utils.runnable import RunnableConfig
 from fast_llm.engine.multi_stage.config import FastLLMModelConfig, StageMode
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 @config_class()
 class ConversionConfig(RunnableConfig):
-    input_type: CheckpointType = Field()
-    output_type: CheckpointType = Field()
+    input_type: CheckpointFormat = Field()
+    output_type: CheckpointFormat = Field()
     input_path: pathlib.Path = Field()
     output_path: pathlib.Path = Field()
     model_type: str | None = Field(default=None)
@@ -101,7 +101,7 @@ class ConversionConfig(RunnableConfig):
             self._convert_model_partial(model_class, self.output_path)
         else:
             # TODO: Support other types?
-            assert self.output_type == CheckpointType.external
+            assert self.output_type == CheckpointFormat.external
             logger.info(f">>> Loading model config")
             # Create a dummy version to determine the stage split.
             model = model_class.from_pretrained(

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -7,7 +7,7 @@ import torch
 import transformers
 import yaml
 
-from fast_llm.engine.config_utils.checkpoint import CheckpointLoadConfig, CheckpointType
+from fast_llm.engine.config_utils.checkpoint import CheckpointLoadConfig, CheckpointType, LoadConfig
 from fast_llm.engine.multi_stage.config import StageMode
 from fast_llm.models.auto import model_registry
 from fast_llm.tools.convert import ConversionConfig
@@ -211,8 +211,7 @@ def test_load_pretrained_distributed_checkpoint():
         path=_CKPT_PATH,
         format=CheckpointType.distributed,
         optimizer_state=True,
-        base_model_config=True,
-        fast_llm_config=True,
+        load_config=LoadConfig.fast_llm,
     )
     model = TEST_MODEL_CLS.from_pretrained(pretrained_config_ref)
     _compare_configs(config, model._base_model_config)
@@ -364,12 +363,12 @@ def test_load_pretrained_in_dp2_match_checkpoint():
     pretrained_config_ref = CheckpointLoadConfig(
         path=_CKPT_PATH,
         format=CheckpointType.distributed,
-        fast_llm_config=True,
+        load_config=LoadConfig.fast_llm,
     )
     pretrained_config_test = CheckpointLoadConfig(
         path=test_ckpt_path,
         format=CheckpointType.distributed,
-        fast_llm_config=True,
+        load_config=LoadConfig.fast_llm,
     )
     config_ref = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_ref)
     config_test = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_test)
@@ -406,8 +405,7 @@ def test_load_distributed_checkpoint_dp2():
     pretrained_config_ref = CheckpointLoadConfig(
         path=_CKPT_PATH,
         format=CheckpointType.distributed,
-        base_model_config=True,
-        fast_llm_config=True,
+        load_config=LoadConfig.fast_llm,
     )
     pretrained_config_test = CheckpointLoadConfig(
         path=TEST_RESULTS_PATH / f"test_{TEST_MODEL}_load_pretrained_distributed_in_dp2" / "checkpoints" / "1",
@@ -463,7 +461,7 @@ def test_load_pretrained_huggingface_in_dp2():
             "training.checkpoint.interval=1",
             "training.train_iters=1",
             f"pretrained.path={_CONVERT_PATH / 'huggingface_0'}",
-            f"pretrained.format=huggingface",
+            f"pretrained.format=external",
             "schedule.skip_step=True",
         ],
         num_gpus=2,

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -7,7 +7,7 @@ import torch
 import transformers
 import yaml
 
-from fast_llm.engine.config_utils.checkpoint import CheckpointLoadConfig, CheckpointType, ModelConfigType
+from fast_llm.engine.config_utils.checkpoint import CheckpointFormat, CheckpointLoadConfig, ModelConfigType
 from fast_llm.engine.multi_stage.config import StageMode
 from fast_llm.models.auto import model_registry
 from fast_llm.tools.convert import ConversionConfig
@@ -89,9 +89,9 @@ _CONVERT_PATH = TEST_RESULTS_PATH / f"test_{TEST_MODEL}_convert_model"
 def test_convert_distributed_to_state_dict():
     _run_conversion(
         ConversionConfig(
-            input_type=CheckpointType.distributed,
+            input_type=CheckpointFormat.distributed,
             input_path=_CKPT_PATH,
-            output_type=CheckpointType.state_dict,
+            output_type=CheckpointFormat.state_dict,
             output_path=_CONVERT_PATH / "state_dict_0",
         )
     )
@@ -103,9 +103,9 @@ def test_convert_state_dict_to_huggingface():
         pytest.skip(f"Conversion not supported for {TEST_MODEL}")
     _run_conversion(
         ConversionConfig(
-            input_type=CheckpointType.state_dict,
+            input_type=CheckpointFormat.state_dict,
             input_path=_CONVERT_PATH / "state_dict_0",
-            output_type=CheckpointType.external,
+            output_type=CheckpointFormat.external,
             output_path=_CONVERT_PATH / "huggingface_0",
             model_type=HUGGINGFACE_MODEL_TYPE,
         )
@@ -116,9 +116,9 @@ def test_convert_state_dict_to_huggingface():
 def test_convert_huggingface_to_distributed():
     _run_conversion(
         ConversionConfig(
-            input_type=CheckpointType.external,
+            input_type=CheckpointFormat.external,
             input_path=_CONVERT_PATH / "huggingface_0",
-            output_type=CheckpointType.distributed,
+            output_type=CheckpointFormat.distributed,
             output_path=_CONVERT_PATH / "distributed_0",
         )
     )
@@ -130,9 +130,9 @@ def test_convert_distributed_to_huggingface():
         pytest.skip(f"Conversion not supported for {TEST_MODEL}")
     _run_conversion(
         ConversionConfig(
-            input_type=CheckpointType.distributed,
+            input_type=CheckpointFormat.distributed,
             input_path=_CKPT_PATH,
-            output_type=CheckpointType.external,
+            output_type=CheckpointFormat.external,
             output_path=_CONVERT_PATH / "huggingface_1",
             model_type=HUGGINGFACE_MODEL_TYPE,
         )
@@ -143,9 +143,9 @@ def test_convert_distributed_to_huggingface():
 def test_convert_huggingface_to_state_dict():
     _run_conversion(
         ConversionConfig(
-            input_type=CheckpointType.external,
+            input_type=CheckpointFormat.external,
             input_path=_CONVERT_PATH / "huggingface_1",
-            output_type=CheckpointType.state_dict,
+            output_type=CheckpointFormat.state_dict,
             output_path=_CONVERT_PATH / "state_dict_1",
         )
     )
@@ -155,9 +155,9 @@ def test_convert_huggingface_to_state_dict():
 def test_convert_state_dict_to_distributed():
     _run_conversion(
         ConversionConfig(
-            input_type=CheckpointType.state_dict,
+            input_type=CheckpointFormat.state_dict,
             input_path=_CONVERT_PATH / "state_dict_1",
-            output_type=CheckpointType.distributed,
+            output_type=CheckpointFormat.distributed,
             output_path=_CONVERT_PATH / "distributed_1",
         )
     )
@@ -209,7 +209,7 @@ def test_load_pretrained_distributed_checkpoint():
     )
     pretrained_config_ref = CheckpointLoadConfig(
         path=_CKPT_PATH,
-        format=CheckpointType.distributed,
+        format=CheckpointFormat.distributed,
         optimizer_state=True,
         load_config=ModelConfigType.fast_llm,
     )
@@ -223,14 +223,14 @@ def test_load_pretrained_distributed_checkpoint():
 
 @pytest.mark.depends(on=["test_load_pretrained_distributed_checkpoint"])
 def test_load_converted_distributed_checkpoint():
-    pretrained_config_ref = CheckpointLoadConfig(path=_CKPT_PATH, format=CheckpointType.distributed)
+    pretrained_config_ref = CheckpointLoadConfig(path=_CKPT_PATH, format=CheckpointFormat.distributed)
     pretrained_config_0 = CheckpointLoadConfig(
         path=_CONVERT_PATH / "distributed_0",
-        format=CheckpointType.distributed,
+        format=CheckpointFormat.distributed,
     )
     pretrained_config_1 = CheckpointLoadConfig(
         path=_CONVERT_PATH / "distributed_1",
-        format=CheckpointType.distributed,
+        format=CheckpointFormat.distributed,
     )
     config = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_ref)
     model = TEST_MODEL_CLS.from_pretrained(pretrained_config_0)
@@ -245,9 +245,9 @@ def test_load_converted_distributed_checkpoint():
 
 @pytest.mark.depends(on=["test_converted_state_dict", "test_load_pretrained_distributed_checkpoint"])
 def test_load_converted_state_dict_checkpoint():
-    pretrained_config_ref = CheckpointLoadConfig(path=_CKPT_PATH, format=CheckpointType.distributed)
-    pretrained_config_0 = CheckpointLoadConfig(path=_CONVERT_PATH / "state_dict_0", format=CheckpointType.state_dict)
-    pretrained_config_1 = CheckpointLoadConfig(path=_CONVERT_PATH / "state_dict_1", format=CheckpointType.state_dict)
+    pretrained_config_ref = CheckpointLoadConfig(path=_CKPT_PATH, format=CheckpointFormat.distributed)
+    pretrained_config_0 = CheckpointLoadConfig(path=_CONVERT_PATH / "state_dict_0", format=CheckpointFormat.state_dict)
+    pretrained_config_1 = CheckpointLoadConfig(path=_CONVERT_PATH / "state_dict_1", format=CheckpointFormat.state_dict)
     config = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_ref)
     model = TEST_MODEL_CLS.from_pretrained(pretrained_config_0)
     config_1 = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_1)
@@ -263,15 +263,15 @@ def test_load_converted_state_dict_checkpoint():
 def test_load_converted_huggingface_checkpoint():
     pretrained_config_ref = CheckpointLoadConfig(
         path=_CKPT_PATH,
-        format=CheckpointType.distributed,
+        format=CheckpointFormat.distributed,
     )
     pretrained_config_0 = CheckpointLoadConfig(
         path=_CONVERT_PATH / "huggingface_0",
-        format=CheckpointType.external,
+        format=CheckpointFormat.external,
     )
     pretrained_config_1 = CheckpointLoadConfig(
         path=_CONVERT_PATH / "huggingface_1",
-        format=CheckpointType.external,
+        format=CheckpointFormat.external,
     )
     config = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_ref)
     model = TEST_MODEL_CLS.from_pretrained(pretrained_config_0, mode=StageMode.weights)
@@ -289,7 +289,7 @@ def test_run_converted_model():
     model_ref = TEST_MODEL_HF_CLS.from_pretrained(
         CheckpointLoadConfig(
             path=_CKPT_PATH,
-            format=CheckpointType.distributed,
+            format=CheckpointFormat.distributed,
         )
     )
     test_input = torch.randint(
@@ -300,7 +300,7 @@ def test_run_converted_model():
     model_from_hf = TEST_MODEL_HF_CLS.from_pretrained(
         CheckpointLoadConfig(
             path=_CONVERT_PATH / "huggingface_0",
-            format=CheckpointType.external,
+            format=CheckpointFormat.external,
         )
     )
     errors = []
@@ -362,12 +362,12 @@ def test_load_pretrained_in_dp2_match_checkpoint():
     test_ckpt_path = TEST_RESULTS_PATH / f"test_{TEST_MODEL}_load_pretrained_distributed_in_dp2" / "checkpoints" / "1"
     pretrained_config_ref = CheckpointLoadConfig(
         path=_CKPT_PATH,
-        format=CheckpointType.distributed,
+        format=CheckpointFormat.distributed,
         load_config=ModelConfigType.fast_llm,
     )
     pretrained_config_test = CheckpointLoadConfig(
         path=test_ckpt_path,
-        format=CheckpointType.distributed,
+        format=CheckpointFormat.distributed,
         load_config=ModelConfigType.fast_llm,
     )
     config_ref = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_ref)
@@ -404,12 +404,12 @@ def test_load_distributed_checkpoint_dp2():
     # This also tests conversion which uses `FastLLMModel.from_checkpoint`
     pretrained_config_ref = CheckpointLoadConfig(
         path=_CKPT_PATH,
-        format=CheckpointType.distributed,
+        format=CheckpointFormat.distributed,
         load_config=ModelConfigType.fast_llm,
     )
     pretrained_config_test = CheckpointLoadConfig(
         path=TEST_RESULTS_PATH / f"test_{TEST_MODEL}_load_pretrained_distributed_in_dp2" / "checkpoints" / "1",
-        format=CheckpointType.distributed,
+        format=CheckpointFormat.distributed,
     )
     config = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_ref)
     model = TEST_MODEL_CLS.from_pretrained(pretrained_config_test, mode=StageMode.weights)

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -7,7 +7,7 @@ import torch
 import transformers
 import yaml
 
-from fast_llm.engine.config_utils.checkpoint import CheckpointLoadConfig, CheckpointType, LoadConfig
+from fast_llm.engine.config_utils.checkpoint import CheckpointLoadConfig, CheckpointType, ModelConfigType
 from fast_llm.engine.multi_stage.config import StageMode
 from fast_llm.models.auto import model_registry
 from fast_llm.tools.convert import ConversionConfig
@@ -211,7 +211,7 @@ def test_load_pretrained_distributed_checkpoint():
         path=_CKPT_PATH,
         format=CheckpointType.distributed,
         optimizer_state=True,
-        load_config=LoadConfig.fast_llm,
+        load_config=ModelConfigType.fast_llm,
     )
     model = TEST_MODEL_CLS.from_pretrained(pretrained_config_ref)
     _compare_configs(config, model._base_model_config)
@@ -363,12 +363,12 @@ def test_load_pretrained_in_dp2_match_checkpoint():
     pretrained_config_ref = CheckpointLoadConfig(
         path=_CKPT_PATH,
         format=CheckpointType.distributed,
-        load_config=LoadConfig.fast_llm,
+        load_config=ModelConfigType.fast_llm,
     )
     pretrained_config_test = CheckpointLoadConfig(
         path=test_ckpt_path,
         format=CheckpointType.distributed,
-        load_config=LoadConfig.fast_llm,
+        load_config=ModelConfigType.fast_llm,
     )
     config_ref = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_ref)
     config_test = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_test)
@@ -405,7 +405,7 @@ def test_load_distributed_checkpoint_dp2():
     pretrained_config_ref = CheckpointLoadConfig(
         path=_CKPT_PATH,
         format=CheckpointType.distributed,
-        load_config=LoadConfig.fast_llm,
+        load_config=ModelConfigType.fast_llm,
     )
     pretrained_config_test = CheckpointLoadConfig(
         path=TEST_RESULTS_PATH / f"test_{TEST_MODEL}_load_pretrained_distributed_in_dp2" / "checkpoints" / "1",

--- a/tools/push_model.py
+++ b/tools/push_model.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 
+from fast_llm.engine.config_utils.checkpoint import CheckpointType
 from fast_llm.engine.config_utils.runnable import RunnableConfig
 
 try:
@@ -26,7 +27,6 @@ except ImportError as e:
 
 
 from fast_llm.config import Config, config_class, Field  # isort:skip
-from fast_llm.engine.multi_stage.config import CheckpointType  # isort:skip
 from fast_llm.tools.convert import ConversionConfig  # isort:skip
 
 
@@ -149,7 +149,7 @@ class PushConfig(RunnableConfig):
                 # Block until the conversion is done
                 ConversionConfig(
                     input_type=CheckpointType.distributed,
-                    output_type=CheckpointType.huggingface,
+                    output_type=CheckpointType.external,
                     input_path=checkpoint_path,
                     output_path=checkpoint_path_hf,
                     model_type=self.model_type,

--- a/tools/push_model.py
+++ b/tools/push_model.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 
 from fast_llm.config import Field, config_class
-from fast_llm.engine.config_utils.checkpoint import CheckpointType
+from fast_llm.engine.config_utils.checkpoint import CheckpointFormat
 from fast_llm.engine.config_utils.runnable import RunnableConfig
 
 try:
@@ -148,8 +148,8 @@ class PushConfig(RunnableConfig):
                 checkpoint_path_hf = checkpoint_path.with_name(checkpoint_path.name + "_hf")
                 # Block until the conversion is done
                 ConversionConfig(
-                    input_type=CheckpointType.distributed,
-                    output_type=CheckpointType.external,
+                    input_type=CheckpointFormat.distributed,
+                    output_type=CheckpointFormat.external,
                     input_path=checkpoint_path,
                     output_path=checkpoint_path_hf,
                     model_type=self.model_type,

--- a/tools/push_model.py
+++ b/tools/push_model.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 
+from fast_llm.config import Field, config_class
 from fast_llm.engine.config_utils.checkpoint import CheckpointType
 from fast_llm.engine.config_utils.runnable import RunnableConfig
 
@@ -26,7 +27,6 @@ except ImportError as e:
     raise ImportError("Please install huggingface_hub to use this script") from e
 
 
-from fast_llm.config import Config, config_class, Field  # isort:skip
 from fast_llm.tools.convert import ConversionConfig  # isort:skip
 
 


### PR DESCRIPTION
* Add a FieldUpdate tool to simplify field overrides.
* Standardize checkpoint saving and loading configs, using mixins so training checkpoint/export configs can use just the right fields (ex. no path since it's provided by the trainer)
* Adjust some fields so they make sense for both saving and loading, and merge the ones for config selection into an enum (see below).
* Move checkpoint save/load from Run to Trainer and simplify.
* Make IntervalConfig into a proper class (use FieldUpdate foe doc instead)
* Make export checkpoint fully configurable, save separately instead of using a symlink.
* Add keep_every for checkpoints to get the old behaviour, and optional callback script.


RENAME[BW COMPATIBLE] pretrained.imported_type ->pretrained.model_type
RENAME[BW COMPATIBLE] pretrained.load_weights -> pretrained.model_weights
RENAME[BW COMPATIBLE] pretrained.load_optimizer -> pretrained.optimizer_state
MERGE (pretrained.override_architecture, pretrained.load_full_base_model_config, pretrained.load_full_fast_llm_config) ->pretrained.load_config:enum