### PR TITLE
New long-term checkpoint format

### DIFF
--- a/fast_llm/engine/checkpoint/config.py
+++ b/fast_llm/engine/checkpoint/config.py
@@ -67,14 +67,14 @@ class DistributedCheckpointFormat(CheckpointFormat):
         return DistributedCheckpointHandler
 
 
-class StateDictCheckpointFormat(CheckpointFormat):
-    name: typing.ClassVar[str] = "state_dict"
+class FastLLMCheckpointFormat(CheckpointFormat):
+    name: typing.ClassVar[str] = "fast_llm"
 
     @classmethod
     def get_handler_class(cls):
-        from fast_llm.engine.checkpoint.state_dict import TrivialCheckpointHandler
+        from fast_llm.engine.checkpoint.state_dict import FastLLMCheckpointHandler
 
-        return TrivialCheckpointHandler
+        return FastLLMCheckpointHandler
 
 
 class ModelConfigType(str, enum.Enum):
@@ -102,7 +102,7 @@ class CheckpointConfigBase(Config):
     # Note: the `format` may be a str when configuring from file or cli.
     #   The actual class should be set through `setup` in a parent config validation.
     format: type[CheckpointFormat] = Field(
-        default=StateDictCheckpointFormat,
+        default=FastLLMCheckpointFormat,
         desc="Format of the checkpoint.",
         hint=FieldHint.core,
     )

