### PR TITLE
[feat] Track entropy and MI of routing distribution for topk MoE

### DIFF
--- a/fast_llm/layers/transformer/config.py
+++ b/fast_llm/layers/transformer/config.py
@@ -74,6 +74,8 @@ class TransformerKwargs:
 class TransformerLossNames:
     load_balancing_loss = "load_balancing_loss"
     router_z_loss = "router_z_loss"
+    router_entropy = "router_entropy"
+    router_mutual_info = "router_mutual_info"
 
 
 class RotaryEmbeddingType(str, enum.Enum):

--- a/fast_llm/layers/transformer/mixture_of_experts.py
+++ b/fast_llm/layers/transformer/mixture_of_experts.py
@@ -25,6 +25,30 @@ from fast_llm.utils import Assert
 
 logger = logging.getLogger(__name__)
 
+def calculate_normalized_average_entropy(probs: torch.Tensor) -> torch.Tensor:
+    '''
+    Calculates routing entropy for each token, then averages over all tokens.
+    If low, means a lot of mass is put on a single expert, which can indicate collapse.
+    '''
+    n_experts = probs.size(-1)
+    entropy_values = entropy(probs)
+    average_entropy = entropy_values.mean()  # Average over batch and tokens
+    return average_entropy / torch.log(torch.tensor(n_experts, dtype=probs.dtype))
+
+def entropy(probs: torch.Tensor) -> torch.Tensor:
+    probs = torch.clamp(probs, min=1e-9)  # Avoid log(0)
+    return -torch.sum(probs * torch.log(probs), dim=-1)
+
+def calculate_mutual_information(probs: torch.Tensor) -> torch.Tensor:
+    '''
+    Calculates the difference between the entropy of the average routing and 
+    the average routing entropy. If low, means that routing is not informative.
+    '''
+    average_routing = torch.mean(probs, dim=1)  # Average over tokens
+    entropy_avg_routing = entropy(average_routing).mean()  # H[E[X]], mean over batch
+    entropy_routing = entropy(probs).mean()  # E[H[X]]
+    
+    return (entropy_avg_routing - entropy_routing) / torch.log(torch.tensor(probs.size(-1), dtype=probs.dtype))  # Normalize
 
 class MixtureOfExpertMLP(MLPBase):
     """
@@ -111,6 +135,7 @@ class MixtureOfExpertMLP(MLPBase):
         else:
             raise NotImplementedError(self._routing_type)
 
+
         if self._debug_mode:
             # To log all ranks set `global_=False`
             self._debug_log(scores, "Router scores", TransformerDimNames.top_experts, kwargs)
@@ -174,6 +199,20 @@ class MixtureOfExpertMLP(MLPBase):
         scores = torch.softmax(top_logits, dim=-1, dtype=torch.float32)
         if losses is not None or (self.training and grad_scale is not None):
             probs = torch.softmax(logits, dim=-1, dtype=torch.float32)
+
+            # Calculate and log entropy and mutual information
+            entropy = calculate_normalized_average_entropy(probs)
+            mutual_info = calculate_mutual_information(probs)
+            
+            # Store these metrics
+            if "router_entropy" not in losses:
+                losses["router_entropy"] = []
+            if "router_mutual_info" not in losses:
+                losses["router_mutual_info"] = []
+                
+            losses["router_entropy"].append(entropy.detach())
+            losses["router_mutual_info"].append(mutual_info.detach())
+
             mask = torch.nn.functional.one_hot(top_experts, num_classes=self._num_unshared_experts).sum(dim=1)
             # Auxiliary loss, corresponding to the sum of probabilities for the top experts.
             # In the optimal case (uniform distribution), loss = experts_per_token / num_experts.

--- a/fast_llm/models/gpt/model.py
+++ b/fast_llm/models/gpt/model.py
@@ -308,6 +308,22 @@ class GPTBaseModel[ConfigType: GPTBaseModelConfig](BaseModel[ConfigType]):
                         count=self._config.transformer.num_layers,
                     )
                 )
+            # Add new metrics
+            loss_defs.append(
+                LossDef(
+                    name="router_entropy",
+                    formatted_name="router entropy",
+                    count=self._config.transformer.num_layers,
+                )
+            )
+            loss_defs.append(
+                LossDef(
+                    name="router_mutual_info",
+                    formatted_name="router mutual info",
+                    count=self._config.transformer.num_layers,
+                )
+            )
+            
         if self._config.logit_z_loss:
             LossDef(name=LanguageModelLossNames.z_loss, formatted_name="logit z loss", count=1)
         return loss_defs

--- a/tests/test_routing_metrics.py
+++ b/tests/test_routing_metrics.py
@@ -1,0 +1,161 @@
+import torch
+import pytest
+from fast_llm.layers.transformer.mixture_of_experts import (
+    calculate_normalized_average_entropy,
+    calculate_mutual_information,
+    entropy
+)
+
+def test_diversity_entropy():
+    '''
+    collapse routing would have low entropy and low mutual information
+    '''
+
+    batch_size = 2
+    seq_len = 3
+    n_experts = 4
+    collapased_probs = torch.tensor([
+        # Batch 1
+        [
+            [0.99, 0.01, 0.0, 0.0],
+            [0.99, 0.01, 0.0, 0.0],
+            [0.99, 0.01, 0.0, 0.0], 
+        ],
+        # Batch 2
+        [
+            [0.99, 0.01, 0.0, 0.0],  
+            [0.99, 0.01, 0.0, 0.0], 
+            [0.99, 0.01, 0.0, 0.0], 
+        ]
+    ])
+    norm_entropy = calculate_normalized_average_entropy(collapased_probs)
+    mutual_info = calculate_mutual_information(collapased_probs)
+    assert torch.isclose(norm_entropy, torch.tensor(0.0), atol=1e-1), f"Expected 0.0, got {norm_entropy}"
+    assert torch.isclose(mutual_info, torch.tensor(0.0), atol=1e-5), f"Expected 0.0, got {mutual_info}"
+
+
+    # diverse but no collapse
+    # should give low entropy and high mutual information
+    diverse_probs = torch.tensor([
+        # Batch 1
+        [
+            [0.99, 0.01, 0.0, 0.0],
+            [0.01, 0.99, 0.0, 0.0],
+            [0.01, 0.01, 0.99, 0.0], 
+        ],
+        # Batch 2
+        [
+            [0.01, 0.01, 0.99, 0.0],
+            [0.99, 0.01, 0.0, 0.0],
+            [0.01, 0.01, 0.01, 0.99], 
+        ]
+    ])
+    norm_entropy = calculate_normalized_average_entropy(diverse_probs)
+    mutual_info = calculate_mutual_information(diverse_probs)
+    assert torch.isclose(norm_entropy, torch.tensor(0.0), atol=1e-1), f"Expected 0.0, got {norm_entropy}"
+    assert torch.isclose(mutual_info, torch.tensor(0.75), atol=1e-1), f"Expected 1.0, got {mutual_info}"
+
+
+def test_calculate_normalized_average_entropy():
+    # AI generated test case
+    # Create a batch of routing probabilities
+    batch_size = 2
+    seq_len = 3
+    n_experts = 4
+    
+    # Test 1: Uniform distribution (should give normalized entropy of 1.0)
+    uniform_probs = torch.ones(batch_size, seq_len, n_experts) / n_experts
+    norm_entropy = calculate_normalized_average_entropy(uniform_probs)
+    assert torch.isclose(norm_entropy, torch.tensor(1.0), atol=1e-5), f"Expected 1.0, got {norm_entropy}"
+    
+    # Test 2: One-hot distribution (should give normalized entropy of 0.0)
+    one_hot = torch.zeros(batch_size, seq_len, n_experts)
+    for b in range(batch_size):
+        for s in range(seq_len):
+            one_hot[b, s, b % n_experts] = 1.0
+    norm_entropy = calculate_normalized_average_entropy(one_hot)
+    assert torch.isclose(norm_entropy, torch.tensor(0.0), atol=1e-5), f"Expected 0.0, got {norm_entropy}"
+    
+    # Test 3: Mixed distribution
+    mixed_probs = torch.tensor([
+        # Batch 1
+        [
+            [0.7, 0.1, 0.1, 0.1],  # Token 1: mostly expert 0
+            [0.1, 0.7, 0.1, 0.1],  # Token 2: mostly expert 1
+            [0.25, 0.25, 0.25, 0.25],  # Token 3: uniform
+        ],
+        # Batch 2
+        [
+            [0.4, 0.4, 0.1, 0.1],  # Token 1: split between experts 0 and 1
+            [0.1, 0.1, 0.4, 0.4],  # Token 2: split between experts 2 and 3
+            [0.1, 0.1, 0.1, 0.7],  # Token 3: mostly expert 3
+        ]
+    ])
+    norm_entropy = calculate_normalized_average_entropy(mixed_probs)
+    # The expected value is between 0 and 1
+    assert 0.0 < norm_entropy < 1.0, f"Expected value between 0 and 1, got {norm_entropy}"
+
+def test_calculate_mutual_information():
+    # AI generated test cases
+    # Create a batch of routing probabilities
+    batch_size = 2
+    seq_len = 3
+    n_experts = 4
+    
+    # Test 1: All tokens route to the same expert (low mutual information)
+    same_expert = torch.zeros(batch_size, seq_len, n_experts)
+    same_expert[:, :, 0] = 1.0  # All tokens route to expert 0
+    mutual_info = calculate_mutual_information(same_expert)
+    assert torch.isclose(mutual_info, torch.tensor(0.0)), f"Expected 0.0, got {mutual_info}"
+    
+    # Test 2: Each token routes to a different expert (high mutual information)
+    different_experts = torch.zeros(batch_size, seq_len, n_experts)
+    for b in range(batch_size):
+        for s in range(seq_len):
+            different_experts[b, s, s % n_experts] = 1.0
+    mutual_info = calculate_mutual_information(different_experts)
+    # The value should be positive and closer to 1
+    assert mutual_info > 0.0, f"Expected positive value, got {mutual_info}"
+    
+    # Test 3: Mixed routing pattern
+    mixed_probs = torch.tensor([
+        # Batch 1
+        [
+            [0.7, 0.1, 0.1, 0.1],  # Token 1: mostly expert 0
+            [0.1, 0.7, 0.1, 0.1],  # Token 2: mostly expert 1
+            [0.1, 0.1, 0.7, 0.1],  # Token 3: mostly expert 2
+        ],
+        # Batch 2
+        [
+            [0.1, 0.1, 0.1, 0.7],  # Token 1: mostly expert 3
+            [0.7, 0.1, 0.1, 0.1],  # Token 2: mostly expert 0
+            [0.1, 0.7, 0.1, 0.1],  # Token 3: mostly expert 1
+        ]
+    ])
+    mutual_info = calculate_mutual_information(mixed_probs)
+    # The expected value is between 0 and 1
+    assert 0.0 < mutual_info < 1.0, f"Expected value between 0 and 1, got {mutual_info}"
+
+def test_edge_cases():
+    # AI generated test cases
+    # Test with very small batch and sequence length
+    tiny_probs = torch.tensor([[[0.25, 0.25, 0.25, 0.25]]])  # batch=1, seq_len=1, n_experts=4
+    norm_entropy = calculate_normalized_average_entropy(tiny_probs)
+    mutual_info = calculate_mutual_information(tiny_probs)
+    assert torch.isclose(norm_entropy, torch.tensor(1.0)), f"Expected 1.0, got {norm_entropy}"
+    assert torch.isclose(mutual_info, torch.tensor(0.0)), f"Expected 0.0, got {mutual_info}"
+    
+    # Test with very small probabilities
+    small_probs = torch.ones(2, 3, 4) * 1e-8
+    small_probs[:, :, 0] = 1.0 - 3e-8  # Make sure they sum to 1
+    norm_entropy = calculate_normalized_average_entropy(small_probs)
+    mutual_info = calculate_mutual_information(small_probs)
+    assert torch.isclose(norm_entropy, torch.tensor(0.0), atol=1e-5), f"Expected ~0.0, got {norm_entropy}"
+    assert torch.isclose(mutual_info, torch.tensor(0.0), atol=1e-5), f"Expected ~0.0, got {mutual_info}"
+
+
+
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_routing_metrics.py
+++ b/tests/test_routing_metrics.py
@@ -54,7 +54,7 @@ def test_diversity_entropy():
     norm_entropy = calculate_normalized_average_entropy(diverse_probs)
     mutual_info = calculate_mutual_information(diverse_probs)
     assert torch.isclose(norm_entropy, torch.tensor(0.0), atol=1e-1), f"Expected 0.0, got {norm_entropy}"
-    assert torch.isclose(mutual_info, torch.tensor(0.75), atol=1e-1), f"Expected 1.0, got {mutual_info}"
+    assert torch.isclose(mutual_info, torch.tensor(0.9), atol=1e-1), f"Expected 1.0, got {mutual_info}"
 
 
 def test_calculate_normalized_average_entropy():

--- a/tests/test_routing_metrics.py
+++ b/tests/test_routing_metrics.py
@@ -1,55 +1,56 @@
-import torch
 import pytest
+import torch
+
 from fast_llm.layers.transformer.mixture_of_experts import (
-    calculate_normalized_average_entropy,
     calculate_mutual_information,
-    entropy
+    calculate_normalized_average_entropy,
 )
 
-def test_diversity_entropy():
-    '''
-    collapse routing would have low entropy and low mutual information
-    '''
 
-    batch_size = 2
-    seq_len = 3
-    n_experts = 4
-    collapased_probs = torch.tensor([
-        # Batch 1
+def test_diversity_entropy():
+    """
+    collapse routing would have low entropy and low mutual information
+    """
+
+    collapased_probs = torch.tensor(
         [
-            [0.99, 0.01, 0.0, 0.0],
-            [0.99, 0.01, 0.0, 0.0],
-            [0.99, 0.01, 0.0, 0.0], 
-        ],
-        # Batch 2
-        [
-            [0.99, 0.01, 0.0, 0.0],  
-            [0.99, 0.01, 0.0, 0.0], 
-            [0.99, 0.01, 0.0, 0.0], 
+            # Batch 1
+            [
+                [0.99, 0.01, 0.0, 0.0],
+                [0.99, 0.01, 0.0, 0.0],
+                [0.99, 0.01, 0.0, 0.0],
+            ],
+            # Batch 2
+            [
+                [0.99, 0.01, 0.0, 0.0],
+                [0.99, 0.01, 0.0, 0.0],
+                [0.99, 0.01, 0.0, 0.0],
+            ],
         ]
-    ])
+    )
     norm_entropy = calculate_normalized_average_entropy(collapased_probs)
     mutual_info = calculate_mutual_information(collapased_probs)
     assert torch.isclose(norm_entropy, torch.tensor(0.0), atol=1e-1), f"Expected 0.0, got {norm_entropy}"
     assert torch.isclose(mutual_info, torch.tensor(0.0), atol=1e-5), f"Expected 0.0, got {mutual_info}"
 
-
     # diverse but no collapse
     # should give low entropy and high mutual information
-    diverse_probs = torch.tensor([
-        # Batch 1
+    diverse_probs = torch.tensor(
         [
-            [0.99, 0.01, 0.0, 0.0],
-            [0.01, 0.99, 0.0, 0.0],
-            [0.01, 0.01, 0.99, 0.0], 
-        ],
-        # Batch 2
-        [
-            [0.01, 0.01, 0.99, 0.0],
-            [0.99, 0.01, 0.0, 0.0],
-            [0.01, 0.01, 0.01, 0.99], 
+            # Batch 1
+            [
+                [0.99, 0.01, 0.0, 0.0],
+                [0.01, 0.99, 0.0, 0.0],
+                [0.01, 0.01, 0.99, 0.0],
+            ],
+            # Batch 2
+            [
+                [0.01, 0.01, 0.99, 0.0],
+                [0.99, 0.01, 0.0, 0.0],
+                [0.01, 0.01, 0.01, 0.99],
+            ],
         ]
-    ])
+    )
     norm_entropy = calculate_normalized_average_entropy(diverse_probs)
     mutual_info = calculate_mutual_information(diverse_probs)
     assert torch.isclose(norm_entropy, torch.tensor(0.0), atol=1e-1), f"Expected 0.0, got {norm_entropy}"
@@ -62,12 +63,12 @@ def test_calculate_normalized_average_entropy():
     batch_size = 2
     seq_len = 3
     n_experts = 4
-    
+
     # Test 1: Uniform distribution (should give normalized entropy of 1.0)
     uniform_probs = torch.ones(batch_size, seq_len, n_experts) / n_experts
     norm_entropy = calculate_normalized_average_entropy(uniform_probs)
     assert torch.isclose(norm_entropy, torch.tensor(1.0), atol=1e-5), f"Expected 1.0, got {norm_entropy}"
-    
+
     # Test 2: One-hot distribution (should give normalized entropy of 0.0)
     one_hot = torch.zeros(batch_size, seq_len, n_experts)
     for b in range(batch_size):
@@ -75,25 +76,28 @@ def test_calculate_normalized_average_entropy():
             one_hot[b, s, b % n_experts] = 1.0
     norm_entropy = calculate_normalized_average_entropy(one_hot)
     assert torch.isclose(norm_entropy, torch.tensor(0.0), atol=1e-5), f"Expected 0.0, got {norm_entropy}"
-    
+
     # Test 3: Mixed distribution
-    mixed_probs = torch.tensor([
-        # Batch 1
+    mixed_probs = torch.tensor(
         [
-            [0.7, 0.1, 0.1, 0.1],  # Token 1: mostly expert 0
-            [0.1, 0.7, 0.1, 0.1],  # Token 2: mostly expert 1
-            [0.25, 0.25, 0.25, 0.25],  # Token 3: uniform
-        ],
-        # Batch 2
-        [
-            [0.4, 0.4, 0.1, 0.1],  # Token 1: split between experts 0 and 1
-            [0.1, 0.1, 0.4, 0.4],  # Token 2: split between experts 2 and 3
-            [0.1, 0.1, 0.1, 0.7],  # Token 3: mostly expert 3
+            # Batch 1
+            [
+                [0.7, 0.1, 0.1, 0.1],  # Token 1: mostly expert 0
+                [0.1, 0.7, 0.1, 0.1],  # Token 2: mostly expert 1
+                [0.25, 0.25, 0.25, 0.25],  # Token 3: uniform
+            ],
+            # Batch 2
+            [
+                [0.4, 0.4, 0.1, 0.1],  # Token 1: split between experts 0 and 1
+                [0.1, 0.1, 0.4, 0.4],  # Token 2: split between experts 2 and 3
+                [0.1, 0.1, 0.1, 0.7],  # Token 3: mostly expert 3
+            ],
         ]
-    ])
+    )
     norm_entropy = calculate_normalized_average_entropy(mixed_probs)
     # The expected value is between 0 and 1
     assert 0.0 < norm_entropy < 1.0, f"Expected value between 0 and 1, got {norm_entropy}"
+
 
 def test_calculate_mutual_information():
     # AI generated test cases
@@ -101,13 +105,13 @@ def test_calculate_mutual_information():
     batch_size = 2
     seq_len = 3
     n_experts = 4
-    
+
     # Test 1: All tokens route to the same expert (low mutual information)
     same_expert = torch.zeros(batch_size, seq_len, n_experts)
     same_expert[:, :, 0] = 1.0  # All tokens route to expert 0
     mutual_info = calculate_mutual_information(same_expert)
     assert torch.isclose(mutual_info, torch.tensor(0.0)), f"Expected 0.0, got {mutual_info}"
-    
+
     # Test 2: Each token routes to a different expert (high mutual information)
     different_experts = torch.zeros(batch_size, seq_len, n_experts)
     for b in range(batch_size):
@@ -116,25 +120,28 @@ def test_calculate_mutual_information():
     mutual_info = calculate_mutual_information(different_experts)
     # The value should be positive and closer to 1
     assert mutual_info > 0.0, f"Expected positive value, got {mutual_info}"
-    
+
     # Test 3: Mixed routing pattern
-    mixed_probs = torch.tensor([
-        # Batch 1
+    mixed_probs = torch.tensor(
         [
-            [0.7, 0.1, 0.1, 0.1],  # Token 1: mostly expert 0
-            [0.1, 0.7, 0.1, 0.1],  # Token 2: mostly expert 1
-            [0.1, 0.1, 0.7, 0.1],  # Token 3: mostly expert 2
-        ],
-        # Batch 2
-        [
-            [0.1, 0.1, 0.1, 0.7],  # Token 1: mostly expert 3
-            [0.7, 0.1, 0.1, 0.1],  # Token 2: mostly expert 0
-            [0.1, 0.7, 0.1, 0.1],  # Token 3: mostly expert 1
+            # Batch 1
+            [
+                [0.7, 0.1, 0.1, 0.1],  # Token 1: mostly expert 0
+                [0.1, 0.7, 0.1, 0.1],  # Token 2: mostly expert 1
+                [0.1, 0.1, 0.7, 0.1],  # Token 3: mostly expert 2
+            ],
+            # Batch 2
+            [
+                [0.1, 0.1, 0.1, 0.7],  # Token 1: mostly expert 3
+                [0.7, 0.1, 0.1, 0.1],  # Token 2: mostly expert 0
+                [0.1, 0.7, 0.1, 0.1],  # Token 3: mostly expert 1
+            ],
         ]
-    ])
+    )
     mutual_info = calculate_mutual_information(mixed_probs)
     # The expected value is between 0 and 1
     assert 0.0 < mutual_info < 1.0, f"Expected value between 0 and 1, got {mutual_info}"
+
 
 def test_edge_cases():
     # AI generated test cases
@@ -144,7 +151,7 @@ def test_edge_cases():
     mutual_info = calculate_mutual_information(tiny_probs)
     assert torch.isclose(norm_entropy, torch.tensor(1.0)), f"Expected 1.0, got {norm_entropy}"
     assert torch.isclose(mutual_info, torch.tensor(0.0)), f"Expected 0.0, got {mutual_info}"
-    
+
     # Test with very small probabilities
     small_probs = torch.ones(2, 3, 4) * 1e-8
     small_probs[:, :, 0] = 1.0 - 3e-8  # Make sure they sum to 1
@@ -152,9 +159,6 @@ def test_edge_cases():
     mutual_info = calculate_mutual_information(small_probs)
     assert torch.isclose(norm_entropy, torch.tensor(0.0), atol=1e-5), f"Expected ~0.0, got {norm_entropy}"
     assert torch.isclose(mutual_info, torch.tensor(0.0), atol=1e-5), f"Expected ~0.0, got {mutual_info}"
-
-
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# ✨ Description
To better detect potential routing collapse and have a better understanding about the routing distribution, we can track the average entropy and mutual information (which is the difference between the entropy of average routing and average routing entropy) of routing probabilities.

Collapse routing would have low entropy and low mutual information. A healthy and specialised router would have low entropy and high mutual information. 

## 🔍 Type of change

Select all that apply:

- [ ] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [x] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)

## 📝 Changes
- added calculation of both metrics in the `mixture_of_experts.py`, they are calculated only for the topk routing type. 

## ✅ Checklist

### General

- [x] 📜 I have read and followed the [contributing guidelines](https://servicenow.github.io/Fast-LLM/developers/contributing).
- [x] 🏷️ I am using a clear and descriptive PR title that summarizes the key change or feature introduced.
- [x] 🎉 The functionality is complete, and I have tested the changes.
- [x] ⚠️ The change does not introduce any new issues (e.g., runtime warnings, type checker errors, linting problems, unhandled edge cases).
- [x] 🧩 I have commented my code, especially in hard-to-understand areas.


### Testing

- [x] 🧪 I have added or updated tests to cover my changes.
- [ ] ✔️ New and existing tests pass locally with my changes.
- [x] 🚦 I have tested these changes on GPUs and verified training stability.
- [x] 🏋️ I have tested the changes on realistic training workloads, if applicable.

### Performance Impact

- [ ] 📊 I have run benchmarks where applicable to evaluate the performance impact.
- [ ] ✅ The benchmarks show no performance regression.
- [ ] 🚀 The benchmarks indicate a potential performance improvement.
- [ ] ⚠️ The benchmarks indicate a potential performance degradation.
- [ ] 📈 I have provided benchmark results and detailed any performance impact below, if applicable.

## 📊 Performance Impact Details

I am not 100% sure there is no performance impact, we are calculating the stats at each forward pass through the router.

---

## 🗒️ Additional Notes

Include any additional context, information, or considerations here, such as known issues, follow-up tasks, or backward compatibility concerns.
