### PR TITLE
Fix sampling, add timeouts for test suprocess and data loaders

### DIFF
--- a/fast_llm/data/data/abstract.py
+++ b/fast_llm/data/data/abstract.py
@@ -4,7 +4,7 @@ import typing
 
 from fast_llm.config import Configurable
 from fast_llm.data.data.config import DataConfig
-from fast_llm.engine.distributed.config import DistributedConfig, PhaseType
+from fast_llm.engine.distributed.config import DistributedConfig
 from fast_llm.engine.schedule.config import BatchConfig
 
 if typing.TYPE_CHECKING:
@@ -45,5 +45,6 @@ class Data[ConfigType: DataConfig](Configurable[ConfigType], abc.ABC):
         consumed_samples: int,
         num_workers: int,
         prefetch_factor: int | None = None,
+        timeout: float = 60,
     ) -> typing.Iterator[typing.Any]:
         pass

--- a/fast_llm/data/data/gpt/data.py
+++ b/fast_llm/data/data/gpt/data.py
@@ -143,6 +143,7 @@ class GPTData[ConfigType: GPTDataConfig](Data[ConfigType]):
         consumed_samples: int,
         num_workers: int,
         prefetch_factor: int | None = None,
+        timeout: float = 60,
     ) -> typing.Iterator[typing.Any]:
         assert self._is_setup
 

--- a/fast_llm/data/dataset/gpt/sampled.py
+++ b/fast_llm/data/dataset/gpt/sampled.py
@@ -181,11 +181,14 @@ class GPTSampledIndexedDataset(SampledDataset):
 
         if self._yaml_path is not None and self._yaml_path.is_file():
             loaded_yaml_data = yaml.safe_load(self._yaml_path.open("r"))
-            if "unshuffled_tokens" not in loaded_yaml_data:
+            if "unshuffled_tokens" in loaded_yaml_data:
+                del loaded_yaml_data["unshuffled_tokens"]
+            else:
                 # Backward compatibility
                 # TODO v0.x: Remove
                 assert self._truncate_documents
                 loaded_yaml_data["unshuffled_tokens"] = tokens_per_epoch * unshuffled_epochs
+
             if loaded_yaml_data != yaml_data:
                 raise RuntimeError(
                     f"Invalid dataset cache for dataset {self.name}."

--- a/fast_llm/data/dataset/gpt/sampled.py
+++ b/fast_llm/data/dataset/gpt/sampled.py
@@ -183,6 +183,7 @@ class GPTSampledIndexedDataset(SampledDataset):
             loaded_yaml_data = yaml.safe_load(self._yaml_path.open("r"))
             if "unshuffled_tokens" not in loaded_yaml_data:
                 # Backward compatibility
+                # TODO v0.x: Remove
                 assert self._truncate_documents
                 loaded_yaml_data["unshuffled_tokens"] = tokens_per_epoch * unshuffled_epochs
             if loaded_yaml_data != yaml_data:

--- a/fast_llm/data/dataset/gpt/sampled.py
+++ b/fast_llm/data/dataset/gpt/sampled.py
@@ -176,7 +176,7 @@ class GPTSampledIndexedDataset(SampledDataset):
             "unshuffled_epochs": unshuffled_epochs,
             "sequence_length": self._sequence_length,
             "truncate_documents": self._truncate_documents,
-            "config": self._config.to_dict(),
+            "config": self._config.to_serialized(),
         }
         self._load_yaml_data(yaml_data)
 

--- a/fast_llm/data/dataset/gpt/sampled.py
+++ b/fast_llm/data/dataset/gpt/sampled.py
@@ -431,7 +431,8 @@ class GPTSampledIndexedDataset(SampledDataset):
 
     def _load_yaml_data(self, data: dict[str, typing.Any]) -> None:
         self._documents_per_epoch = data["dataset"]["documents_per_epoch"]
-        self._unshuffled_tokens = data["unshuffled_tokens"]
+        if "unshuffled_tokens" in data:
+            self._unshuffled_tokens = data["unshuffled_tokens"]
         self._unshuffled_documents = data["unshuffled_epochs"] * self._documents_per_epoch
 
 

