### PR TITLE
[perf] use lazy iterator for documents

### DIFF
--- a/fast_llm/data/tokenizer.py
+++ b/fast_llm/data/tokenizer.py
@@ -11,7 +11,9 @@ class Tokenizer:
 
     def __init__(self, config: TokenizerConfig):
         log_main_rank(f"> loading tokenizer from {config.path} ...")
-        self.tokenizer = PreTrainedTokenizerFast(tokenizer_file=config.path, errors="replace", max_len=None)
+        self.tokenizer = PreTrainedTokenizerFast.from_pretrained(
+            pretrained_model_name_or_path=config.path, errors="replace", max_len=None
+        )
         if self.tokenizer.eos_token_id is None:
             raise ValueError("Tokenizer does not have an EOS token.")
         self.eod_id = self.tokenizer.eos_token_id


### PR DESCRIPTION
# ✨ Description

This PR refactors the `write_dataset` method in `GPTMemmapDataset` to enable lazy writing of datasets to reduce memory usage and improve scalability. The key motivation behind this change is to optimize memory consumption, especially when processing large datasets, by avoiding loading all documents into memory simultaneously.  

## 🔍 Type of change

Select all that apply:

- [ ] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [ ] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [x] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [x] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)

## 📝 Changes

List the key changes introduced in this PR:

1. Refactored `write_dataset` to accept a lazy iterator (`Iterable[np.ndarray]`) instead of requiring all documents to be preloaded in memory.
2. Updated `_save_shard` to generate documents lazily and pass them to `write_dataset`.
3. Enhanced performance by reducing peak memory usage during dataset processing.

## ✅ Checklist

Make sure the following tasks are completed before submitting the PR:

### General

- [x] 📜 I have read and followed the [contributing guidelines](https://servicenow.github.io/Fast-LLM/developers/contributing).
- [x] 🏷️ I am using a clear and descriptive PR title that summarizes the key change or feature introduced.
- [x] 🎉 The functionality is complete, and I have tested the changes.
- [x] 📝 I have updated the documentation if needed.
- [x] ⚠️ The change does not introduce any new issues (e.g., runtime warnings, type checker errors, linting problems, unhandled edge cases).
- [x] 🧩 I have commented my code, especially in hard-to-understand areas.

### Dependencies and Configuration

- [ ] 🐋 I have updated the Docker configuration or dependencies, if applicable.
- [x] 🔄 I have ensured compatibility with the existing setup after dependency changes.

### Testing

- [x] 🧪 I have added or updated tests to cover my changes.
- [x] ✔️ New and existing tests pass locally with my changes.
- [x] 🚦 I have tested these changes on GPUs and verified training stability.
- [x] 🏋️ I have tested the changes on realistic training workloads, if applicable.

### Performance Impact

- [x] 📊 I have run benchmarks where applicable to evaluate the performance impact.
- [x] ✅ The benchmarks show no performance regression.
- [x] 🚀 The benchmarks indicate a potential performance improvement.
- [ ] ⚠️ The benchmarks indicate a potential performance degradation.
- [x] 📈 I have provided benchmark results and detailed any performance impact below, if applicable.

## 📊 Performance Impact Details

### Memory Usage
- Peak memory usage reduced significantly during the `_save_shard` phase. <img width="1792" alt="Screenshot 2024-11-28 at 9 38 30 PM" src="https://github.com/user-attachments/assets/6b081929-5d1d-4eed-ae43-5ca1f13f63df">
- Verified with large datasets (e.g., 1TB+ scale): memory footprint is now proportional to the size of a single document rather than the entire dataset.

### Performance
- Sequential writing using a lazy iterator has shown no significant increase in runtime.
- Benchmarks indicate a slight improvement in processing speed due to reduced memory overhead and smoother I/O operations.

## 🗒️ Additional Notes

- This refactor ensures backward compatibility by maintaining the same `.idx` and `.bin` file format.
- Extensive testing was conducted to ensure that lazy iteration does not introduce new issues.
- Future improvements may include adding optional batching for even better performance.
