### PR TITLE
Support for max_window_layers

### DIFF
--- a/fast_llm/layers/transformer/config.py
+++ b/fast_llm/layers/transformer/config.py
@@ -577,4 +577,10 @@ class TransformerConfig(TransformerArchitectureConfig, BaseModelConfig):
                 Assert.geq(scale, 0)
 
     def do_use_flash_attention(self, distributed_config: DistributedConfig) -> bool:
-        return self.use_flash_attention and distributed_config.training_dtype in (DataType.float16, DataType.bfloat16)
+        use_flash_attention =  self.use_flash_attention and distributed_config.training_dtype in (DataType.float16, DataType.bfloat16)
+        
+        # Config parameter `window_size` only can be used with flash attention
+        if not use_flash_attention:
+            Assert.is_(self.window_size, None)
+
+        return use_flash_attention

--- a/fast_llm/layers/transformer/config.py
+++ b/fast_llm/layers/transformer/config.py
@@ -443,6 +443,12 @@ class TransformerConfig(TransformerArchitectureConfig, BaseModelConfig):
         hint=FieldHint.feature,
         valid=skip_valid_if_none(check_field(Assert.geq, 0)),
     )
+    max_window_layers: int | None = Field(
+        default=None,
+        desc="The number of layers that use SWA (Sliding Window Attention). The bottom layers use SWA while the top use full attention.",
+        hint=FieldHint.optional,
+        valid=skip_valid_if_none(check_field(Assert.geq, 0)),
+    )
     # normalization_implementation: NormalizationImplementation = NormalizationImplementation.auto
     mlp_recompute_level: MLPRecomputeLevel = Field(
         default=MLPRecomputeLevel.none,

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -1,0 +1,22 @@
+import unittest.mock
+from fast_llm.layers.transformer.attention import Attention
+from fast_llm.layers.transformer.config import TransformerConfig
+
+
+def test_decide_window_size():
+    attention = unittest.mock.Mock(spec=Attention)
+    attention._decide_window_size = Attention._decide_window_size.__get__(attention)  # Attach real method
+
+    # Arrange - Case 1: window_size is returned (layer_index >= max_window_layers)
+    attention._config = TransformerConfig(window_size=512, max_window_layers=2)
+    attention._layer_index = 2
+    assert attention._decide_window_size() == 512
+
+    # Arrange - Case 2: window_size is None (layer_index < max_window_layers)
+    attention._config = TransformerConfig(window_size=512, max_window_layers=2)
+    attention._layer_index = 1
+    assert attention._decide_window_size() is None
+
+    # Arrange - Case 3: max_window_layers is None (always return window_size)
+    attention._config = TransformerConfig(window_size=512, max_window_layers=None)
+    assert attention._decide_window_size() == 512

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,14 @@
 import pathlib
+import pytest
 import subprocess
-
+import unittest.mock
 import yaml
+
+
+from fast_llm.layers.transformer.config import TransformerConfig
+from fast_llm.utils import Assert
+from fast_llm.engine.distributed.config import DistributedConfig
+from fast_llm.engine.config_utils.data_type import DataType
 
 from fast_llm.models.auto import trainer_registry
 
@@ -51,3 +58,29 @@ def test_validate_example_config():
         (pathlib.Path(__file__).parents[1] / "examples" / "mistral.yaml").read_text()
     )
     trainer_registry["gpt"].from_dict(fast_llm_config_dict)
+
+
+def test_do_use_flash_attention():
+    # Create a mock DistributedConfig
+    mock_distributed_config = unittest.mock.Mock(spec=DistributedConfig)
+
+    # Test case 1: use_flash_attention is True and training_dtype is float16
+    config = TransformerConfig(use_flash_attention=True, window_size=None)
+    mock_distributed_config.training_dtype = DataType.float16
+    assert config.do_use_flash_attention(mock_distributed_config) is True
+
+    # Test case 2: use_flash_attention is False
+    config = TransformerConfig(use_flash_attention=False, window_size=None)
+    mock_distributed_config.training_dtype = DataType.float16
+    assert config.do_use_flash_attention(mock_distributed_config) is False
+
+    # Test case 3: use_flash_attention is True but training_dtype is not float16 or bfloat16
+    config = TransformerConfig(use_flash_attention=True, window_size=None)
+    mock_distributed_config.training_dtype = DataType.float32
+    assert config.do_use_flash_attention(mock_distributed_config) is False
+
+    # Test case 4: use_flash_attention is False and window_size is not None
+    config = TransformerConfig(use_flash_attention=False, window_size=512)
+    mock_distributed_config.training_dtype = DataType.float32
+    with pytest.raises(AssertionError):
+        config.do_use_flash_attention(mock_distributed_config)


### PR DESCRIPTION
# ✨ Description

Closes #147
Also, added assert for `window_size` usage for non flash attention

## 🔍 Type of change

Select all that apply:

- [x] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [x] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)

## 📝 Changes

List the key changes introduced in this PR:

1. Adds support for `max_window_layers` a threshold on which layers to use sliding window attention
2. Added assert for `window_size` usage for non flash attention

## ✅ Checklist

Make sure the following tasks are completed before submitting the PR:

### General

- [x] 📜 I have read and followed the [contributing guidelines](https://servicenow.github.io/Fast-LLM/developers/contributing).
- [x] 🏷️ I am using a clear and descriptive PR title that summarizes the key change or feature introduced.
- [x] 🎉 The functionality is complete, and I have tested the changes. **(tested only new test cases)**
- [ ] 📝 I have updated the documentation if needed. **(not applicable)**
- [x] ⚠️ The change does not introduce any new issues (e.g., runtime warnings, type checker errors, linting problems, unhandled edge cases).
- [x] 🧩 I have commented my code, especially in hard-to-understand areas.

### Testing

- [x] 🧪 I have added or updated tests to cover my changes.
- [x] ✔️ New and existing tests pass locally with my changes. **(tested only new test cases)**
- [ ] 🚦 I have tested these changes on GPUs and verified training stability. **(not applicable)**
- [ ] 🏋️ I have tested the changes on realistic training workloads, if applicable. **(not applicable)**