--- a/fast_llm/data/dataset/gpt/sampled.py
+++ b/fast_llm/data/dataset/gpt/sampled.py
@@ -65,7 +65,7 @@ class MemmapArray:
 
     def _lazy_load(self):
         if self._array is None:
-            assert self.exists()
+            assert self.exists(), self._path
             self._array = np.load(self._path, mmap_mode="r")
 
 
@@ -176,7 +176,7 @@ class GPTSampledIndexedDataset(SampledDataset):
             "unshuffled_epochs": unshuffled_epochs,
             "sequence_length": self._sequence_length,
             "truncate_documents": self._truncate_documents,
-            "config": self._config.to_serialized(),
+            "config": self._config.to_dict(),
         }
         self._load_yaml_data(yaml_data)
 
@@ -432,7 +432,7 @@ class GPTSampledIndexedDataset(SampledDataset):
 
     def _load_yaml_data(self, data: dict[str, typing.Any]) -> None:
         self._documents_per_epoch = data["dataset"]["documents_per_epoch"]
-        if unshuffled_tokens := data.get("unshuffled_tokens") is not None:
+        if (unshuffled_tokens := data.get("unshuffled_tokens")) is not None:
             self._unshuffled_tokens = unshuffled_tokens
         else:
             self._unshuffled_tokens = data["unshuffled_epochs"] * data["dataset"]["tokens_per_epoch"]

--- a/fast_llm/data/dataset/gpt/sampled.py
+++ b/fast_llm/data/dataset/gpt/sampled.py
@@ -178,25 +178,25 @@ class GPTSampledIndexedDataset(SampledDataset):
             "truncate_documents": self._truncate_documents,
             "config": self._config.to_serialized(),
         }
-        self._load_yaml_data(yaml_data)
 
