### PR TITLE
Extend add_linear_biases to support a dictionary of sub-layers to which linear bias should be added.

### DIFF
--- a/fast_llm/layers/transformer/mixture_of_experts.py
+++ b/fast_llm/layers/transformer/mixture_of_experts.py
@@ -40,11 +40,11 @@ class MixtureOfExpertMLP(MLPBase):
 
     _group: ProcessGroup
 
-    def __init__(self, config: TransformerConfig, tensor_space: TensorSpace, name: str = "mlp"):
+    def __init__(self, config: TransformerConfig, tensor_space: TensorSpace, layer_index: int, name: str = "mlp"):
         Assert.gt(config.num_experts, 1)
         # TODO: Implement?
         assert not config.add_linear_biases, "Biases not supported for MoE."
-        super().__init__(config, tensor_space, name)
+        super().__init__(config, tensor_space, layer_index, name)
         self._config = config
         self._tensor_space = tensor_space
         self._debug_mode = self._config.debug_transformer or self._config.debug_transformer_memory

--- a/fast_llm/layers/transformer/transformer.py
+++ b/fast_llm/layers/transformer/transformer.py
@@ -43,7 +43,7 @@ class TransformerLayer(Layer):
         self.self_attn = Attention(self._config, self._tensor_space, layer_index)
 
         self.mlp = (MixtureOfExpertMLP if self._config.num_experts > 1 else MLP)(
-            self._config, self._tensor_space, f"{self.name} mlp"
+            self._config, self._tensor_space, self._layer_index, f"{self.name} mlp"
         )
 
     @torch.compile

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -1,6 +1,8 @@
 import unittest.mock
 from fast_llm.layers.transformer.attention import Attention
 from fast_llm.layers.transformer.config import TransformerConfig
+from fast_llm.engine.distributed.config import DistributedConfig
+from fast_llm.engine.config_utils.tensor_space import TensorSpace
 
 
 def test_decide_window_size():
@@ -20,3 +22,17 @@ def test_decide_window_size():
     # Arrange - Case 3: max_window_layers is None (always return window_size)
     attention._config = TransformerConfig(window_size=512, max_window_layers=None)
     assert attention._decide_window_size() == 512
+
+
+def test_attention_constructor():
+    transformer_conf = TransformerConfig(
+        num_layers=2, 
+        num_attention_heads=2,
+        hidden_size=16,
+    )
+    distributed_config = DistributedConfig()
+    tensor_space = TensorSpace(distributed_config=distributed_config)
+    transformer_conf.setup_tensor_space(tensor_space)
+
+    Attention(transformer_conf, tensor_space, 1)
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,11 @@ import unittest.mock
 import yaml
 
 
-from fast_llm.layers.transformer.config import TransformerConfig
+from fast_llm.layers.transformer.config import (
+    TransformerConfig,
+    TransformerArchitectureConfig,
+    TransformerSubLayerKeys,
+)
 from fast_llm.utils import Assert
 from fast_llm.engine.distributed.config import DistributedConfig
 from fast_llm.engine.config_utils.data_type import DataType
@@ -84,3 +88,96 @@ def test_do_use_flash_attention():
     mock_distributed_config.training_dtype = DataType.float32
     with pytest.raises(AssertionError):
         config.do_use_flash_attention(mock_distributed_config)
