### PR TITLE
add rope-scaling to mixtral and mistral converter

### DIFF
--- a/fast_llm/models/gpt/conversion.py
+++ b/fast_llm/models/gpt/conversion.py
@@ -283,6 +283,19 @@ class CommonLlamaHuggingfaceCheckpointHandler(CommonHuggingfaceCheckpointHandler
             ),
             ConstantImportParamConverter(fast_llm_names=(("transformer", "gated"),), fast_llm_value=True),
             ConstantImportParamConverter(fast_llm_names=(("transformer", "add_linear_biases"),), fast_llm_value=False),
+            RopeScalingParamConverter(
+                fast_llm_names=(
+                    ("transformer", "rotary", "type"),
+                    ("transformer", "rotary", "scale_factor"),
+                    ("transformer", "rotary", "low_frequency_factor"),
+                    ("transformer", "rotary", "high_frequency_factor"),
+                    ("transformer", "rotary", "original_context_length"),
+                    ("transformer", "rotary", "attention_factor"),
+                    ("transformer", "rotary", "beta_fast"),
+                    ("transformer", "rotary", "beta_slow"),
+                ),
+                export_names=(("rope_scaling",),),
+            ),
         ]
 
 
@@ -336,19 +349,6 @@ class LlamaHuggingfaceCheckpointHandler(CommonLlamaHuggingfaceCheckpointHandler)
             # TODO: Llama supports biases
             ConstantExportParamConverter(export_names=(("attention_bias",),), export_value=False),
             ConstantExportParamConverter(export_names=(("mlp_bias",),), export_value=False),
-            RopeScalingParamConverter(
-                fast_llm_names=(
-                    ("transformer", "rotary", "type"),
-                    ("transformer", "rotary", "scale_factor"),
-                    ("transformer", "rotary", "low_frequency_factor"),
-                    ("transformer", "rotary", "high_frequency_factor"),
-                    ("transformer", "rotary", "original_context_length"),
-                    ("transformer", "rotary", "attention_factor"),
-                    ("transformer", "rotary", "beta_fast"),
-                    ("transformer", "rotary", "beta_slow"),
-                ),
-                export_names=(("rope_scaling",),),
-            ),
         ]
 
     def _get_mlp_converters(self, fast_llm_prefix: str, hf_prefix: str) -> list[WeightConverter]:
@@ -376,9 +376,6 @@ class MistralHuggingfaceCheckpointHandler(CommonLlamaHuggingfaceCheckpointHandle
     def _create_config_converters(cls) -> list[ParamConverter]:
         return super()._create_config_converters() + [
             ConstantExportParamConverter(export_names=(("architectures",),), export_value=["MistralForCausalLM"]),
-            ConstantImportParamConverter(
-                fast_llm_names=(("transformer", "rotary", "type"),), fast_llm_value=RotaryEmbeddingType.default
-            ),
             IgnoreImportParamConverter(export_names=(("sliding_window",),), ignore_export_value=None),
         ]
 
@@ -403,9 +400,6 @@ class MixtralHuggingfaceCheckpointHandler(CommonLlamaHuggingfaceCheckpointHandle
     def _create_config_converters(cls) -> list[ParamConverter]:
         return super()._create_config_converters() + [
             ConstantExportParamConverter(export_names=(("architectures",),), export_value=["MixtralForCausalLM"]),
-            ConstantImportParamConverter(
-                fast_llm_names=(("transformer", "rotary", "type"),), fast_llm_value=RotaryEmbeddingType.default
-            ),
             ConstantImportParamConverter(
                 fast_llm_names=(("transformer", "expert_routing_type"),), fast_llm_value=RoutingType.topk
             ),

--- a/tests/common.py
+++ b/tests/common.py
@@ -155,6 +155,14 @@ CONFIG_LLAMA3_FAST_LLM = CONFIG_LLAMA_FAST_LLM + [
 ]
 CONFIG_LLAMA3_COMMON = CONFIG_LLAMA3_FAST_LLM + ["model.distributed.training_dtype=bf16"]
 
+# Yarn-style Rotary Embeddings
+CONFIG_LLAMA_YARN_MEGATRON = None
+CONFIG_LLAMA_YARN_FAST_LLM = CONFIG_LLAMA_FAST_LLM + [
+    "model.base_model.transformer.rotary.type=yarn",
+]
+CONFIG_LLAMA_YARN_COMMON = CONFIG_LLAMA_YARN_FAST_LLM + ["model.distributed.training_dtype=bf16"]
+
+
 CONFIG_MIXTRAL_MEGATRON = CONFIG_LLAMA_MEGATRON + [
     "--num-experts=4",
     "--moe-router-topk=4",
@@ -164,6 +172,11 @@ CONFIG_MIXTRAL_FAST_LLM = CONFIG_LLAMA_FAST_LLM + [
     "model.base_model.transformer.num_experts_per_token=4",
 ]
 CONFIG_MIXTRAL_COMMON = CONFIG_MIXTRAL_FAST_LLM + ["model.distributed.training_dtype=bf16"]
+CONFIG_MIXTRAL_YARN_MEGATRON = None
+CONFIG_MIXTRAL_YARN_FAST_LLM = CONFIG_MIXTRAL_FAST_LLM + [
+    "model.base_model.transformer.rotary.type=yarn",
+]
+CONFIG_MIXTRAL_YARN_COMMON = CONFIG_MIXTRAL_YARN_FAST_LLM + ["model.distributed.training_dtype=bf16"]
 
 _CONFIGS = {
     "gpt2": ("gpt", CONFIG_GPT2_FAST_LLM, CONFIG_GPT2_MEGATRON, CONFIG_GPT2_COMMON, None),
@@ -189,6 +202,13 @@ _CONFIGS = {
         CONFIG_LLAMA3_COMMON,
         LlamaGPTHuggingfaceCheckpointFormat,
     ),
+    "llama-yarn": (
+        "gpt",
+        CONFIG_LLAMA_YARN_FAST_LLM,
+        CONFIG_LLAMA_YARN_MEGATRON,
+        CONFIG_LLAMA_YARN_COMMON,
+        LlamaGPTHuggingfaceCheckpointFormat,
+    ),
     "mistral": (
         "gpt",
         CONFIG_LLAMA_FAST_LLM,
@@ -201,6 +221,13 @@ _CONFIGS = {
         CONFIG_MIXTRAL_FAST_LLM,
         CONFIG_MIXTRAL_MEGATRON,
         CONFIG_MIXTRAL_COMMON,
+        MixtralGPTHuggingfaceCheckpointFormat,
+    ),
+    "mixtral-yarn": (
+        "gpt",
+        CONFIG_MIXTRAL_YARN_FAST_LLM,
+        CONFIG_MIXTRAL_YARN_MEGATRON,
+        CONFIG_MIXTRAL_YARN_COMMON,
         MixtralGPTHuggingfaceCheckpointFormat,
     ),
 }


### PR DESCRIPTION
# ✨ Description

Add support for rope-scaling in Mixtral and Mistral converters, to enable BTX experiments @oleksost 

`rope_scaling` is not directly present in `MistralConfig`, but `modeling_mistral.py` loads rotary the same way as Llama, so in practice this works.

## 🔍 Type of change

Select all that apply:

- [ ] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [x] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)