--- a/fast_llm/engine/checkpoint/external.py
+++ b/fast_llm/engine/checkpoint/external.py
@@ -304,7 +304,7 @@ class HuggingfaceStateDictCheckpointHandler(ExternalStateDictCheckpointHandler, 
         logger.info(f"Saving index to {path}")
         # Save the index.
         json.dump(
-            {"metadata": metadata, "weight_map": self._index},
+            {"metadata": metadata, "weight_map": index},
             path.open("w"),
             indent=4,
         )

--- a/fast_llm/engine/checkpoint/external.py
+++ b/fast_llm/engine/checkpoint/external.py
@@ -298,9 +298,18 @@ class AutoStateDictCheckpointHandler(ExternalStateDictCheckpointHandler, abc.ABC
 
 
 class HuggingfaceStateDictCheckpointHandler(ExternalStateDictCheckpointHandler, abc.ABC):
-    base_file_name: typing.ClassVar[str] = "model"
 
-    def _save_metadata(self, config: CheckpointSaveMetadataConfig, metadata: CheckpointMetadata) -> dict:
+    def _save_serialized_metadata(self, config: CheckpointSaveMetadataConfig, metadata: dict, index: dict):
+        path = config.path / f"{self.base_file_name}.safetensors.index.json"
+        logger.info(f"Saving index to {path}")
+        # Save the index.
+        json.dump(
+            {"metadata": metadata, "weight_map": self._index},
+            path.open("w"),
+            indent=4,
+        )
+
+    def _serialize_metadata(self, config: CheckpointSaveMetadataConfig, metadata: CheckpointMetadata) -> dict:
         huggingface_config = self._export_config(self._model.base_model_config)
         self._save_config(config.path, huggingface_config)
         return {

--- a/fast_llm/engine/checkpoint/state_dict.py
+++ b/fast_llm/engine/checkpoint/state_dict.py
@@ -6,6 +6,7 @@ import typing
 import safetensors
 import safetensors.torch
 import torch
+import yaml
 
 from fast_llm.core.distributed import safe_barrier
 from fast_llm.engine.checkpoint.config import (
@@ -15,7 +16,7 @@ from fast_llm.engine.checkpoint.config import (
     CheckpointLoadMetadataConfig,
     CheckpointSaveConfig,
     CheckpointSaveMetadataConfig,
-    StateDictCheckpointFormat,
+    FastLLMCheckpointFormat,
     export_safetensors_metadata,
 )
 from fast_llm.engine.checkpoint.safe_load import SafeLoad
@@ -28,36 +29,45 @@ logger = logging.getLogger(__name__)
 
 
 class StateDictCheckpointHandler(CheckpointHandler):
-    base_file_name: typing.ClassVar[str]
+    base_file_name: typing.ClassVar[str] = "model"
 
     def save(self, config: CheckpointSaveConfig, metadata: CheckpointMetadata):
-        with StateDictSaveContext(
+        serialized_metadata = self._serialize_metadata(config, metadata)
+        saver = StateDictSaver(
             config,
             distributed=self._model.distributed,
-            metadata=self._save_metadata(config, metadata),
+            serialized_metadata=serialized_metadata,
             base_file_name=self.base_file_name,
-        ) as context:
-            # The tensor mapping may not be one-to-one. `convert_state_dict` pops all tensors from
-            #   `state_dict` that are ready for conversion,
-            #   and return a dict containing the converted tensors(s).
-            #   If converting a tensor requires another one that is not yet available (e.g. for concatenation),
-            #   it will remain in `state_dict` until that tensor is available.
-            state_dict = {}
-            for parameter_name, shard_name, tensor in self._model.get_state_tensor_iterator(
-                self.get_shard_names(config), config.data_type
-            ):
-                if shard_name not in state_dict:
-                    state_dict[shard_name] = {}
-                shard_state_dict = state_dict[shard_name]
-                assert parameter_name not in shard_state_dict
-                shard_state_dict[parameter_name] = tensor
-                for exported_name, exported_tensor in self._convert_state_dict(shard_state_dict, True).items():
-                    context.add_tensor(self._get_key(exported_name, shard_name), exported_tensor)
+        )
+        # The tensor mapping may not be one-to-one. `convert_state_dict` pops all tensors from
+        #   `state_dict` that are ready for conversion,
+        #   and return a dict containing the converted tensors(s).
+        #   If converting a tensor requires another one that is not yet available (e.g. for concatenation),
+        #   it will remain in `state_dict` until that tensor is available.
+        state_dict = {}
+        for parameter_name, shard_name, tensor in self._model.get_state_tensor_iterator(
+            self.get_shard_names(config), config.data_type
+        ):
+            if shard_name not in state_dict:
+                state_dict[shard_name] = {}
+            shard_state_dict = state_dict[shard_name]
+            assert parameter_name not in shard_state_dict
+            shard_state_dict[parameter_name] = tensor
+            for exported_name, exported_tensor in self._convert_state_dict(shard_state_dict, True).items():
+                saver.add_tensor(self._get_key(exported_name, shard_name), exported_tensor)
 
-            for shard_name, shard_state_dict in state_dict.items():
-                assert not shard_state_dict, (shard_name, list(state_dict))
+        for shard_name, shard_state_dict in state_dict.items():
+            assert not shard_state_dict, (shard_name, list(state_dict))
 
-    def _save_metadata(self, config: CheckpointSaveMetadataConfig, metadata: CheckpointMetadata) -> dict:
+        index = saver.finalize()
+        if self._model.distributed_config.rank == 0:
+            self._save_serialized_metadata(config, serialized_metadata, index)
+
+    @abc.abstractmethod
+    def _save_serialized_metadata(self, config: CheckpointSaveMetadataConfig, metadata: dict, index: dict):
+        pass
+
+    def _serialize_metadata(self, config: CheckpointSaveMetadataConfig, metadata: CheckpointMetadata) -> dict:
         return metadata.to_serialized()
 
     def load(self, config: CheckpointLoadConfig, metadata: CheckpointMetadata):
@@ -99,15 +109,29 @@ class StateDictCheckpointHandler(CheckpointHandler):
         pass
 
 
-class TrivialCheckpointHandler(StateDictCheckpointHandler):
-    format: typing.ClassVar[type[CheckpointFormat]] = StateDictCheckpointFormat
-    base_file_name = "state_dict"
+class FastLLMCheckpointHandler(StateDictCheckpointHandler):
+    format: typing.ClassVar[type[CheckpointFormat]] = FastLLMCheckpointFormat
 
     @classmethod
     def load_metadata(cls, config: CheckpointLoadMetadataConfig):
-        return CheckpointMetadata.from_dict(
-            json.load((config.path / f"state_dict.safetensors.index.json").open("r"))["metadata"]
-        )
+        # TODO v0.2: Remove backward compatibility.
+        old_path = config.path / "state_dict.safetensors.index.json"
+        if old_path.is_file():
+            logger.warning(f"Loading metadata from {old_path} (deprecated format)")
+            serialized_metadata = json.load((config.path / "state_dict.safetensors.index.json").open("r"))
+            metadata = CheckpointMetadata.from_dict(serialized_metadata)["metadata"]
+            metadata.metadata["index"] = serialized_metadata["weight_map"]
+        else:
+            path = config.path / f"metadata.yaml"
+            logger.warning(f"Loading metadata from {path}")
+            metadata = CheckpointMetadata.from_dict(yaml.safe_load(path.open("r")))
+        return metadata
+
+    def _save_serialized_metadata(self, config: CheckpointSaveMetadataConfig, serialized_metadata: dict, index: dict):
+        path = config.path / f"metadata.yaml"
+        logger.info(f"Saving metadata to {path}")
+        serialized_metadata["metadata"]["state_index"] = index
+        yaml.safe_dump(serialized_metadata, path.open("w"))
 
     @classmethod
     def _get_key(cls, parameter_name: str, shard_name: str) -> str:
@@ -123,13 +147,10 @@ class TrivialCheckpointHandler(StateDictCheckpointHandler):
     def _load_weights(
         self, config: CheckpointLoadConfig, device
     ) -> typing.Iterator[tuple[str, str, torch.Tensor | SafeTensorSlice]]:
-        index_path = config.path / f"state_dict.safetensors.index.json"
-        logger.info(f"Loading index from {index_path}")
-        file_names = set(json.load(index_path.open("r"))["weight_map"].values())
         metadata = self.load_metadata(config)
         shard_names = self.get_shard_names(config)
         Assert.eq(metadata.shards[: self.get_num_shards(config)], list(shard_names))
-        for file_name in file_names:
+        for file_name in set(metadata.metadata["state_index"].values()):
             logger.info(f"Loading from {config.path / file_name}")
             with safetensors.safe_open(
                 config.path / file_name,
@@ -142,18 +163,18 @@ class TrivialCheckpointHandler(StateDictCheckpointHandler):
                         yield parameter_name, shard_name, f.get_slice(key)
 
 
-class StateDictSaveContext:
+class StateDictSaver:
     def __init__(
         self,
         config: CheckpointSaveConfig,
         *,
         distributed: Distributed,
-        metadata: dict,
+        serialized_metadata: dict,
         base_file_name: str,
     ):
         self._config = config
-        self._metadata = metadata
-        self.distributed = distributed
+        self._safetensors_metadata = export_safetensors_metadata(serialized_metadata)
+        self._distributed = distributed
         self._distributed_config = distributed.config
         self.base_file_name = (
             base_file_name
@@ -162,65 +183,56 @@ class StateDictSaveContext:
         )
         # All ranks reconstruct the pipeline-parallel state (for simplicity), but only one saves it.
         self._do_save = self._distributed_config.data_rank == self._distributed_config.tensor_rank == 0
+        self._file_count = 0
+        self._parameter_count = 0
+        self._tensors = {}
+        self._index = {}
 
     def add_tensor(self, name: str, tensor: torch.Tensor):
-        assert name not in self.tensors
-        self.tensors[name] = tensor
-        self.param_count += tensor.numel()
-        if self.param_count >= self._config.parameters_per_file:
+        assert name not in self._tensors
+        self._tensors[name] = tensor
+        self._parameter_count += tensor.numel()
+        if self._parameter_count >= self._config.parameters_per_file:
             self._save_next_file()
 
-    def __enter__(self):
-        self.file_count = 0
-        self.param_count = 0
-        self.tensors = {}
-        self.index = {}
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.tensors:
+    def finalize(self):
+        if self._tensors:
             # Save the last file.
             self._save_next_file()
-
-        if self._do_save and self._distributed_config.pipeline_parallel != 1:
-            # Combine the indexes from all pipeline ranks.
-            logger.info(f"Merging pipeline-parallel indexes.")
-            json.dump(
-                self.index, (self._config.path / f"index_{self._distributed_config.pipeline_rank}.json").open("w")
-            )
-            safe_barrier(self.distributed.pipeline_group, "save state dict")
-            if self._distributed_config.pipeline_rank == 0:
-                self.index = {}
-                for rank in range(self._distributed_config.pipeline_parallel):
-                    file_name = self._config.path / f"index_{rank}.json"
-                    local_index = json.load(file_name.open("r"))
-                    for key, value in local_index.items():
-                        assert key not in self.index, key
-                        self.index[key] = value
-                    file_name.unlink()
-
-        if self._distributed_config.rank == 0:
-            path = self._config.path / f"{self.base_file_name}.safetensors.index.json"
-            logger.info(f"Saving index to {path}")
-            # Save the index.
-            json.dump(
-                {"metadata": self._metadata, "weight_map": self.index},
-                path.open("w"),
-                indent=4,
-            )
+        # Merge pipeline-parallel indexes.
+        self._merge_index()
+        return self._index
 
     def _save_next_file(self):
-        file_name = f"{self.base_file_name}_{self.file_count}.safetensors"
+        file_name = f"{self.base_file_name}_{self._file_count}.safetensors"
         if self._do_save:
             logger.info(f"Saving tensors to {self._config.path / file_name}")
             safetensors.torch.save_file(
-                tensors=self.tensors,
+                tensors=self._tensors,
                 filename=self._config.path / file_name,
-                metadata=export_safetensors_metadata(self._metadata),
+                metadata=self._safetensors_metadata,
             )
-        for name_ in self.tensors:
-            assert name_ not in self.index
-            self.index[name_] = file_name
-        self.file_count += 1
-        self.param_count = 0
-        self.tensors = {}
+        for name_ in self._tensors:
+            assert name_ not in self._index
+            self._index[name_] = file_name
+        self._file_count += 1
+        self._parameter_count = 0
+        self._tensors = {}
+
+    def _merge_index(self):
+        if self._do_save and self._distributed_config.pipeline_parallel != 1:
+            # Combine the indexes from all pipeline ranks.
+            logger.info(f"Merging pipeline-parallel indexes.")
+            yaml.dump(
+                self._index, (self._config.path / f"index_{self._distributed_config.pipeline_rank}.yaml").open("w")
+            )
+            safe_barrier(self._distributed.pipeline_group, "save state dict")
+            self._index = {}
+            if self._distributed_config.pipeline_rank == 0:
+                for rank in range(self._distributed_config.pipeline_parallel):
+                    file_name = self._config.path / f"index_{rank}.yaml"
+                    local_index = yaml.safe_load(file_name.open("r"))
+                    for key, value in local_index.items():
+                        assert key not in self._index, key
+                        self._index[key] = value
+                    file_name.unlink()

--- a/fast_llm/engine/checkpoint/state_dict.py
+++ b/fast_llm/engine/checkpoint/state_dict.py
@@ -130,6 +130,8 @@ class FastLLMCheckpointHandler(StateDictCheckpointHandler):
     def _save_serialized_metadata(self, config: CheckpointSaveMetadataConfig, serialized_metadata: dict, index: dict):
         path = config.path / f"metadata.yaml"
         logger.info(f"Saving metadata to {path}")
+        if "metadata" not in serialized_metadata:
+            serialized_metadata["metadata"] = {}
         serialized_metadata["metadata"]["state_index"] = index
         yaml.safe_dump(serialized_metadata, path.open("w"))
 

--- a/fast_llm/engine/huggingface/config.py
+++ b/fast_llm/engine/huggingface/config.py
@@ -5,7 +5,7 @@ import typing
 
 import transformers
 
-from fast_llm.engine.checkpoint.config import CheckpointLoadMetadataConfig, StateDictCheckpointFormat
+from fast_llm.engine.checkpoint.config import CheckpointLoadMetadataConfig, FastLLMCheckpointFormat
 from fast_llm.engine.multi_stage.config import FastLLMModelConfig
 
 logger = logging.getLogger(__name__)
@@ -66,7 +66,7 @@ class HuggingfaceModelConfig(transformers.PretrainedConfig):
         else:
             pretrained = CheckpointLoadMetadataConfig(
                 path=pathlib.Path(pretrained_model_name_or_path),
-                format=StateDictCheckpointFormat,
+                format=FastLLMCheckpointFormat,
             )
         metadata = cls.model_config_class.load_metadata(pretrained)
         updates = {}

--- a/fast_llm/engine/huggingface/model.py
+++ b/fast_llm/engine/huggingface/model.py
@@ -5,7 +5,7 @@ import typing
 import transformers.modeling_outputs
 
 from fast_llm.config import NoAutoValidate
-from fast_llm.engine.checkpoint.config import CheckpointLoadConfig, StateDictCheckpointFormat
+from fast_llm.engine.checkpoint.config import CheckpointLoadConfig, FastLLMCheckpointFormat
 from fast_llm.engine.distributed.config import PhaseType
 from fast_llm.engine.huggingface.config import HuggingfaceModelConfig
 from fast_llm.engine.multi_stage.config import StageMode
@@ -68,7 +68,7 @@ class HuggingfacePreTrainedModel(transformers.PreTrainedModel):
         if not isinstance(pretrained_model_name_or_path, CheckpointLoadConfig):
             pretrained_model_name_or_path = CheckpointLoadConfig(
                 path=pathlib.Path(pretrained_model_name_or_path),
-                format=StateDictCheckpointFormat,
+                format=FastLLMCheckpointFormat,
             )
 
         config_updates = {}

--- a/fast_llm/engine/multi_stage/config.py
+++ b/fast_llm/engine/multi_stage/config.py
@@ -14,7 +14,7 @@ from fast_llm.engine.checkpoint.config import (
     CheckpointLoadMetadataConfig,
     CheckpointSaveMetadataConfig,
     DistributedCheckpointFormat,
-    StateDictCheckpointFormat,
+    FastLLMCheckpointFormat,
 )
 from fast_llm.engine.distributed.config import DistributedConfig
 from fast_llm.utils import Assert
@@ -189,7 +189,7 @@ class FastLLMModelConfig(Config):
     _abstract = True
     checkpoint_formats: typing.ClassVar[tuple[type[CheckpointFormat], ...]] = (
         DistributedCheckpointFormat,
-        StateDictCheckpointFormat,
+        FastLLMCheckpointFormat,
     )
     model_name: typing.ClassVar[str]
     base_model: BaseModelConfig = Field(
@@ -214,6 +214,9 @@ class FastLLMModelConfig(Config):
             format_ = cls.get_checkpoint_format(format.name)
             Assert.is_(format, format_)
             return format_
+        # TODO v0.2: Remove backward compatibility.
+        if format == "state_dict":
+            format = "fast_llm"
         for format_ in cls.checkpoint_formats:
             if format_.name == format:
                 return format_

--- a/fast_llm/engine/training/trainer.py
+++ b/fast_llm/engine/training/trainer.py
@@ -7,7 +7,6 @@ import time
 import typing
 
 import torch
-from wandb import config
 
 from fast_llm.core.distributed import safe_barrier
 from fast_llm.data.config import AbstractData
@@ -457,8 +456,9 @@ class Trainer(abc.ABC):
     def _get_last_checkpoint(self):
         if self._run.experiment_directory is None:
             return None
-        checkpoint_base_directory = self._run.experiment_directory / config.get_save_directory(
+        checkpoint_base_directory = (
             self._run.experiment_directory
+            / self._config.training.checkpoint.get_save_directory(self._run.experiment_directory)
         )
         if self._run.is_main_rank and checkpoint_base_directory.is_dir():
             checkpoints = [int(path.name) for path in checkpoint_base_directory.iterdir()]

--- a/fast_llm/engine/training/trainer.py
+++ b/fast_llm/engine/training/trainer.py
@@ -7,6 +7,7 @@ import time
 import typing
 
 import torch
+from wandb import config
 
 from fast_llm.core.distributed import safe_barrier
 from fast_llm.data.config import AbstractData
@@ -400,7 +401,7 @@ class Trainer(abc.ABC):
         self, config: TrainingCheckpointBaseConfig, metrics: dict[PhaseType, dict[str, float | int]] | None
     ):
         # TODO v0.2: Move barrier, ok file to FastLLMModel
-        checkpoint_base_directory = self._run.experiment_directory / config.directory_name
+        checkpoint_base_directory = config.get_save_directory(self._run.experiment_directory)
         checkpoint_directory = checkpoint_base_directory / str(self._completed_steps)
 
         # Create the checkpoint
@@ -438,7 +439,7 @@ class Trainer(abc.ABC):
             config.callback.run()
 
     def _load_checkpoint(self, config: TrainingCheckpointConfig, iteration: int):
-        checkpoint_directory = self._run.experiment_directory / config.directory_name / str(iteration)
+        checkpoint_directory = config.get_save_directory(self._run.experiment_directory) / str(iteration)
         Assert.custom(pathlib.Path.is_file, checkpoint_directory / "ok")
         # TODO v0.2: Use config.get_load_config to make it generic
         # TODO v0.2: Detect format instead of hard-coding
@@ -456,7 +457,9 @@ class Trainer(abc.ABC):
     def _get_last_checkpoint(self):
         if self._run.experiment_directory is None:
             return None
-        checkpoint_base_directory = self._run.experiment_directory / self._config.training.checkpoint.directory_name
+        checkpoint_base_directory = self._run.experiment_directory / config.get_save_directory(
+            self._run.experiment_directory
+        )
         if self._run.is_main_rank and checkpoint_base_directory.is_dir():
             checkpoints = [int(path.name) for path in checkpoint_base_directory.iterdir()]
             iteration = max(checkpoints) if checkpoints else -1

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -11,8 +11,8 @@ from fast_llm.engine.checkpoint.config import (
     CheckpointLoadConfig,
     CheckpointSaveConfig,
     DistributedCheckpointFormat,
+    FastLLMCheckpointFormat,
     ModelConfigType,
-    StateDictCheckpointFormat,
 )
 from fast_llm.engine.multi_stage.config import StageMode
 from fast_llm.models.auto import model_registry
@@ -103,7 +103,7 @@ def test_convert_distributed_to_state_dict():
             ),
             output=CheckpointSaveConfig(
                 path=_CONVERT_PATH / "state_dict_0",
-                format=StateDictCheckpointFormat,
+                format=FastLLMCheckpointFormat,
             ),
         )
     )
@@ -117,7 +117,7 @@ def test_convert_state_dict_to_huggingface():
         ConversionConfig(
             input=CheckpointLoadConfig(
                 path=_CONVERT_PATH / "state_dict_0",
-                format=StateDictCheckpointFormat,
+                format=FastLLMCheckpointFormat,
             ),
             output=CheckpointSaveConfig(
                 path=_CONVERT_PATH / "huggingface_0",
@@ -171,7 +171,7 @@ def test_convert_huggingface_to_state_dict():
             ),
             output=CheckpointSaveConfig(
                 path=_CONVERT_PATH / "state_dict_1",
-                format=StateDictCheckpointFormat,
+                format=FastLLMCheckpointFormat,
             ),
         )
     )
@@ -183,7 +183,7 @@ def test_convert_state_dict_to_distributed():
         ConversionConfig(
             input=CheckpointLoadConfig(
                 path=_CONVERT_PATH / "state_dict_1",
-                format=StateDictCheckpointFormat,
+                format=FastLLMCheckpointFormat,
             ),
             output=CheckpointSaveConfig(
                 path=_CONVERT_PATH / "distributed_1",
@@ -276,8 +276,8 @@ def test_load_converted_distributed_checkpoint():
 @pytest.mark.depends(on=["test_converted_state_dict", "test_load_pretrained_distributed_checkpoint"])
 def test_load_converted_state_dict_checkpoint():
     pretrained_config_ref = CheckpointLoadConfig(path=_CKPT_PATH, format=DistributedCheckpointFormat)
-    pretrained_config_0 = CheckpointLoadConfig(path=_CONVERT_PATH / "state_dict_0", format=StateDictCheckpointFormat)
-    pretrained_config_1 = CheckpointLoadConfig(path=_CONVERT_PATH / "state_dict_1", format=StateDictCheckpointFormat)
+    pretrained_config_0 = CheckpointLoadConfig(path=_CONVERT_PATH / "state_dict_0", format=FastLLMCheckpointFormat)
+    pretrained_config_1 = CheckpointLoadConfig(path=_CONVERT_PATH / "state_dict_1", format=FastLLMCheckpointFormat)
     config = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_ref)
     model = TEST_MODEL_CLS.from_pretrained(pretrained_config_0)
     config_1 = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_1)

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -49,13 +49,13 @@ def test_checkpoint_and_eval():
 
 
 def _prepare_resume_fn(test_path: pathlib.Path, compare_path: pathlib.Path, skip: bool) -> bool:
-    if skip and (test_path / "checkpoints" / "2" / "ok").is_file():
+    if skip and (test_path / "checkpoint" / "2" / "ok").is_file():
         return True
     elif test_path.is_dir():
         shutil.rmtree(test_path)
     shutil.copytree(compare_path, test_path)
-    shutil.rmtree(test_path / "checkpoints" / "2")
-    assert (test_path / "checkpoints" / "1" / "ok").is_file()
+    shutil.rmtree(test_path / "checkpoint" / "2")
+    assert (test_path / "checkpoint" / "1" / "ok").is_file()
     # TODO: Eval
     shutil.rmtree(test_path / "runs")
     return False
@@ -89,12 +89,12 @@ def _run_conversion(config: ConversionConfig):
         config.run(TEST_MODEL_CONFIG_CLS)
 
 
-_CKPT_PATH = TEST_RESULTS_PATH / f"test_{TEST_MODEL}_checkpoint_and_eval" / "checkpoints" / "2"
+_CKPT_PATH = TEST_RESULTS_PATH / f"test_{TEST_MODEL}_checkpoint_and_eval" / "checkpoint" / "2"
 _CONVERT_PATH = TEST_RESULTS_PATH / f"test_{TEST_MODEL}_convert_model"
 
 
 @pytest.mark.depends(on=["test_checkpoint_and_eval"])
-def test_convert_distributed_to_state_dict():
+def test_convert_distributed_to_fast_llm():
     _run_conversion(
         ConversionConfig(
             input=CheckpointLoadConfig(
@@ -102,21 +102,21 @@ def test_convert_distributed_to_state_dict():
                 format=DistributedCheckpointFormat,
             ),
             output=CheckpointSaveConfig(
-                path=_CONVERT_PATH / "state_dict_0",
+                path=_CONVERT_PATH / "fast_llm_0",
                 format=FastLLMCheckpointFormat,
             ),
         )
     )
 
 
-@pytest.mark.depends(on=["test_convert_distributed_to_state_dict"])
-def test_convert_state_dict_to_huggingface():
+@pytest.mark.depends(on=["test_convert_distributed_to_fast_llm"])
+def test_convert_fast_llm_to_huggingface():
     if HUGGINGFACE_CHECKPOINT_FORMAT is None:
         pytest.skip(f"Conversion not supported for {TEST_MODEL}")
     _run_conversion(
         ConversionConfig(
             input=CheckpointLoadConfig(
-                path=_CONVERT_PATH / "state_dict_0",
+                path=_CONVERT_PATH / "fast_llm_0",
                 format=FastLLMCheckpointFormat,
             ),
             output=CheckpointSaveConfig(
@@ -127,7 +127,7 @@ def test_convert_state_dict_to_huggingface():
     )
 
 
-@pytest.mark.depends(on=["test_convert_state_dict_to_huggingface"])
+@pytest.mark.depends(on=["test_convert_fast_llm_to_huggingface"])
 def test_convert_huggingface_to_distributed():
     _run_conversion(
         ConversionConfig(
@@ -162,7 +162,7 @@ def test_convert_distributed_to_huggingface():
 
 
 @pytest.mark.depends(on=["test_convert_distributed_to_huggingface"])
-def test_convert_huggingface_to_state_dict():
+def test_convert_huggingface_to_fast_llm():
     _run_conversion(
         ConversionConfig(
             input=CheckpointLoadConfig(
@@ -170,19 +170,19 @@ def test_convert_huggingface_to_state_dict():
                 format=HUGGINGFACE_CHECKPOINT_FORMAT,
             ),
             output=CheckpointSaveConfig(
-                path=_CONVERT_PATH / "state_dict_1",
+                path=_CONVERT_PATH / "fast_llm_1",
                 format=FastLLMCheckpointFormat,
             ),
         )
     )
 
 
-@pytest.mark.depends(on=["test_convert_huggingface_to_state_dict"])
-def test_convert_state_dict_to_distributed():
+@pytest.mark.depends(on=["test_convert_huggingface_to_fast_llm"])
+def test_convert_fast_llm_to_distributed():
     _run_conversion(
         ConversionConfig(
             input=CheckpointLoadConfig(
-                path=_CONVERT_PATH / "state_dict_1",
+                path=_CONVERT_PATH / "fast_llm_1",
                 format=FastLLMCheckpointFormat,
             ),
             output=CheckpointSaveConfig(
@@ -193,7 +193,7 @@ def test_convert_state_dict_to_distributed():
     )
 
 
-@pytest.mark.depends(on=["test_convert_huggingface_to_distributed", "test_convert_state_dict_to_distributed"])
+@pytest.mark.depends(on=["test_convert_huggingface_to_distributed", "test_convert_fast_llm_to_distributed"])
 def test_converted_distributed():
     # Compare the fast llm weights
     # TODO: Compare configs
@@ -208,17 +208,17 @@ def test_converted_distributed():
         assert (w[key][:1] == w1[key]).all(), (w[key][:1], w1[key])
 
 
-@pytest.mark.depends(on=["test_convert_distributed_to_state_dict", "test_convert_huggingface_to_state_dict"])
-def test_converted_state_dict():
-    s0 = safetensors.torch.load_file(_CONVERT_PATH / "state_dict_0" / "state_dict_0.safetensors")
-    s1 = safetensors.torch.load_file(_CONVERT_PATH / "state_dict_1" / "state_dict_0.safetensors")
+@pytest.mark.depends(on=["test_convert_distributed_to_fast_llm", "test_convert_huggingface_to_fast_llm"])
+def test_converted_fast_llm():
+    s0 = safetensors.torch.load_file(_CONVERT_PATH / "fast_llm_0" / "model_0.safetensors")
+    s1 = safetensors.torch.load_file(_CONVERT_PATH / "fast_llm_1" / "model_0.safetensors")
     assert s0.keys() == s1.keys()
     for key in s0:
         assert s0[key].shape == s1[key].shape, (key, s0[key].shape, s1[key].shape)
         assert (s0[key] == s1[key]).all(), (key, s0, s1)
 
 
-@pytest.mark.depends(on=["test_convert_state_dict_to_huggingface", "test_convert_distributed_to_huggingface"])
+@pytest.mark.depends(on=["test_convert_fast_llm_to_huggingface", "test_convert_distributed_to_huggingface"])
 def test_converted_huggingface():
     h0 = safetensors.torch.load_file(_CONVERT_PATH / "huggingface_0" / "model_0.safetensors")
     h1 = safetensors.torch.load_file(_CONVERT_PATH / "huggingface_1" / "model_0.safetensors")
@@ -273,11 +273,11 @@ def test_load_converted_distributed_checkpoint():
     assert (weight_shard == model._state_shard).all()
 
 
-@pytest.mark.depends(on=["test_converted_state_dict", "test_load_pretrained_distributed_checkpoint"])
-def test_load_converted_state_dict_checkpoint():
+@pytest.mark.depends(on=["test_converted_fast_llm", "test_load_pretrained_distributed_checkpoint"])
+def test_load_converted_fast_llm_checkpoint():
     pretrained_config_ref = CheckpointLoadConfig(path=_CKPT_PATH, format=DistributedCheckpointFormat)
-    pretrained_config_0 = CheckpointLoadConfig(path=_CONVERT_PATH / "state_dict_0", format=FastLLMCheckpointFormat)
-    pretrained_config_1 = CheckpointLoadConfig(path=_CONVERT_PATH / "state_dict_1", format=FastLLMCheckpointFormat)
+    pretrained_config_0 = CheckpointLoadConfig(path=_CONVERT_PATH / "fast_llm_0", format=FastLLMCheckpointFormat)
+    pretrained_config_1 = CheckpointLoadConfig(path=_CONVERT_PATH / "fast_llm_1", format=FastLLMCheckpointFormat)
     config = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_ref)
     model = TEST_MODEL_CLS.from_pretrained(pretrained_config_0)
     config_1 = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_1)
@@ -289,7 +289,7 @@ def test_load_converted_state_dict_checkpoint():
     assert (weight_shard == model._state_shard).all()
 
 
-@pytest.mark.depends(on=["test_converted_state_dict", "test_load_pretrained_distributed_checkpoint"])
+@pytest.mark.depends(on=["test_converted_fast_llm", "test_load_pretrained_distributed_checkpoint"])
 def test_load_converted_huggingface_checkpoint():
     pretrained_config_ref = CheckpointLoadConfig(
         path=_CKPT_PATH,
@@ -314,7 +314,7 @@ def test_load_converted_huggingface_checkpoint():
     assert (weight_shard == model._state_shard).all()
 
 
-@pytest.mark.depends(on=["test_load_converted_state_dict_checkpoint", "test_load_converted_huggingface_checkpoint"])
+@pytest.mark.depends(on=["test_load_converted_fast_llm_checkpoint", "test_load_converted_huggingface_checkpoint"])
 def test_run_converted_model():
     model_ref = TEST_MODEL_HF_CLS.from_pretrained(
         CheckpointLoadConfig(
@@ -326,7 +326,7 @@ def test_run_converted_model():
         0, model_ref.config.fast_llm_config.base_model.vocab_size, size=(4, 100), dtype=torch.int64, device="cuda"
     )
     output_ref = model_ref(test_input)
-    model_from_state_dict = TEST_MODEL_HF_CLS.from_pretrained(_CONVERT_PATH / "state_dict_0")
+    model_from_fast_llm = TEST_MODEL_HF_CLS.from_pretrained(_CONVERT_PATH / "fast_llm_0")
     model_from_hf = TEST_MODEL_HF_CLS.from_pretrained(
         CheckpointLoadConfig(
             path=_CONVERT_PATH / "huggingface_0",
@@ -338,7 +338,7 @@ def test_run_converted_model():
     model_as_hf = transformers.AutoModelForCausalLM.from_pretrained(_CONVERT_PATH / "huggingface_0").cuda()
     for name, model in zip(
         ("From state dict", "From Huggingface", "Native Huggingface"),
-        (model_from_state_dict, model_from_hf, model_as_hf),
+        (model_from_fast_llm, model_from_hf, model_as_hf),
     ):
         print(name)
         output = model(test_input)
@@ -392,7 +392,7 @@ def test_load_pretrained_distributed_with_config():
 
 @pytest.mark.depends(on=["test_load_pretrained_distributed_in_dp2"])
 def test_load_pretrained_in_dp2_match_checkpoint():
-    test_ckpt_path = TEST_RESULTS_PATH / f"test_{TEST_MODEL}_load_pretrained_distributed_in_dp2" / "checkpoints" / "1"
+    test_ckpt_path = TEST_RESULTS_PATH / f"test_{TEST_MODEL}_load_pretrained_distributed_in_dp2" / "checkpoint" / "1"
     pretrained_config_ref = CheckpointLoadConfig(
         path=_CKPT_PATH,
         format=DistributedCheckpointFormat,
@@ -442,7 +442,7 @@ def test_load_distributed_checkpoint_dp2():
         load_config=ModelConfigType.fast_llm,
     )
     pretrained_config_test = CheckpointLoadConfig(
-        path=TEST_RESULTS_PATH / f"test_{TEST_MODEL}_load_pretrained_distributed_in_dp2" / "checkpoints" / "1",
+        path=TEST_RESULTS_PATH / f"test_{TEST_MODEL}_load_pretrained_distributed_in_dp2" / "checkpoint" / "1",
         format=DistributedCheckpointFormat,
     )
     config = TEST_MODEL_CONFIG_CLS.from_pretrained(pretrained_config_ref)
@@ -455,16 +455,16 @@ def test_load_distributed_checkpoint_dp2():
 
 
 @pytest.mark.slow
-@pytest.mark.depends(on=["test_load_converted_state_dict_checkpoint", "test_load_pretrained_in_dp2_match_checkpoint"])
-def test_load_pretrained_state_dict_in_dp2():
+@pytest.mark.depends(on=["test_load_converted_fast_llm_checkpoint", "test_load_pretrained_in_dp2_match_checkpoint"])
+def test_load_pretrained_fast_llm_in_dp2():
     run_test_script(
-        f"test_{TEST_MODEL}_load_pretrained_state_dict_in_dp2",
+        f"test_{TEST_MODEL}_load_pretrained_fast_llm_in_dp2",
         CONFIG_COMMON
         + [
             "training.checkpoint.interval=1",
             "training.train_iters=1",
-            f"pretrained.path={_CONVERT_PATH / 'state_dict_0'}",
-            f"pretrained.format=state_dict",
+            f"pretrained.path={_CONVERT_PATH / 'fast_llm_0'}",
+            f"pretrained.format=fast_llm",
             "schedule.skip_step=True",
         ],
         num_gpus=2,
@@ -473,14 +473,14 @@ def test_load_pretrained_state_dict_in_dp2():
         ref_shard = safetensors.torch.load_file(
             TEST_RESULTS_PATH
             / f"test_{TEST_MODEL}_load_pretrained_distributed_in_dp2"
-            / "checkpoints"
+            / "checkpoint"
             / "1"
             / f"rank_{rank}.safetensors"
         )["state_shard"]
         test_shard = safetensors.torch.load_file(
             TEST_RESULTS_PATH
-            / f"test_{TEST_MODEL}_load_pretrained_state_dict_in_dp2"
-            / "checkpoints"
+            / f"test_{TEST_MODEL}_load_pretrained_fast_llm_in_dp2"
+            / "checkpoint"
             / "1"
             / f"rank_{rank}.safetensors"
         )["state_shard"]
@@ -506,14 +506,14 @@ def test_load_pretrained_huggingface_in_dp2():
         ref_shard = safetensors.torch.load_file(
             TEST_RESULTS_PATH
             / f"test_{TEST_MODEL}_load_pretrained_distributed_in_dp2"
-            / "checkpoints"
+            / "checkpoint"
             / "1"
             / f"rank_{rank}.safetensors"
         )["state_shard"]
         test_shard = safetensors.torch.load_file(
             TEST_RESULTS_PATH
             / f"test_{TEST_MODEL}_load_pretrained_huggingface_in_dp2"
-            / "checkpoints"
+            / "checkpoint"
             / "1"
             / f"rank_{rank}.safetensors"
         )["state_shard"]


### PR DESCRIPTION
# ✨ Description

Rework the `state_dict` checkpoint format. Old checkpoints should still be loadable for now.
* Rename to `fast_llm`, to stress that it's the standard Fast-LLM checkpointing format.
* Replace `state_dict.safetensors.index.json` (copied from Hugginface format) with a cleaner `metadata.yaml` that matches the `distributed` format.
* Rename state_dict -> model for safetensors files (was `state_dict` to make the difference with HF format more obvious, but now the `metadata.yaml` makes it clear enough)

Change the checkpoint directory structure. Backward compatible in fast-llm, but not for outside uses:
* export/ -> export/format/
* checkpoints -> checkpoint

This should be it for checkpoints for now. There are more things to do (#26, async checkpoints, polish interfaces,  tests, etc.), but I spent enough time on checkpoints.

## 🔍 Type of change

Select all that apply:

- [ ] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [x] 🚀 **New feature** (non-breaking change that adds functionality)
- [x] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [x] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)
