### PR TITLE
make `head_dim` common to llama models only

### DIFF
--- a/fast_llm/models/gpt/conversion.py
+++ b/fast_llm/models/gpt/conversion.py
@@ -143,10 +143,6 @@ class CommonHuggingfaceCheckpointHandler(HuggingfaceStateDictCheckpointHandler):
                 export_names=(("intermediate_size",),),
             ),
             RenameParamConverter(
-                fast_llm_names=(("transformer", "kv_channels"),),
-                export_names=(("head_dim"),),
-            ),
-            RenameParamConverter(
                 fast_llm_names=(("vocab_size",),),
                 export_names=(("vocab_size",),),
             ),
@@ -280,6 +276,10 @@ class CommonLlamaHuggingfaceCheckpointHandler(CommonHuggingfaceCheckpointHandler
             ),
             RenameParamConverter(
                 fast_llm_names=(("transformer", "normalization", "epsilon"),), export_names=(("rms_norm_eps",),)
+            ),
+            RenameParamConverter(
+                fast_llm_names=(("transformer", "kv_channels"),),
+                export_names=(("head_dim"),),
             ),
             ConstantImportParamConverter(fast_llm_names=(("transformer", "gated"),), fast_llm_value=True),
             ConstantImportParamConverter(fast_llm_names=(("transformer", "add_linear_biases"),), fast_llm_value=False),


### PR DESCRIPTION
# ✨ Description

Not all huggingface models have `head_dim`, e.g., StarCoder2. Making `head_dim` common only to Llama models for now

Related to https://github.com/ServiceNow/Fast-LLM/issues/102

## 🔍 Type of change

Select all that apply:

- [x] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [ ] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)


### Testing

- [ ] 🧪 I have added or updated tests to cover my changes.
- [x] ✔️ New and existing tests pass locally with my changes.
- [x] 🚦 I have tested these changes on GPUs and verified training stability.
- [x] 🏋️ I have tested the changes on realistic training workloads, if applicable.
