### PR TITLE
Fix checkpoint backward compatibility, improve metadata error reporting

### DIFF
--- a/fast_llm/config.py
+++ b/fast_llm/config.py
@@ -544,6 +544,10 @@ class Config:
         for name, field in self.fields():
             value = getattr(self, name, MISSING)
             self._add_field_to_args(arg_dict, name, field, value, verbose, all_fields, format_, serializable)
+        if hasattr(self, "_unknown_fields"):
+            for name, value in self._unknown_fields.items():
+                self._add_field_to_args(arg_dict, f"!!! {name}", None, value, None, all_fields, format_, serializable)
+
         return arg_dict
 
     @classmethod

--- a/fast_llm/engine/config_utils/run.py
+++ b/fast_llm/engine/config_utils/run.py
@@ -164,7 +164,7 @@ class Run:
             self._artifact_dir = run_dir / "artifacts" / str(self._distributed_config.rank)
             log_dir = run_dir / "logs"
         else:
-            _experiment_directory, self._artifact_dir, log_dir = None, None, None
+            self._experiment_directory, self._artifact_dir, log_dir = None, None, None
             self.index = None
 
         if self._config.structured_logs:


### PR DESCRIPTION
# ✨ Description

* Fix a bug introduced in #28 where older checkpoints were not loaded in the flat format.
* Re-raise errors in `load_metadata` as ValueError to prevent them from being hidden when called during validation.
* Add unknown fields to `_to_dict` so they are more visible.

## 🔍 Type of change

Select all that apply:

- [x] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [ ] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)