-        if self._yaml_path is not None:
-            if self._yaml_path.is_file():
-                loaded_yaml_data = yaml.safe_load(self._yaml_path.open("r"))
-                unshuffled_tokens = loaded_yaml_data.pop("unshuffled_tokens", None)
-                if unshuffled_tokens is not None:
-                    self._unshuffled_tokens = unshuffled_tokens
-                if loaded_yaml_data != yaml_data:
-                    raise RuntimeError(
-                        f"Invalid dataset cache for dataset {self.name}."
-                        " If this is due to an intended configuration change,"
-                        " please delete the cache before continuing."
-                        f"\nCurrent config:\n{yaml.safe_dump(yaml_data)}"
-                        f"\nCached config:\n{yaml.safe_dump(loaded_yaml_data)}"
-                    )
-                # Dataset is already sampled, skip.
-                logger.info(f"Using existing sampling for dataset {self.name}")
-                return
+        if self._yaml_path is not None and self._yaml_path.is_file():
+            loaded_yaml_data = yaml.safe_load(self._yaml_path.open("r"))
+            if "unshuffled_tokens" not in loaded_yaml_data:
+                # Backward compatibility
+                assert self._truncate_documents
+                loaded_yaml_data["unshuffled_tokens"] = tokens_per_epoch * unshuffled_epochs
+            if loaded_yaml_data != yaml_data:
+                raise RuntimeError(
+                    f"Invalid dataset cache for dataset {self.name}."
+                    " If this is due to an intended configuration change,"
+                    " please delete the cache before continuing."
+                    f"\nCurrent config:\n{yaml.safe_dump(yaml_data)}"
+                    f"\nCached config:\n{yaml.safe_dump(loaded_yaml_data)}"
+                )
+            # Dataset is already sampled, skip.
+            logger.info(f"Using existing sampling for dataset {self.name}")
+            self._load_yaml_data(yaml_data)
+            return
 
         if shuffled_documents > 1e8:
             warnings.warn(
@@ -255,25 +255,25 @@ class GPTSampledIndexedDataset(SampledDataset):
         # Using `TOKEN_CUMSUM_RATE > 1` reduces pre-computation overhead at the cost of runtime computation.
         # Equivalent to `torch.hstack((0, document_sizes[all_document_index].cumsum()[::TOKEN_CUMSUM_RATE]))`
         if unshuffled_epochs > 0:
-            token_cumsum_unshuffled, self._unshuffled_tokens = self._get_token_cumsum(
+            token_cumsum_unshuffled, yaml_data["unshuffled_tokens"] = self._get_token_cumsum(
                 document_sizes,
                 offset=0,
                 # TODO: Allowing for max 100% extra tokens for padding, is that enough?
                 dtype=get_unsigned_integer_type((2 - self._truncate_documents) * tokens_per_epoch * num_epochs),
             )
             if self._truncate_documents:
-                self._unshuffled_tokens = tokens_per_epoch * unshuffled_epochs
+                yaml_data["unshuffled_tokens"] = tokens_per_epoch * unshuffled_epochs
             self._token_cumsum_unshuffled.save(token_cumsum_unshuffled)
         else:
-            self._unshuffled_tokens = 0
+            yaml_data["unshuffled_tokens"] = 0
 
+        self._load_yaml_data(yaml_data)
         if self._yaml_path is not None:
-            yaml_data["unshuffled_tokens"] = self._unshuffled_tokens
             self._yaml_path.parent.mkdir(parents=True, exist_ok=True)
             yaml.safe_dump(yaml_data, self._yaml_path.open("w"))
 
         if shuffled_epochs > 0:
-            token_cumsum_shuffled, num_tokens_shuffled = self._get_token_cumsum(
+            token_cumsum_shuffled, _ = self._get_token_cumsum(
                 document_sizes[
                     # Torch indexing only works with int32 or int64
                     document_shuffling.to(
@@ -431,8 +431,7 @@ class GPTSampledIndexedDataset(SampledDataset):
 
     def _load_yaml_data(self, data: dict[str, typing.Any]) -> None:
         self._documents_per_epoch = data["dataset"]["documents_per_epoch"]
-        if "unshuffled_tokens" in data:
-            self._unshuffled_tokens = data["unshuffled_tokens"]
+        self._unshuffled_tokens = data["unshuffled_tokens"]
         self._unshuffled_documents = data["unshuffled_epochs"] * self._documents_per_epoch
 
 

--- a/fast_llm/engine/training/trainer.py
+++ b/fast_llm/engine/training/trainer.py
@@ -416,6 +416,7 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
             consumed_samples=completed_steps * self._config.batch.batch_size,
             num_workers=self._config.training.num_workers,
             prefetch_factor=prefetch_factor,
+            timeout=self._config.training.timeout,
         )
 
     def _prepare_training_state(self) -> None:

--- a/tests/common.py
+++ b/tests/common.py
@@ -394,7 +394,7 @@ def run_test_script(
         if num_gpus == 1 and not is_megatron:
             CliTrainingConfig.parse_and_run(script)
         else:
-            completed_proc = subprocess.run(command, env=env)
+            completed_proc = subprocess.run(command, env=env, timeout=30)
             if completed_proc.returncode:
                 raise RuntimeError(f"Process failed with return code {completed_proc.returncode}")
     if compare:

--- a/tests/common.py
+++ b/tests/common.py
@@ -394,7 +394,7 @@ def run_test_script(
         if num_gpus == 1 and not is_megatron:
             CliTrainingConfig.parse_and_run(script)
         else:
-            completed_proc = subprocess.run(command, env=env, timeout=30)
+            completed_proc = subprocess.run(command, env=env, timeout=60)
             if completed_proc.returncode:
                 raise RuntimeError(f"Process failed with return code {completed_proc.returncode}")
     if compare:


### PR DESCRIPTION
# ✨ Description

#186 Broke sampling because of an incorrect walrus which always set `unshuffled_tokens` to 1 (`True`). I fixed it and simplified related code.

This bug only showed in slow tests (@sohamparikh please make sure these pass before merging) which didn't terminate because of a data loader crash somehow not being caught. I added some timeouts to ensure this doesn't happen again.


## 🔍 Type of change

Select all that apply:

- [x] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [x] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)
