### PR TITLE
Fix llama conversion, improve parameter conversion

### DIFF
--- a/fast_llm/engine/checkpoint/external.py
+++ b/fast_llm/engine/checkpoint/external.py
@@ -72,9 +72,6 @@ class ConstantImportParamConverter(ParamConverter):
     def import_params(self, export_values):
         return (self.fast_llm_value,)
 
-    # def __repr__(self):
-    #    return f"ConstantImportParamConverter({'.'.join(self.fast_llm_names[0])} = {self.fast_llm_value} <--> N.A.)"
-
 
 @dataclasses.dataclass(kw_only=True)
 class ConstantExportParamConverter(ParamConverter):
@@ -90,9 +87,6 @@ class ConstantExportParamConverter(ParamConverter):
     def import_params(self, export_values):
         Assert.eq(export_values[0], self.export_value)
         return ()
-
-    # def __repr__(self):
-    #    return f"ConstantExportParamConverter(N.A. <--> {'.'.join(self.export_names[0])} = {self.export_value})"
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -114,9 +108,6 @@ class IgnoreImportParamConverter(ParamConverter):
             )
         return ()
 
-    # def __repr__(self):
-    #    return f"IgnoreImportParamConverter(N.A. <--> {'.'.join(self.export_names[0])} ?= {self.ignore_export_value})"
-
 
 @dataclasses.dataclass(kw_only=True)
 class MappedConfigParamConverter(ParamConverter):
@@ -132,9 +123,6 @@ class MappedConfigParamConverter(ParamConverter):
 
     def import_params(self, export_values):
         return (self.fast_llm_value(export_values[0]),)
-
-    # def __repr__(self):
-    #    return f"MappedConfigParamConverter({'.'.join(self.fast_llm_names[0])} <--> {'.'.join(self.export_names[0])})"
 
 
 class WeightConverter:

--- a/fast_llm/engine/checkpoint/external.py
+++ b/fast_llm/engine/checkpoint/external.py
@@ -9,6 +9,7 @@ import safetensors
 import torch
 
 from fast_llm import __version__
