### PR TITLE
Speedup dataset blending

### DIFF
--- a/fast_llm/csrc/data.cpp
+++ b/fast_llm/csrc/data.cpp
@@ -38,69 +38,6 @@ namespace py = pybind11;
 using namespace std;
 
 
-void build_blending_indices(py::array_t<int16_t>& dataset_index,
-			    py::array_t<int64_t>& dataset_sample_index,
-			    const py::array_t<double>& weights,
-			    const int32_t num_datasets,
-			    const int64_t size, const bool verbose) {
-  /* Given multiple datasets and a weighting array, build samples
-   such that it follows those weights.*/
-
-  if (verbose) {
-    std::cout << "> building indices for blendable datasets ..." << std::endl;
-  }
-
-  // Get the pointer access without the checks.
-  auto dataset_index_ptr = dataset_index.mutable_unchecked<1>();
-  auto dataset_sample_index_ptr = dataset_sample_index.mutable_unchecked<1>();
-  auto weights_ptr = weights.unchecked<1>();
-
-  // Initialize buffer for number of samples used for each dataset.
-  int64_t current_samples[num_datasets];
-  for(int64_t i = 0; i < num_datasets; ++i) {
-    current_samples[i] = 0;
-  }
-
-  // For each sample:
-  for(int64_t sample_idx = 0; sample_idx < size; ++sample_idx) {
-
-    // Determine where the max error in sampling is happening.
-    auto sample_idx_double = std::max(static_cast<double>(sample_idx), 1.0);
-    int64_t max_error_index = 0;
-    double max_error = weights_ptr[0] * sample_idx_double -
-      static_cast<double>(current_samples[0]);
-    for (int64_t dataset_idx = 1; dataset_idx < num_datasets; ++dataset_idx) {
-      double error = weights_ptr[dataset_idx] * sample_idx_double -
-	static_cast<double>(current_samples[dataset_idx]);
-      if (error > max_error) {
-	max_error = error;
-	max_error_index = dataset_idx;
-      }
-    }
-
-    // Populate the indices.
-    dataset_index_ptr[sample_idx] = static_cast<int16_t>(max_error_index);
-    dataset_sample_index_ptr[sample_idx] = current_samples[max_error_index];
-
-    // Update the total samples.
-    current_samples[max_error_index] += 1;
-
-  }
-
-  // print info
-  if (verbose) {
-    std::cout << " > sample ratios:" << std::endl;
-    for (int64_t dataset_idx = 0; dataset_idx < num_datasets; ++dataset_idx) {
-      auto ratio = static_cast<double>(current_samples[dataset_idx]) /
-	static_cast<double>(size);
-      std::cout << "   dataset " << dataset_idx << ", input: " <<
-	weights_ptr[dataset_idx] << ", achieved: " << ratio << std::endl;
-    }
-  }
-
-}
-
-
 py::array build_sample_idx(const py::array_t<int32_t>& sizes_,
 			   const py::array_t<int32_t>& doc_idx_,
 			   const int32_t seq_length,
@@ -194,5 +131,4 @@ py::array build_sample_idx(const py::array_t<int32_t>& sizes_,
 
 PYBIND11_MODULE(data, m) {
     m.def("build_sample_idx", &build_sample_idx);
-    m.def("build_blending_indices", &build_blending_indices);
 }

--- a/fast_llm/data/dataset/blended.py
+++ b/fast_llm/data/dataset/blended.py
@@ -1,5 +1,4 @@
 import logging
-import pathlib
 import typing
 
 import numpy as np
@@ -7,13 +6,6 @@ import numpy as np
 from fast_llm.data.dataset.abstract import SampledDataset
 from fast_llm.data.dataset.config import SamplingConfig
 from fast_llm.utils import Assert, normalize_probabilities
-
-try:
-    from fast_llm.csrc.data import build_blending_indices  # noqa
-
-    _extension_available = True
-except ImportError:
-    _extension_available = False
 
 logger = logging.getLogger(__name__)
 
@@ -37,96 +29,45 @@ class BlendedDataset(SampledDataset):
         assert len(datasets) > 0
         Assert.eq(len(datasets), len(weights))
         self._datasets = datasets
-        self._weights = normalize_probabilities(weights)
+        self._weights = np.array(normalize_probabilities(weights))
         self._num_samples = sampling_config.num_samples
-
-        if sampling_config.cache_directory is None:
-            self._dataset_idx_filename, self._sample_idx_filename = None, None
-            self._dataset_index, self._sample_index = self._build_blending_indices()
-        else:
-            group = sampling_config.distributed.world_group
-            self._dataset_idx_filename = sampling_config.cache_directory / (self._name + "_blending_dataset_idx.npy")
-            self._sample_idx_filename = sampling_config.cache_directory / (self._name + "_blending_sample_idx.npy")
-
-            # Build the indexed mapping if it doesn't exist.
-            # TODO: This only works if the dataset location is accessible by all job.
-            if (group is None or group.rank() == 0) and not (
-                self._dataset_idx_filename.is_file() and self._sample_idx_filename.is_file()
-            ):
-                dataset_index, sample_index = self._build_blending_indices()
-                sampling_config.cache_directory.mkdir(exist_ok=True, parents=True)
-                np.save(self._dataset_idx_filename, dataset_index)
-                np.save(self._sample_idx_filename, sample_index)
-
-    def __getstate__(self) -> tuple[typing.Any, ...]:
-        return (
-            self._datasets,
-            self._name,
-            self._num_samples,
-            self._data_sample_warn_time_ms,
-            self._dataset_index if self._dataset_idx_filename is None else self._dataset_idx_filename,
-            self._sample_index if self._sample_idx_filename is None else self._sample_idx_filename,
-        )
-
-    def __setstate__(self, state: tuple[typing.Any, ...]):
-        (
-            self._datasets,
-            self._name,
-            self._num_samples,
-            self._data_sample_warn_time_ms,
-            dataset_index,
-            sample_index,
-        ) = state
-        if isinstance(dataset_index, pathlib.Path):
-            self._dataset_idx_filename, self._sample_idx_filename = dataset_index, sample_index
-        else:
-            self._dataset_idx_filename, self._sample_idx_filename = None, None
-            self._dataset_index, self._sample_index = dataset_index, sample_index
-
-    def _load_mappings(self) -> None:
-        if hasattr(self, "_dataset_index") and hasattr(self, "_sample_index"):
-            return
-        self._dataset_index = np.load(self._dataset_idx_filename, mmap_mode="r")
-        self._sample_index = np.load(self._sample_idx_filename, mmap_mode="r")
 
     def __len__(self) -> int:
         return self._num_samples
 
-    def _build_blending_indices(self) -> tuple[np.ndarray, np.ndarray]:
-        assert _extension_available, (
-            "The C++ extension for dataset blending is missing." " Please make sure Fast-LLM is installed correctly."
-        )
-        Assert.lt(len(self._datasets), 32767)
-        dataset_index = np.zeros(self._num_samples, dtype=np.int16)
-        dataset_sample_index = np.zeros(self._num_samples, dtype=np.int64)
-        build_blending_indices(
-            dataset_index,
-            dataset_sample_index,
-            self._weights,
-            len(self._datasets),
-            self._num_samples,
-            True,  # Verbose
-        )
-        available_samples_per_dataset = np.array([len(dataset) for dataset in self._datasets])
-        sampled_per_dataset = np.bincount(dataset_index)
-        # Oversampling is extremely unlikely but still possible.
-        if not (sampled_per_dataset <= available_samples_per_dataset[: len(sampled_per_dataset)]).all():
-            raise RuntimeError(
-                "Failed to build blending indices:"
-                + "".join(
-                    [
-                        f"\n  Dataset {i} {self._datasets[i].name} available {sampled}, "
-                        f"sampled {available_samples_per_dataset[i]}"
-                        for i, sampled in enumerate(sampled_per_dataset)
-                        if sampled > available_samples_per_dataset[i]
-                    ]
-                )
-            )
-        return dataset_index, dataset_sample_index
-
     def __getitem__(self, idx: int) -> typing.Any:
-        self._load_mappings()
-        return self._datasets[self._dataset_index[idx]][self._sample_index[idx].item()]
+        """
+        Blending is typically done in one of the following way (ex. in Megatron datasets):
+        ```python
+        dataset_index=np.zeros(num_samples)
+        sample_index=np.zeros(num_samples)
+        samples_per_dataset=np.zeros(len(weights))
+        for idx in range(num_samples):
+            error = weights * idx - samples_per_dataset
+            dataset_index_ = np.argmax(error)
+            dataset_index[idx] =dataset_index_
+            sample_index[idx] =samples_per_dataset[dataset_index_]
+            samples_per_dataset[dataset_index_] +=1
+        ```
+        Here we provide an implementation which allows computing values on the fly instead pre-computing them all.
+        """
+        # We have target sampling amount in floating point,
+        # and we want to find a set of integers as close as possible to this value.
+        # First, we determine the target prior to the present sample.
+        target = self._weights * idx
+        # Then we determine a lower bound for the number previous samples from each dataset by rounding down the target.
+        # This is indeed a lower bound because a lower value for one dataset would involve more sampling below,
+        # and it would be from that dataset because it would have the highest error,
+        # i.e., the dataset would have to be sampled again before `idx`.
+        sampled = np.floor(target).astype(int)
+        # Then we calculate the error between the target and lower bound, which we'll try to minimize below.
+        error = target - sampled
+        # Now we're ready to start sampling, and since we calculated a lower bound,
+        # we may need to sample a few more until we reach the current sample,
+        # each time by taking the dataset with the highest error (argmax).
+        # By construction each dataset will be sampled at most once, so
+        dataset_index = error.argsort(stable=True)[::-1][idx - sampled.sum()].item()
+        return self._datasets[dataset_index.item()][sampled[dataset_index].item()]
 
     @property
     def name(self):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -401,7 +401,7 @@ GPT_COMPOSED_EXPECTED_SAMPLES = [
 ]
 
 
-def test_gpt_compose():
+def test_gpt_concatenated_memmap():
     # Make sure dataset splitting works and check for unintended changes in behavior.
     _get_test_dataset_concatenated_memmap()
     # samples[9:18]
@@ -424,13 +424,13 @@ def test_gpt_compose():
     )
 
 
-def test_gpt_composed_data():
+def test_gpt_concatenated_memmap_data():
     _get_test_dataset_concatenated_memmap()
     _, samples = get_test_data_and_samples(
         {
             "datasets": {
                 "Training": {
-                    "type": "composed",
+                    "type": "concatenated_memmap",
                     "path": _DATASET_PREFIX_MIX_CONCATENATED_MEMMAP,
                 }
             }
@@ -442,18 +442,6 @@ def test_gpt_composed_data():
         np.stack(samples[PhaseType.training]),
         np.array(GPT_COMPOSED_EXPECTED_SAMPLES),
     )
-
-
-GPT_BLENDED_EXPECTED_SAMPLES = [
-    [1725, 74, 207, 1635, 4440, 2774],
-    [2066, 207, 6436, 2360, 2210, 6633],
-    [359, 489, 4266, 2052, 5351, 80],
-    [374, 7534, 87, 1073, 79, 480],
-    [8008, 498, 71, 727, 80, 315],
-    [555, 3042, 83, 207, 498, 3373],
-    [2210, 8179, 73, 2582, 897, 1178],
-    [409, 5091, 328, 1378, 5483, 88],
-]
 
 
 def _get_blending_alt(probs: list[float], num_samples: int) -> tuple[np.ndarray, np.ndarray]:
@@ -521,6 +509,18 @@ def test_blending(probs):
     Assert.all_equal(samples, samples_alt)
 
 
+GPT_BLENDED_EXPECTED_SAMPLES = [
+    [1725, 74, 207, 1635, 4440, 2774],
+    [359, 489, 4266, 2052, 5351, 80],
+    [2066, 207, 6436, 2360, 2210, 6633],
+    [374, 7534, 87, 1073, 79, 480],
+    [8008, 498, 71, 727, 80, 315],
+    [2210, 8179, 73, 2582, 897, 1178],
+    [555, 3042, 83, 207, 498, 3373],
+    [409, 5091, 328, 1378, 5483, 88],
+]
+
+
 def test_gpt_blended():
     # Make sure dataset blending works and check for unintended changes in behavior.
     get_test_dataset()
@@ -570,12 +570,12 @@ def test_gpt_blended_data():
 
 GPT_BLENDED_LEGACY_EXPECTED_SAMPLES = [
     [1725, 74, 207, 1635, 4440, 2774],
-    [328, 80, 263, 890, 1797, 88],
     [359, 489, 4266, 2052, 5351, 80],
+    [328, 80, 263, 890, 1797, 88],
     [374, 7534, 87, 1073, 79, 480],
     [8008, 498, 71, 727, 80, 315],
-    [1852, 71, 776, 7878, 7390, 80],
     [2210, 8179, 73, 2582, 897, 1178],
+    [1852, 71, 776, 7878, 7390, 80],
     [409, 5091, 328, 1378, 5483, 88],
 ]
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,3 +1,4 @@
+import math
 import pathlib
 import typing
 
@@ -23,7 +24,7 @@ from fast_llm.data.tokenizer import Tokenizer
 from fast_llm.engine.distributed.config import DistributedConfig, PhaseType
 from fast_llm.engine.distributed.distributed import Distributed
 from fast_llm.engine.schedule.config import BatchConfig
-from fast_llm.utils import Assert
+from fast_llm.utils import Assert, normalize_probabilities
 from tests.common import (
     DATASET_CACHE,
     DATASET_PREFIX,
@@ -453,6 +454,71 @@ GPT_BLENDED_EXPECTED_SAMPLES = [
     [2210, 8179, 73, 2582, 897, 1178],
     [409, 5091, 328, 1378, 5483, 88],
 ]
+
+
+def _get_blending_alt(probs: list[float], num_samples: int) -> tuple[np.ndarray, np.ndarray]:
+    probs = np.array(probs)
+    dataset_index = np.zeros(num_samples)
+    sample_index = np.zeros(num_samples)
+    sampled = np.zeros(len(probs))
+    for idx in range(num_samples):
+        error = probs * (idx + 1) - sampled
+        dataset_index_ = np.argmax(error)
+        dataset_index[idx] = dataset_index_
+        sample_index[idx] = sampled[dataset_index_]
+        sampled[dataset_index_] += 1
+    return dataset_index, sample_index
+
+
+@pytest.mark.parametrize(
+    "probs",
+    [
+        # Two datasets
+        [0.5, 0.5],
+        [0.6, 0.4],
+        [0.75, 0.25],
+        [0.2, 0.8],
+        # Irrational, not normalized.
+        [math.pi, 2],
+        # More datasets
+        [0.3, 0.4, 0.3],
+        [0.75, 0.05, 0.20],
+        [0.3, 0.2, 0.4, 0.1],
+        # Lots of datasets, not normalized.
+        (np.arange(200) % 7 + 0.2).tolist(),
+        # Useless but should still work.
+        [1],
+        [1, 0],
+        [0, 1],
+    ],
+)
+def test_blending(probs):
+    num_samples = 100
+    from fast_llm.data.dataset.blended import BlendedDataset
+
+    dataset = BlendedDataset(
+        "dataset",
+        # Use a list of integers as a mock dataset, encoding both indexes in the sample.
+        [list(range(i * num_samples, (i + 1) * num_samples)) for i, _ in enumerate(probs)],  # noqa
+        probs,
+        get_sampling_config(num_samples),
+    )
+    probs = normalize_probabilities(probs)
+    samples = np.array([dataset[i] for i in range(num_samples)])
+    dataset_index = samples // 100
+    sample_index = samples % 100
+    # Consistency checks, just in case the alt implementation is also wrong.
+    for i, p in enumerate(probs):
+        s = sample_index[dataset_index == i]
+        # Samples for each dataset should be a sequence of natural numbers.
+        Assert.all_equal(sorted(s), np.arange(len(s)))
+        # And close enough to the target.
+        Assert.leq(abs(len(s) - p * num_samples), 1)
+
+    # Compare to the alternate implementation.
+    dataset_index_alt, sample_index_alt = _get_blending_alt(probs, num_samples)
+    samples_alt = sample_index_alt + dataset_index_alt * num_samples
+    Assert.all_equal(samples, samples_alt)
 
 
 def test_gpt_blended():


### PR DESCRIPTION
# ✨ Description

Calculate blending indices on the fly. Creating a blended dataset is now instantaneous rather than taking up to several minutes or even hours. Also drops some of the legacy cpp code. Part of #132.

One minor downside, there is a slight difference in the sampling order compared to the previous implementation, because Megatron-LM uses `idx*weights` instead of `(idx+1)*weights` for the target, which is arguably wrong. I tried to reproduce the old behavior for legacy datasets but couldn't get to work so I gave up. Anyway, the difference is a tiny movement of samples which won't do much, and they'll usually stay on the same batch anyway.

## 🔍 Type of change

Select all that apply:

- [ ] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [ ] 🚀 **New feature** (non-breaking change that adds functionality)
- [x] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [x] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)
