### PR TITLE
fix preprocessing absolute embeddings

### DIFF
--- a/fast_llm/layers/language_model/preprocessing.py
+++ b/fast_llm/layers/language_model/preprocessing.py
@@ -37,7 +37,7 @@ class PositionEmbeddingPreprocessor:
         Assert.leq(sequence_length, self._config.num_absolute_position_embeddings)
         self._position_ids = torch.arange(
             0, sequence_length, device=self._tensor_space.distributed.device, dtype=torch.int64
-        ).unsqueeze(0)
+        )
 
     def preprocess(self, kwargs: dict[str, typing.Any]) -> None:
         sequence_k = kwargs[TransformerKwargs.sequence_k_dim].size


### PR DESCRIPTION
# ✨ Description

Fix bug introduced in c28cfbe
Verified that the previously failing tests pass, and I can run `fast-llm train gpt data.format=random training.train_iters=10` without errors

Closes #193 

## 🔍 Type of change

Select all that apply:

- [x] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [ ] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)