+from fast_llm.config import MISSING
 from fast_llm.engine.base_model.config import BaseModelArchitectureConfig
 from fast_llm.engine.checkpoint.config import (
     CheckpointLoadConfig,
@@ -24,65 +25,116 @@ from fast_llm.utils import Assert, get_nested_dict_value, set_nested_dict_value
 logger = logging.getLogger(__name__)
 
 
-@dataclasses.dataclass
-class ParamConverter:
-    fast_llm_name: tuple[str, ...] | None
-    export_name: tuple[str, ...] | str | None
+@dataclasses.dataclass(kw_only=True)
+class ParamConverter(abc.ABC):
+    fast_llm_names: tuple[tuple[str, ...], ...] = ()  # Array of fast-llm names, in nested (tuple) format.
+    export_names: tuple[tuple[str, ...], ...] = ()  # Array of export names, in nested (tuple) format.
 
-    def export_param(self, fast_llm_value):
-        return fast_llm_value
-
-    def import_param(self, export_value):
-        return export_value
-
-
-@dataclasses.dataclass
-class ConstantImportParamConverter(ParamConverter):
-    fast_llm_value: typing.Any
-
-    def export_param(self, fast_llm_value):
-        Assert.eq(fast_llm_value, self.fast_llm_value)
-
-    def import_param(self, export_value):
-        return self.fast_llm_value
-
-
-@dataclasses.dataclass
-class ConstantExportParamConverter(ParamConverter):
-    export_value: typing.Any
-
-    def export_param(self, fast_llm_value):
-        return self.export_value
-
-    def import_param(self, export_value):
-        Assert.eq(export_value, self.export_value)
-
-
-@dataclasses.dataclass
-class IgnoreImportParamConverter(ParamConverter):
-    ignore_export_value: typing.Any
-
-    def export_param(self, fast_llm_value):
+    @abc.abstractmethod
+    def export_params(self, fast_llm_values: tuple[typing.Any, ...]) -> tuple[typing.Any, ...]:
         pass
 
-    def import_param(self, export_value):
-        if export_value is not self.ignore_export_value:
+    @abc.abstractmethod
+    def import_params(self, export_values: tuple[typing.Any, ...]) -> tuple[typing.Any, ...]:
+        pass
+
+
+@dataclasses.dataclass(kw_only=True)
+class RenameParamConverter(ParamConverter):
+
+    def __post_init__(self):
+        Assert.eq(len(self.fast_llm_names), 1)
+        Assert.eq(len(self.export_names), 1)
+
+    def export_params(self, fast_llm_values):
+        return fast_llm_values
+
+    def import_params(self, export_values):
+        return export_values
+
+
+# def __repr__(self):
+#     return f"RenameParamConverter({'.'.join(self.fast_llm_names[0])} <--> {'.'.join(self.export_names[0])})"
+
+
+@dataclasses.dataclass(kw_only=True)
+class ConstantImportParamConverter(ParamConverter):
+    fast_llm_value: typing.Any = MISSING
+
+    def __post_init__(self):
+        Assert.eq(len(self.fast_llm_names), 1)
+        Assert.eq(len(self.export_names), 0)
+
+    def export_params(self, fast_llm_values):
+        Assert.eq(fast_llm_values[0], self.fast_llm_value)
+        return ()
+
+    def import_params(self, export_values):
+        return (self.fast_llm_value,)
+
+    # def __repr__(self):
+    #    return f"ConstantImportParamConverter({'.'.join(self.fast_llm_names[0])} = {self.fast_llm_value} <--> N.A.)"
+
+
+@dataclasses.dataclass(kw_only=True)
+class ConstantExportParamConverter(ParamConverter):
+    export_value: typing.Any = MISSING
+
+    def __post_init__(self):
+        Assert.eq(len(self.fast_llm_names), 0)
+        Assert.eq(len(self.export_names), 1)
+
+    def export_params(self, fast_llm_values):
+        return (self.export_value,)
+
+    def import_params(self, export_values):
+        Assert.eq(export_values[0], self.export_value)
+        return ()
+
+    # def __repr__(self):
+    #    return f"ConstantExportParamConverter(N.A. <--> {'.'.join(self.export_names[0])} = {self.export_value})"
+
+
+@dataclasses.dataclass(kw_only=True)
+class IgnoreImportParamConverter(ParamConverter):
+    ignore_export_value: typing.Any = MISSING
+
+    def __post_init__(self):
+        Assert.eq(len(self.fast_llm_names), 0)
+        Assert.eq(len(self.export_names), 1)
+
+    def export_params(self, fast_llm_values):
+        return (MISSING,)
+
+    def import_params(self, export_values):
+        if export_values[0] not in (self.ignore_export_value, MISSING):
             logger.warning(
-                f"The configuration parameter `{self.export_name}={export_value}` is ignored during conversion."
+                f"The configuration parameter `{self.export_names[0]}={export_values[0]}` is ignored during conversion."
                 f" If you intend to use it in Fast-LLM, make sure to set it explicitly in the model configuration."
             )
+        return ()
+
+    # def __repr__(self):
+    #    return f"IgnoreImportParamConverter(N.A. <--> {'.'.join(self.export_names[0])} ?= {self.ignore_export_value})"
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(kw_only=True)
 class MappedConfigParamConverter(ParamConverter):
-    fast_llm_value: typing.Callable
-    export_value: typing.Callable
+    fast_llm_value: typing.Callable = lambda x: x
+    export_value: typing.Callable = lambda x: x
 
-    def export_param(self, fast_llm_value):
-        return self.export_value(fast_llm_value)
+    def __post_init__(self):
+        Assert.eq(len(self.fast_llm_names), 1)
+        Assert.eq(len(self.export_names), 1)
 
-    def import_param(self, export_value):
-        return self.fast_llm_value(export_value)
+    def export_params(self, fast_llm_values):
+        return (self.export_value(fast_llm_values[0]),)
+
+    def import_params(self, export_values):
+        return (self.fast_llm_value(export_values[0]),)
+
+    # def __repr__(self):
+    #    return f"MappedConfigParamConverter({'.'.join(self.fast_llm_names[0])} <--> {'.'.join(self.export_names[0])})"
 
 
 class WeightConverter:
@@ -197,13 +249,16 @@ class ExternalStateDictCheckpointHandler(StateDictCheckpointHandler):
         # TODO v0.3: not used in this class
         exported_config = {}
         for converter in cls._get_config_converters():
-            value = converter.export_param(
-                None
-                if converter.fast_llm_name is None
-                else cls._get_fast_llm_attribute(config, converter.fast_llm_name)  # Noqa
-            )
-            if converter.export_name is not None:
-                set_nested_dict_value(exported_config, converter.export_name, value)
+            try:
+                values = [
+                    converter.export_params(cls._get_fast_llm_attribute(config, fast_llm_name))
+                    for fast_llm_name in converter.fast_llm_names
+                ]
+                for export_name, value in zip(converter.export_names, values, strict=True):
+                    if value is not MISSING:
+                        set_nested_dict_value(exported_config, export_name, value)
+            except Exception as e:
+                raise RuntimeError(f"Config conversion failed for converter {converter}", *e.args)
 
         return exported_config  # Noqa
 
@@ -214,12 +269,25 @@ class ExternalStateDictCheckpointHandler(StateDictCheckpointHandler):
         kwargs = {}
         for converter in cls._get_config_converters():
             try:
-                value = None if converter.export_name is None else get_nested_dict_value(config, converter.export_name)
-            except KeyError:
-                value = None
-            value = converter.import_param(value)
-            if converter.fast_llm_name is not None:
-                kwargs[converter.fast_llm_name] = value
+                values = ()
+                for export_name in converter.export_names:
+                    try:
+                        value = get_nested_dict_value(config, export_name)
+                    except KeyError:
+                        value = MISSING
+                    values = values + (value,)
+                values = converter.import_params(values)
+                for fast_llm_name, value in zip(converter.fast_llm_names, values, strict=True):
+                    if value is MISSING:
+                        # Missing values need to be handled in dedicated converters,
+                        # because implicit / default values may not match.
+                        # TODO: Different behavior from other uses of MISSING. Use different tag?
+                        raise ValueError(f"Missing converted value for fast-llm parameter {fast_llm_name}")
+                    if fast_llm_name in kwargs:
+                        raise ValueError(f"Duplicate converted value for fast-llm parameter {fast_llm_name}")
+                    kwargs[fast_llm_name] = value
+            except Exception as e:
+                raise RuntimeError(f"Config conversion failed for converter {converter}", *e.args)
 
         config_class = cls._model_class.get_base_model_config_class()
         if architecture_only:
@@ -335,7 +403,11 @@ class HuggingfaceStateDictCheckpointHandler(ExternalStateDictCheckpointHandler, 
     @classmethod
     @abc.abstractmethod
     def _create_config_converters(cls) -> list[ParamConverter]:
-        return [ConstantExportParamConverter(None, "model_type", cls.get_huggingface_model_type())]
+        return [
+            ConstantExportParamConverter(
+                export_names=(("model_type",),), export_value=cls.get_huggingface_model_type()
+            )
+        ]
 
     @classmethod
     def _load_config(cls, directory: pathlib.Path | str) -> dict:

--- a/fast_llm/engine/checkpoint/external.py
+++ b/fast_llm/engine/checkpoint/external.py
@@ -238,10 +238,12 @@ class ExternalStateDictCheckpointHandler(StateDictCheckpointHandler):
         exported_config = {}
         for converter in cls._get_config_converters():
             try:
-                values = [
-                    converter.export_params(cls._get_fast_llm_attribute(config, fast_llm_name))
-                    for fast_llm_name in converter.fast_llm_names
-                ]
+                values = converter.export_params(
+                    tuple(
+                        cls._get_fast_llm_attribute(config, fast_llm_name)
+                        for fast_llm_name in converter.fast_llm_names
+                    )
+                )
                 for export_name, value in zip(converter.export_names, values, strict=True):
                     if value is not MISSING:
                         set_nested_dict_value(exported_config, export_name, value)

--- a/fast_llm/layers/transformer/config.py
+++ b/fast_llm/layers/transformer/config.py
@@ -123,15 +123,6 @@ class RotaryArchitectureConfig(BaseModelArchitectureConfig):
         return self.enabled and not self.triton
 
     def _validate(self):
-        # These happen during conversion.
-        if self.scale_factor is None:
-            self.scale_factor = 8.0
-        if self.low_frequency_factor is None:
-            self.low_frequency_factor = 1.0
-        if self.high_frequency_factor is None:
-            self.high_frequency_factor = 4.0
-        if self.original_context_length is None:
-            self.original_context_length = 8192
         super()._validate()
         if self.triton and not TritonConfig.TRITON_ENABLED:
             warnings.warn("Triton is disabled, but the triton rotary kernel will be used anyway.")

--- a/fast_llm/models/gpt/conversion.py
+++ b/fast_llm/models/gpt/conversion.py
@@ -299,9 +299,9 @@ class RopeScalingParamConverter(ParamConverter):
     def export_params(self, fast_llm_values):
         rope_type, *parameters = fast_llm_values
         if rope_type == RotaryEmbeddingType.default:
-            return None
+            return (None,)
         elif rope_type == RotaryEmbeddingType.llama3:
-            return {key: value for key, value in zip(self._HUGGINGFACE_NAMES, ("llama3",) + parameters, strict=True)}
+            return ({key: value for key, value in zip(self._HUGGINGFACE_NAMES, ("llama3", *parameters), strict=True)},)
         else:
             raise ValueError(f"Unsupported rotary scaling type: {rope_type}")
 
@@ -311,7 +311,7 @@ class RopeScalingParamConverter(ParamConverter):
             return (RotaryEmbeddingType.default,) + (DEFAULT,) * 4
         elif rope_type == RotaryEmbeddingType.llama3:
             # TODO: Is it safe to assume all values are provided?
-            return {self._HUGGINGFACE_NAMES[0]: "llama3", **{export_value[key] for key in self._HUGGINGFACE_NAMES[1:]}}
+            return ("llama3", *[export_value[key] for key in self._HUGGINGFACE_NAMES[1:]])
         else:
             raise ValueError(f"Unsupported rotary scaling type: {rope_type}")
 

--- a/fast_llm/models/gpt/conversion.py
+++ b/fast_llm/models/gpt/conversion.py
@@ -1,8 +1,10 @@
 import abc
+import dataclasses
 import typing
 
 import torch
 
+from fast_llm.config import DEFAULT
 from fast_llm.engine.checkpoint.config import CheckpointFormat
 from fast_llm.engine.checkpoint.external import (
     AutoStateDictCheckpointHandler,
@@ -13,6 +15,7 @@ from fast_llm.engine.checkpoint.external import (
     IgnoreWeightConverter,
     MappedConfigParamConverter,
     ParamConverter,
+    RenameParamConverter,
     SplitWeightConverter,
     WeightConverter,
 )
@@ -31,6 +34,7 @@ from fast_llm.models.gpt.config import (
 )
 from fast_llm.models.gpt.model import GPTModel
 from fast_llm.tensor import SafeTensorSlice
+from fast_llm.utils import Assert
 
 if typing.TYPE_CHECKING:
     pass
@@ -112,21 +116,44 @@ class CommonHuggingfaceCheckpointHandler(HuggingfaceStateDictCheckpointHandler):
     @classmethod
     def _create_config_converters(cls) -> list[ParamConverter]:
         return super()._create_config_converters() + [
-            ConstantImportParamConverter(("use_position_embeddings",), None, False),
-            ParamConverter(("transformer", "rotary", "theta"), "rope_theta"),
-            MappedConfigParamConverter(
-                ("transformer", "activation_type"),
-                "hidden_act",
-                ActivationType.from_hf_name,
-                lambda activation_type: activation_type.hf_name,
+            ConstantImportParamConverter(fast_llm_names=(("use_position_embeddings",),), fast_llm_value=False),
+            RenameParamConverter(
+                fast_llm_names=(("transformer", "rotary", "theta"),), export_names=(("rope_theta",),)
             ),
-            ParamConverter(("transformer", "num_layers"), "num_hidden_layers"),
-            ParamConverter(("transformer", "hidden_size"), "hidden_size"),
-            ParamConverter(("transformer", "num_attention_heads"), "num_attention_heads"),
-            ParamConverter(("transformer", "head_groups"), "num_key_value_heads"),
-            ParamConverter(("transformer", "ffn_hidden_size"), "intermediate_size"),
-            ParamConverter(("vocab_size",), "vocab_size"),
-            ParamConverter(("tie_word_embeddings",), "tie_word_embeddings"),
+            MappedConfigParamConverter(
+                fast_llm_names=(("transformer", "activation_type"),),
+                export_names=(("hidden_act",),),
+                fast_llm_value=ActivationType.from_hf_name,
+                export_value=lambda activation_type: activation_type.hf_name,
+            ),
+            RenameParamConverter(
+                fast_llm_names=(("transformer", "num_layers"),),
+                export_names=(("num_hidden_layers",),),
+            ),
+            RenameParamConverter(
+                fast_llm_names=(("transformer", "hidden_size"),),
+                export_names=(("hidden_size",),),
+            ),
+            RenameParamConverter(
+                fast_llm_names=(("transformer", "num_attention_heads"),),
+                export_names=(("num_attention_heads",),),
+            ),
+            RenameParamConverter(
+                fast_llm_names=(("transformer", "head_groups"),),
+                export_names=(("num_key_value_heads",),),
+            ),
+            RenameParamConverter(
+                fast_llm_names=(("transformer", "ffn_hidden_size"),),
+                export_names=(("intermediate_size",),),
+            ),
+            RenameParamConverter(
+                fast_llm_names=(("vocab_size",),),
+                export_names=(("vocab_size",),),
+            ),
+            RenameParamConverter(
+                fast_llm_names=(("tie_word_embeddings",),),
+                export_names=(("tie_word_embeddings",),),
+            ),
         ]
 
     def _create_weight_converters(self) -> list[WeightConverter]:
@@ -214,12 +241,18 @@ class Starcoder2HuggingfaceCheckpointHandler(CommonHuggingfaceCheckpointHandler)
     @classmethod
     def _create_config_converters(cls) -> list[ParamConverter]:
         return super()._create_config_converters() + [
-            ConstantExportParamConverter(None, "architectures", ["Starcoder2ForCausalLM"]),
-            ConstantImportParamConverter(("transformer", "rotary", "type"), None, RotaryEmbeddingType.default),
-            ConstantImportParamConverter(("transformer", "normalization", "type"), None, NormalizationType.layer_norm),
-            ParamConverter(("transformer", "normalization", "epsilon"), "norm_epsilon"),
-            ConstantImportParamConverter(("transformer", "gated"), None, False),
-            ConstantImportParamConverter(("transformer", "add_linear_biases"), None, True),
+            ConstantExportParamConverter(export_names=(("architectures",),), export_value=["Starcoder2ForCausalLM"]),
+            ConstantImportParamConverter(
+                fast_llm_names=(("transformer", "rotary", "type"),), fast_llm_value=RotaryEmbeddingType.default
+            ),
+            ConstantImportParamConverter(
+                fast_llm_names=(("transformer", "normalization", "type"),), fast_llm_value=NormalizationType.layer_norm
+            ),
+            RenameParamConverter(
+                fast_llm_names=(("transformer", "normalization", "epsilon"),), export_names=(("norm_epsilon",),)
+            ),
+            ConstantImportParamConverter(fast_llm_names=(("transformer", "gated"),), fast_llm_value=False),
+            ConstantImportParamConverter(fast_llm_names=(("transformer", "add_linear_biases"),), fast_llm_value=True),
         ]
 
     def _get_mlp_converters(self, fast_llm_prefix: str, hf_prefix: str):
@@ -238,33 +271,49 @@ class CommonLlamaHuggingfaceCheckpointHandler(CommonHuggingfaceCheckpointHandler
     @classmethod
     def _create_config_converters(cls) -> list[ParamConverter]:
         return super()._create_config_converters() + [
-            ConstantImportParamConverter(("transformer", "normalization", "type"), None, NormalizationType.rms_norm),
-            ParamConverter(("transformer", "normalization", "epsilon"), "rms_norm_eps"),
-            ConstantImportParamConverter(("transformer", "gated"), None, True),
-            ConstantImportParamConverter(("transformer", "add_linear_biases"), None, False),
+            ConstantImportParamConverter(
+                fast_llm_names=(("transformer", "normalization", "type"),), fast_llm_value=NormalizationType.rms_norm
+            ),
+            RenameParamConverter(
+                fast_llm_names=(("transformer", "normalization", "epsilon"),), export_names=(("rms_norm_eps",),)
+            ),
+            ConstantImportParamConverter(fast_llm_names=(("transformer", "gated"),), fast_llm_value=True),
+            ConstantImportParamConverter(fast_llm_names=(("transformer", "add_linear_biases"),), fast_llm_value=False),
         ]
 
 
-def export_rotary_scaling_type(fast_llm_value: RotaryEmbeddingType):
-    match fast_llm_value:
-        case RotaryEmbeddingType.default:
-            return "default"
-        case RotaryEmbeddingType.llama3:
-            return "llama3"
-        case _:
-            raise ValueError(f"Unsupported rotary scaling type: {fast_llm_value}")
+@dataclasses.dataclass
+class RopeScalingParamConverter(ParamConverter):
+    _HUGGINGFACE_NAMES = (
+        "rope_type",
+        "factor",
+        "low_freq_factor",
+        "high_freq_factor",
+        "original_max_position_embeddings",
+    )
 
+    def __post_init__(self):
+        Assert.eq(len(self.fast_llm_names), 5)
+        Assert.eq(len(self.export_names), 1)
 
-def import_rotary_scaling_type(export_value):
-    if export_value is None:
-        return RotaryEmbeddingType.default
-    match export_value:
-        case "default":
-            return RotaryEmbeddingType.default
-        case "llama3":
-            return RotaryEmbeddingType.llama3
-        case _:
-            raise ValueError(f"Unsupported rotary scaling type: {export_value}")
+    def export_params(self, fast_llm_values):
+        rope_type, *parameters = fast_llm_values
+        if rope_type == RotaryEmbeddingType.default:
+            return None
+        elif rope_type == RotaryEmbeddingType.llama3:
+            return {key: value for key, value in zip(self._HUGGINGFACE_NAMES, ("llama3",) + parameters, strict=True)}
+        else:
+            raise ValueError(f"Unsupported rotary scaling type: {rope_type}")
+
+    def import_params(self, export_values):
+        (export_value,) = export_values
+        if export_value is None or (rope_type := export_value[self._HUGGINGFACE_NAMES[0]]) == "default":
+            return (RotaryEmbeddingType.default,) + (DEFAULT,) * 4
+        elif rope_type == RotaryEmbeddingType.llama3:
+            # TODO: Is it safe to assume all values are provided?
+            return {self._HUGGINGFACE_NAMES[0]: "llama3", **{export_value[key] for key in self._HUGGINGFACE_NAMES[1:]}}
+        else:
+            raise ValueError(f"Unsupported rotary scaling type: {rope_type}")
 
 
 class LlamaHuggingfaceCheckpointHandler(CommonLlamaHuggingfaceCheckpointHandler):
@@ -273,31 +322,19 @@ class LlamaHuggingfaceCheckpointHandler(CommonLlamaHuggingfaceCheckpointHandler)
     @classmethod
     def _create_config_converters(cls) -> list[ParamConverter]:
         return super()._create_config_converters() + [
-            ConstantExportParamConverter(None, "architectures", ["LlamaForCausalLM"]),
+            ConstantExportParamConverter(export_names=(("architectures",),), export_value=["LlamaForCausalLM"]),
             # TODO: Llama supports biases
-            ConstantExportParamConverter(None, "attention_bias", False),
-            ConstantExportParamConverter(None, "mlp_bias", False),
-            MappedConfigParamConverter(
-                ("transformer", "rotary", "type"),
-                ("rope_scaling", "rope_type"),
-                import_rotary_scaling_type,
-                export_rotary_scaling_type,
-            ),
-            ParamConverter(
-                ("transformer", "rotary", "scale_factor"),
-                ("rope_scaling", "factor"),
-            ),
-            ParamConverter(
-                ("transformer", "rotary", "low_frequency_factor"),
-                ("rope_scaling", "low_freq_factor"),
-            ),
-            ParamConverter(
-                ("transformer", "rotary", "high_frequency_factor"),
-                ("rope_scaling", "high_freq_factor"),
-            ),
-            ParamConverter(
-                ("transformer", "rotary", "original_context_length"),
-                ("rope_scaling", "original_max_position_embeddings"),
+            ConstantExportParamConverter(export_names=(("attention_bias",),), export_value=False),
+            ConstantExportParamConverter(export_names=(("mlp_bias",),), export_value=False),
+            RopeScalingParamConverter(
+                fast_llm_names=(
+                    ("transformer", "rotary", "type"),
+                    ("transformer", "rotary", "scale_factor"),
+                    ("transformer", "rotary", "low_frequency_factor"),
+                    ("transformer", "rotary", "high_frequency_factor"),
+                    ("transformer", "rotary", "original_context_length"),
+                ),
+                export_names=(("rope_scaling",),),
             ),
         ]
 
@@ -325,9 +362,11 @@ class MistralHuggingfaceCheckpointHandler(CommonLlamaHuggingfaceCheckpointHandle
     @classmethod
     def _create_config_converters(cls) -> list[ParamConverter]:
         return super()._create_config_converters() + [
-            ConstantExportParamConverter(None, "architectures", ["MistralForCausalLM"]),
-            ConstantImportParamConverter(("transformer", "rotary", "type"), None, RotaryEmbeddingType.default),
-            IgnoreImportParamConverter(None, "sliding_window", None),
+            ConstantExportParamConverter(export_names=(("architectures",),), export_value=["MistralForCausalLM"]),
+            ConstantImportParamConverter(
+                fast_llm_names=(("transformer", "rotary", "type"),), fast_llm_value=RotaryEmbeddingType.default
+            ),
+            IgnoreImportParamConverter(export_names=(("sliding_window",),), ignore_export_value=None),
         ]
 
     def _get_mlp_converters(self, fast_llm_prefix: str, hf_prefix: str):
@@ -350,12 +389,20 @@ class MixtralHuggingfaceCheckpointHandler(CommonLlamaHuggingfaceCheckpointHandle
     @classmethod
     def _create_config_converters(cls) -> list[ParamConverter]:
         return super()._create_config_converters() + [
-            ConstantExportParamConverter(None, "architectures", ["MixtralForCausalLM"]),
-            ConstantImportParamConverter(("transformer", "rotary", "type"), None, RotaryEmbeddingType.default),
-            ConstantImportParamConverter(("transformer", "expert_routing_type"), None, RoutingType.topk),
-            ParamConverter(("transformer", "num_experts"), "num_local_experts"),
-            ParamConverter(("transformer", "num_experts_per_token"), "num_experts_per_tok"),
-            IgnoreImportParamConverter(None, "sliding_window", None),
+            ConstantExportParamConverter(export_names=(("architectures",),), export_value=["MixtralForCausalLM"]),
+            ConstantImportParamConverter(
+                fast_llm_names=(("transformer", "rotary", "type"),), fast_llm_value=RotaryEmbeddingType.default
+            ),
+            ConstantImportParamConverter(
+                fast_llm_names=(("transformer", "expert_routing_type"),), fast_llm_value=RoutingType.topk
+            ),
+            RenameParamConverter(
+                fast_llm_names=(("transformer", "num_experts"),), export_names=(("num_local_experts",),)
+            ),
+            RenameParamConverter(
+                fast_llm_names=(("transformer", "num_experts_per_token"),), export_names=(("num_experts_per_tok",),)
+            ),
+            IgnoreImportParamConverter(export_names=(("sliding_window",),), ignore_export_value=None),
         ]
 
     def _get_mlp_converters(self, fast_llm_prefix: str, hf_prefix: str):

--- a/tests/test_match_megatron.py
+++ b/tests/test_match_megatron.py
@@ -3,8 +3,8 @@ import pytest
 from tests.common import (
     CONFIG_GPT2_FAST_LLM,
     CONFIG_GPT2_MEGATRON,
-    CONFIG_MISTRAL_FAST_LLM,
-    CONFIG_MISTRAL_MEGATRON,
+    CONFIG_LLAMA_FAST_LLM,
+    CONFIG_LLAMA_MEGATRON,
     CONFIG_MIXTRAL_FAST_LLM,
     CONFIG_MIXTRAL_MEGATRON,
     CONFIG_SC1_FAST_LLM,
@@ -100,7 +100,7 @@ def test_gpt2_match_meg():
 def test_mistral_meg():
     # Mistral with Megatron.
     # No linear bias, swiglu activation, RMSNorm
-    run_test_script("test_mistral_meg", CONFIG_MISTRAL_MEGATRON + ["--micro-batch-size=8"], is_megatron=True)
+    run_test_script("test_mistral_meg", CONFIG_LLAMA_MEGATRON + ["--micro-batch-size=8"], is_megatron=True)
 
 
 @pytest.mark.depends(on=["test_mistral_meg"])
@@ -108,7 +108,7 @@ def test_mistral_match_meg():
     # Mistral with Fast-LLM.
     run_test_script(
         "test_mistral_match_meg",
-        CONFIG_MISTRAL_FAST_LLM + ["model.base_model.use_megatron_initialization=True"],
+        CONFIG_LLAMA_FAST_LLM + ["model.base_model.use_megatron_initialization=True"],
         compare="test_mistral_meg",
         config=CompareConfig(
             ignore_tensors=[


### PR DESCRIPTION
# ✨ Description

Fixes: #93 

#55 added support for rope scaling, but requires the value to be a dict. However, the value can also be  `None`, in which case #55 broke conversion. 

This could not be solved in an easy, non-hacky way, because there is a variable set of entries on the HF side, which may depend on each other. I handled this by making a converter for the entire rope scaling dict on the HF side, but this has to be mapped to multiple values on the Fast-LLM side, which is also a problem. (Mapping to the whole `rotary` config dict wouldn't work because of rope theta.)

So the solution is to adapt parameter converters to take a variable number of parameters on each side. The rope scaling if the first use case for this, but I expect more in the future. Also it's the same thing we do for weight converters (and for exactly the same reason), so it's a natural next step. That makes converter definitions a bit more complicated since I had to enforce 2d arrays of tuples to make things less confusing and error-prone, but I think it's worth it in the long run.

Added the `DEFAULT` tag that gets replaced with the default value during config validation, so far it's used to avoid the ad-hoc None handling in rope config, but I'm sure it will have more uses elsewhere.

Added a plain llama model in the tests, it's the same as mistral but uses the llama converter.

Note that it will force some small changes in unmerged converters (only #5 and #84)


## 🔍 Type of change

Select all that apply:

- [x] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [x] 🚀 **New feature** (non-breaking change that adds functionality)
- [x] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [x] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)
