### PR TITLE
map kv_channels to head_dim

### DIFF
--- a/fast_llm/models/gpt/conversion.py
+++ b/fast_llm/models/gpt/conversion.py
@@ -143,6 +143,10 @@ class CommonHuggingfaceCheckpointHandler(HuggingfaceStateDictCheckpointHandler):
                 export_names=(("intermediate_size",),),
             ),
             RenameParamConverter(
+                fast_llm_names=(("transformer", "kv_channels"),),
+                export_names=(("head_dim"),),
+            ),
+            RenameParamConverter(
                 fast_llm_names=(("vocab_size",),),
                 export_names=(("vocab_size",),),
             ),


### PR DESCRIPTION
# ✨ Description

Map `kv_channels` -> `head_dim` in the export configuration for huggingface checkpoints.

Closes https://github.com/ServiceNow/Fast-LLM/issues/102

## 🔍 Type of change

Select all that apply:

- [ ] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [ ] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)

### Testing

- [ ] 🧪 I have added or updated tests to cover my changes.
- [ ] ✔️ New and existing tests pass locally with my changes.
- [ ] 🚦 I have tested these changes on GPUs and verified training stability.
- [ ] 🏋️ I have tested the changes on realistic training workloads, if applicable.

Verified that:
- conversion of Slam-5.1B to HF format sets `head_dim=128` in `config.json`
- Fast-LLM is able to load the converted checkpoint as a pretrained model and correctly read `head_dim` into `kv_channels` even when `num_heads * head_dim != hidden_size`