+
+
+@pytest.fixture
+def config_with_true_biases():
+    """Fixture for TransformerArchitectureConfig with True add_linear_biases."""
+    return TransformerArchitectureConfig(add_linear_biases=True)
+
+
+@pytest.fixture
+def config_with_false_biases():
+    """Fixture for TransformerArchitectureConfig with False add_linear_biases."""
+    return TransformerArchitectureConfig(add_linear_biases=False)
+
+
+@pytest.fixture
+def config_with_dict_biases():
+    """Fixture for TransformerArchitectureConfig with dict add_linear_biases."""
+    return TransformerArchitectureConfig(
+        num_layers = 10, 
+        add_linear_biases={
+            "layers.self_attn.query": "*",
+            "layers.mlp.layer_1": "1:10:3, 9",
+            "layers.mlp.layer_2": "5:7",
+        }
+    )
+
+
+def test_add_linear_biases_bool_true(config_with_true_biases):
+    """Test case for add_linear_biases set to True (default)."""
+    assert config_with_true_biases._parsed_add_linear_biases == True
+
+
+def test_add_linear_biases_bool_false(config_with_false_biases):
+    """Test case for add_linear_biases set to False."""
+    assert config_with_false_biases._parsed_add_linear_biases == False
+
+
+def test_add_linear_biases_dict_valid(config_with_dict_biases):
+    """Test case for add_linear_biases with valid dictionary."""
+    assert config_with_dict_biases._parsed_add_linear_biases == {
+        TransformerSubLayerKeys.attn_query: {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+        TransformerSubLayerKeys.mlp_layer1: {2, 5, 8, 10},
+        TransformerSubLayerKeys.mlp_layer2: {6, 7},
+    }
+
+
+def test_invalid_key_in_dict():
+    """Test case where an invalid key is provided in add_linear_biases dictionary."""
+    with pytest.raises(AssertionError):
+        # Using an invalid key in the dictionary.
+        TransformerArchitectureConfig(add_linear_biases={"invalid_key": "*"})
+
+
+def test_invalid_range_format():
+    """Test case where invalid range format is provided."""
+    with pytest.raises(AssertionError):
+        TransformerArchitectureConfig(add_linear_biases={TransformerSubLayerKeys.mlp_layer1: "1:10:3, abc"})
+
+
+def test_empty_add_linear_biases():
+    """Test case for empty add_linear_biases dictionary."""
+    with pytest.raises(AssertionError):  # Expecting AssertionError for invalid empty dictionary
+        TransformerArchitectureConfig(add_linear_biases={})
+
+
+def test_should_add_linear_bias_for_layer_and_sublayer(config_with_dict_biases):
+    """Test case for should_add_linear_bias based on layer index and sublayer key."""
+
+    # Layer 1 and sublayer mlp_layer1
+    assert config_with_dict_biases.should_add_linear_bias(1, TransformerSubLayerKeys.mlp_layer1) == False
+
+    # Layer 2 and sublayer mlp_layer1
+    assert config_with_dict_biases.should_add_linear_bias(2, TransformerSubLayerKeys.mlp_layer1) == True
+
+    # Layer 9 and sublayer mlp_layer1
+    assert config_with_dict_biases.should_add_linear_bias(9, TransformerSubLayerKeys.mlp_layer1) == False
+
+    # Layer 6 and sublayer mlp_layer2
+    assert config_with_dict_biases.should_add_linear_bias(6, TransformerSubLayerKeys.mlp_layer2) == True
+
+    # Layer 5 and sublayer attn_query
+    assert config_with_dict_biases.should_add_linear_bias(5, TransformerSubLayerKeys.attn_query) == True
+
+
+def test_should_add_linear_bias_for_bool_true(config_with_true_biases):
+    """Test case for add_linear_biases set to True (should always return True)."""
+    assert config_with_true_biases.should_add_linear_bias(10, TransformerSubLayerKeys.mlp_layer1) == True
+
+
+def test_should_add_linear_bias_for_bool_false(config_with_false_biases):
+    """Test case for add_linear_biases set to False (should always return False)."""
+    assert config_with_false_biases.should_add_linear_bias(10, TransformerSubLayerKeys.mlp_layer1) == False
+

--- a/tests/test_mlp.py
+++ b/tests/test_mlp.py
@@ -1,0 +1,33 @@
+from fast_llm.layers.transformer.mlp import MLP
+from fast_llm.layers.transformer.mixture_of_experts import MixtureOfExpertMLP
+from fast_llm.layers.transformer.config import TransformerConfig
+from fast_llm.engine.distributed.config import DistributedConfig
+from fast_llm.engine.config_utils.tensor_space import TensorSpace
+
+
+def test_mlp_constructor():
+    transformer_conf = TransformerConfig(
+        num_layers=2,
+        num_attention_heads=2,
+        hidden_size=16,
+    )
+    distributed_config = DistributedConfig()
+    tensor_space = TensorSpace(distributed_config=distributed_config)
+    transformer_conf.setup_tensor_space(tensor_space)
+
+    MLP(transformer_conf, tensor_space, 1, "name")
+
+
+def test_moe_mlp_constructor():
+    transformer_conf = TransformerConfig(
+        num_layers=2,
+        num_attention_heads=2,
+        hidden_size=16,
+        num_experts=2,
+        add_linear_biases=False
+    )
+    distributed_config = DistributedConfig()
+    tensor_space = TensorSpace(distributed_config=distributed_config)
+    transformer_conf.setup_tensor_space(tensor_space)
+
+    MixtureOfExpertMLP(transformer_conf, tensor_space, 1, "name")


### PR DESCRIPTION
# ✨ Description

A possibility to specify the addition of linear biases per layer and `attention` and `mlp` sub-layers in the form of a dictionary, with sub-layer keys and their presence in layers, like this:
```yaml
 add_linear_biases: 
     "layers.self_attn.query": "*"
     "layers.mlp.layer_1": "1:10:3, 9"
     "layers.mlp.layer_2": "5:7"
```

## 🔍 Type of change

Select all that apply:

- [ ] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [x] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)

## 📝 Changes

List the key changes introduced in this PR:

1. Adds support for `add_linear_biases` as dict


## ✅ Checklist

Make sure the following tasks are completed before submitting the PR:

### General

- [x] 📜 I have read and followed the [contributing guidelines](https://servicenow.github.io/Fast-LLM/developers/contributing).
- [x] 🏷️ I am using a clear and descriptive PR title that summarizes the key change or feature introduced.
- [x] 🎉 The functionality is complete, and I have tested the changes. **(tested only new test cases)**
- [ ] 📝 I have updated the documentation if needed. **(not applicable)**
- [x] ⚠️ The change does not introduce any new issues (e.g., runtime warnings, type checker errors, linting problems, unhandled edge cases).
- [x] 🧩 I have commented my code, especially in hard-to-understand areas.

### Testing

- [x] 🧪 I have added or updated tests to cover my changes.
- [x] ✔️ New and existing tests pass locally with my changes. **(tested only new test cases)**
- [ ] 🚦 I have tested these changes on GPUs and verified training stability. **(not applicable)**
- [ ] 🏋️ I have tested the changes on realistic training workloads, if applicable. **(not applicable)**
