### PR TITLE
Remove the architecture split

### DIFF
--- a/fast_llm/config.py
+++ b/fast_llm/config.py
@@ -53,6 +53,7 @@ class FieldHint:
     """
 
     core = "core"
+    architecture = "architecture"
     optional = "optional"
     performance = "performance"
     stability = "stability"
@@ -69,6 +70,7 @@ class FieldHint:
 
 FieldHintImportance = {
     FieldHint.core: 0,
+    FieldHint.architecture: 0,
     FieldHint.optional: 10,
     FieldHint.performance: 20,
     FieldHint.stability: 20,
@@ -95,6 +97,7 @@ class FieldVerboseLevel:
 
 FieldHintDoc = {
     FieldHint.core: "A core configuration parameter that is expected to always be provided explicitly.",
+    FieldHint.architecture: "A base model configuration parameters that shouldn't be modified when loading a pretrained model.",
     FieldHint.optional: "An optional parameter that may be ignored as the default tends to be good enough.",
     FieldHint.performance: "An optional parameter related to computational performance.",
     FieldHint.stability: "An optional parameter related to numerical precision and computational stability.",

--- a/fast_llm/engine/base_model/base_model.py
+++ b/fast_llm/engine/base_model/base_model.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn
 
 from fast_llm.config import Configurable
-from fast_llm.engine.base_model.config import BaseModelArchitectureConfig, BaseModelConfig, Preprocessor
+from fast_llm.engine.base_model.config import BaseModelConfig, Preprocessor
 from fast_llm.engine.config_utils.tensor_space import TensorSpace
 from fast_llm.engine.distributed.config import DistributedConfig, PhaseType
 from fast_llm.engine.distributed.distributed import Distributed
@@ -95,10 +95,6 @@ class BaseModel[ConfigType: BaseModelConfig](Configurable[ConfigType], Sequentia
             Assert.custom(isinstance, value, ParameterMeta)
             # Rename to the parameter full name
             value.tensor_name = key
-
-    @classmethod
-    def architecture_cls(cls) -> type[BaseModelArchitectureConfig]:
-        return cls.config_class.architecture_class
 
     @abc.abstractmethod
     def get_layers(self) -> list[Layer]:

--- a/fast_llm/engine/base_model/config.py
+++ b/fast_llm/engine/base_model/config.py
@@ -41,7 +41,7 @@ class BaseModelConfig(Config):
                 continue
             assert isinstance(field, Field), f"{name}, {field}"
             if field.hint == FieldHint.architecture:
-                architecture[name] = self._serialize_architecture_field(field, getattr(self, name, MISSING))
+                architecture[name] = self._serialize_architecture_field(getattr(self, name, MISSING))
 
     def _serialize_architecture_field(self, value: typing.Any) -> typing.Any:
         if isinstance(value, BaseModelConfig):

--- a/fast_llm/engine/base_model/config.py
+++ b/fast_llm/engine/base_model/config.py
@@ -1,7 +1,8 @@
 import abc
+import dataclasses
 import typing
 
-from fast_llm.config import MISSING, Config, FieldHint, FieldVerboseLevel, config_class
+from fast_llm.config import MISSING, Config, Field, FieldHint, FieldVerboseLevel, config_class
 from fast_llm.utils import compare_nested, log
 
 if typing.TYPE_CHECKING:
@@ -36,6 +37,9 @@ class BaseModelConfig(Config):
     def _get_architecture(self) -> dict[str, typing.Any]:
         architecture = {}
         for name, field in self.fields():
+            if not field.init or field._field_type == dataclasses._FIELD_CLASSVAR:
+                continue
+            assert isinstance(field, Field), f"{name}, {field}"
             if field.hint == FieldHint.architecture:
                 architecture[name] = self._serialize_architecture_field(field, getattr(self, name, MISSING))
 

--- a/fast_llm/engine/base_model/config.py
+++ b/fast_llm/engine/base_model/config.py
@@ -1,16 +1,17 @@
 import abc
 import typing
 
-from fast_llm.config import Config, config_class
+from fast_llm.config import MISSING, Config, FieldHint, FieldVerboseLevel, config_class
+from fast_llm.utils import compare_nested, log
 
 if typing.TYPE_CHECKING:
     from fast_llm.engine.config_utils.tensor_space import TensorSpace
 
 
 @config_class()
-class BaseModelArchitectureConfig(Config):
+class BaseModelConfig(Config):
     """
-    Abstract config class for a base model architecture.
+    Abstract config class for a base model.
     # TODO: Find better name?
     """
 
@@ -19,28 +20,38 @@ class BaseModelArchitectureConfig(Config):
     def setup_tensor_space(self, tensor_space: "TensorSpace") -> None:
         raise NotImplementedError()
 
-    def get_architecture[T: BaseModelArchitectureConfig](self: T) -> T:
-        return self
-
     def compare_architecture(
         self,
-        model_config: "BaseModelArchitectureConfig",
+        model_config: typing.Self,
         log_fn: typing.Union[type[BaseException], typing.Callable] = ValueError,
     ):
-        return self.get_architecture().compare(model_config.get_architecture(), log_fn)
+        errors = compare_nested(self._get_architecture(), model_config._get_architecture())
+        if errors:
+            return log(
+                f"Config comparison errors:\n  " + "\n".join(errors),
+                log_fn=log_fn,
+            )
+        return None
 
+    def _get_architecture(self) -> dict[str, typing.Any]:
+        architecture = {}
+        for name, field in self.fields():
+            if field.hint == FieldHint.architecture:
+                architecture[name] = self._serialize_architecture_field(field, getattr(self, name, MISSING))
 
-@config_class()
-class BaseModelConfig(BaseModelArchitectureConfig):
-    """
-    Abstract config class for a base model.
-    # TODO: Find better name?
-    """
-
-    architecture_class: typing.ClassVar[type[BaseModelArchitectureConfig]]
-
-    def get_architecture(self) -> BaseModelArchitectureConfig:
-        return self.architecture_class.from_dict(self, strict=False)
+    def _serialize_architecture_field(self, value: typing.Any) -> typing.Any:
+        if isinstance(value, BaseModelConfig):
+            # TODO: Make sure all nested configs have an architecture type hint?
+            return value._get_architecture()
+        elif isinstance(value, Config):
+            # TODO: Explicitly prevent this case?
+            return value.to_dict(verbose=FieldVerboseLevel.everything)
+        elif isinstance(value, (list, tuple, set)):
+            return [self._serialize_architecture_field(value_) for value_ in value]
+        elif isinstance(value, dict):
+            return {self._serialize_architecture_field(value_) for name, value_ in value.items()}
+        else:
+            return self._serialize_value(value)
 
 
 class Preprocessor(abc.ABC):

--- a/fast_llm/engine/checkpoint/config.py
+++ b/fast_llm/engine/checkpoint/config.py
@@ -240,7 +240,7 @@ class CheckpointHandler(abc.ABC):
         if not config.load_config.load_fast_llm:
             updates[("config", "multi_stage")] = {}
             updates[("config", "distributed")] = {}
-        elif not config.load_config.load_base_model:
+        if not config.load_config.load_base_model:
             updates[("config", "base_model")] = {}
         if updates:
             metadata = metadata.to_copy(updates)

--- a/fast_llm/functional/config.py
+++ b/fast_llm/functional/config.py
@@ -34,7 +34,7 @@ class MLPRecomputeLevel(str, enum.Enum):
         return self in (MLPRecomputeLevel.full, MLPRecomputeLevel.activation_and_input)
 
 
-class ActivationType(str, enum.Enum):
+class ActivationType(enum.StrEnum):
     """
     An enum for the available activation types for the MLP layer.
     """

--- a/fast_llm/layers/common/config.py
+++ b/fast_llm/layers/common/config.py
@@ -2,7 +2,7 @@ import enum
 import typing
 
 from fast_llm.config import Field, FieldHint, check_field, config_class
-from fast_llm.engine.base_model.config import BaseModelArchitectureConfig, BaseModelConfig
+from fast_llm.engine.base_model.config import BaseModelConfig
 from fast_llm.utils import Assert
 
 if typing.TYPE_CHECKING:
@@ -34,41 +34,27 @@ class NormalizationType(str, enum.Enum):
 
 
 @config_class()
-class NormalizationArchitectureConfig(BaseModelArchitectureConfig):
+class NormalizationConfig(BaseModelConfig):
     _abstract = False
-    # TODO: Remove "normalization" from names once we have fully nested configs?
+
     # Normalization type
     type: NormalizationType = Field(
         default=NormalizationType.layer_norm,
         desc="The type of normalization to use, for example Layer Norm or RMS Norm.",
-        hint=FieldHint.core,
+        hint=FieldHint.architecture,
     )
     # TODO: Rename to normalization_epsilon
     epsilon: float = Field(
-        default=1e-5, desc="Regularizer for the division.", hint=FieldHint.stability, valid=check_field(Assert.gt, 0)
+        default=1e-5,
+        desc="Regularizer for the division.",
+        hint=FieldHint.architecture,
+        valid=check_field(Assert.gt, 0),
     )
     zero_centered: bool = Field(
         default=False,
         desc="Write the normalization weight as `w = 1 + w'`, to improve numerical accuracy when close to one.",
-        hint=FieldHint.stability,
+        hint=FieldHint.architecture,
     )
-
-    @classmethod
-    def _from_dict(
-        cls,
-        default: dict[str, typing.Any],
-        strict: bool = True,
-        flat: bool = False,
-    ) -> typing.Self:
-        # TODO v0.3: Remove.
-        cls._handle_renamed_field(default, "normalization_type", "type")
-        cls._handle_renamed_field(default, "layer_norm_eps", "epsilon")
-        cls._handle_renamed_field(default, "zero_centered_normalization", "zero_centered")
-        return super()._from_dict(default, strict, flat)
-
-
-@config_class()
-class NormalizationConfig(NormalizationArchitectureConfig, BaseModelConfig):
     implementation: NormalizationImplementation = Field(
         default=NormalizationImplementation.auto,
         desc="The implementation to use for the normalization layer.",
@@ -113,6 +99,9 @@ class NormalizationConfig(NormalizationArchitectureConfig, BaseModelConfig):
         strict: bool = True,
         flat: bool = False,
     ) -> typing.Self:
+        cls._handle_renamed_field(default, "normalization_type", "type")
+        cls._handle_renamed_field(default, "layer_norm_eps", "epsilon")
+        cls._handle_renamed_field(default, "zero_centered_normalization", "zero_centered")
         cls._handle_renamed_field(default, "normalization_implementation", "implementation")
         cls._handle_renamed_field(default, "layer_norm_init_range", "initialization_range")
         return super()._from_dict(default, strict, flat)
@@ -125,13 +114,8 @@ class PeftType(str, enum.Enum):
 
 
 @config_class()
-class PeftArchitectureConfig(BaseModelArchitectureConfig):
+class PeftConfig(BaseModelConfig):
     _abstract = False
-
-
-@config_class()
-class PeftConfig(PeftArchitectureConfig, BaseModelConfig):
-    # TODO: Architecture/non-architecture split might not make much sense here.
 
     type: PeftType = Field(
         default=PeftType.none,

--- a/fast_llm/layers/ssm/llamba_block.py
+++ b/fast_llm/layers/ssm/llamba_block.py
@@ -13,7 +13,7 @@ class LlambaBlock(BaseBlock):
     A transformer-like decoder block with a SSM mixer, see https://arxiv.org/abs/2502.14458
     """
 
-    name = "Llamba block"
+    _name = "Llamba block"
     _mixer_module_name = "mixer"
 
     def __init__(

--- a/fast_llm/layers/transformer/config.py
+++ b/fast_llm/layers/transformer/config.py
@@ -1,22 +1,17 @@
 import enum
+import functools
 import logging
 import math
 import typing
 import warnings
 
-from fast_llm.config import Field, FieldHint, FieldUpdate, check_field, config_class, skip_valid_if_none
-from fast_llm.engine.base_model.config import BaseModelArchitectureConfig, BaseModelConfig
+from fast_llm.config import Field, FieldHint, check_field, config_class, skip_valid_if_none
+from fast_llm.engine.base_model.config import BaseModelConfig
 from fast_llm.engine.config_utils.data_type import DataType
 from fast_llm.engine.config_utils.tensor_space import CompositeTensorDim, TensorDim, TensorSpace
 from fast_llm.engine.distributed.config import DistributedConfig, DistributedDimNames
 from fast_llm.functional.config import ActivationType, MLPRecomputeLevel, TritonConfig
-from fast_llm.layers.common.config import (
-    NormalizationArchitectureConfig,
-    NormalizationConfig,
-    PeftArchitectureConfig,
-    PeftConfig,
-    PeftType,
-)
+from fast_llm.layers.common.config import NormalizationConfig, PeftConfig, PeftType
 from fast_llm.utils import Assert, div
 
 if typing.TYPE_CHECKING:
@@ -101,26 +96,28 @@ class RotaryEmbeddingType(str, enum.Enum):
 
 
 @config_class()
-class RotaryArchitectureConfig(BaseModelArchitectureConfig):
+class RotaryConfig(BaseModelConfig):
     _abstract = False
     type: RotaryEmbeddingType = Field(
         default=RotaryEmbeddingType.none,
         desc="The type of rotary embedding to use. Choices: none, default, llama3.",
-        hint=FieldHint.feature,
+        hint=FieldHint.architecture,
     )
     theta: float = Field(
         default=10000,
         desc="Scale for the rotary positional embeddings",
-        hint=FieldHint.feature,
+        hint=FieldHint.architecture,
     )
     # TODO: Make a backup implementation that doesn't affect the layout.
     triton: bool = Field(
         default=True,
         desc="Enable the triton implementation of the rotary embeddings. Affects the model layout.",
-        hint=FieldHint.deprecated,
+        hint=FieldHint.architecture,
     )
     # TODO: These are not really architecture parameters, but we want to import them from huggingface.
-    scale_factor: float = Field(default=8.0, desc="Scaling factor for llama3-type scaling.", hint=FieldHint.feature)
+    scale_factor: float = Field(
+        default=8.0, desc="Scaling factor for llama3-type scaling.", hint=FieldHint.architecture
+    )
     low_frequency_factor: float = Field(
         default=1.0, desc="Low frequency factor for llama3-type scaling.", hint=FieldHint.feature
     )
@@ -159,11 +156,6 @@ class RotaryArchitectureConfig(BaseModelArchitectureConfig):
         super()._validate()
         if self.triton and not TritonConfig.TRITON_ENABLED:
             warnings.warn("Triton is disabled, but the triton rotary kernel will be used anyway.")
-
-
-@config_class()
-class RotaryConfig(RotaryArchitectureConfig, BaseModelConfig):
-    pass
 
 
 class AddLinearBiasChoices(str, enum.Enum):
@@ -253,44 +245,52 @@ class TransformerPeftConfig(PeftConfig):
 
 
 @config_class()
-class TransformerArchitectureConfig(BaseModelArchitectureConfig):
+class TransformerConfig(BaseModelConfig):
     _abstract = False
-    normalization: NormalizationArchitectureConfig = Field(
-        default_factory=NormalizationArchitectureConfig,
+    normalization: NormalizationConfig = Field(
+        default_factory=NormalizationConfig,
         desc="Configuration for the normalization layers architecture.",
-        hint=FieldHint.core,
+        hint=FieldHint.architecture,
     )
-    peft: PeftArchitectureConfig = Field(
-        default_factory=PeftArchitectureConfig,
+    rotary: RotaryConfig = Field(
+        default_factory=RotaryConfig,
+        desc="Configuration for the rotary positional embeddings.",
+        hint=FieldHint.architecture,
+    )
+    peft: PeftConfig = Field(
+        default_factory=PeftConfig,
         desc="Configuration for the parameter-efficient fine tuning.",
-        hint=FieldHint.core,
+        hint=FieldHint.architecture,
     )
     num_layers: int = Field(
-        default=12, desc="Number of layers in the transformer.", hint=FieldHint.core, valid=check_field(Assert.geq, 0)
+        default=12,
+        desc="Number of layers in the transformer.",
+        hint=FieldHint.architecture,
+        valid=check_field(Assert.geq, 0),
     )
     hidden_size: int = Field(
         default=1024,
         desc="Size of the transformer's main hidden dimension, e.g., for its input and output layers.",
-        hint=FieldHint.core,
+        hint=FieldHint.architecture,
         valid=check_field(Assert.gt, 0),
     )
-    num_attention_heads: int = Field(default=8, desc="Number of attention heads.", hint=FieldHint.core)
+    num_attention_heads: int = Field(default=8, desc="Number of attention heads.", hint=FieldHint.architecture)
     head_groups: int = Field(
         default=1,
         desc="Number of head group for grouped query attention.",
         doc="Set to 1 for multi-query attention, `num_attention_heads` for multi-head.",
-        hint=FieldHint.core,
+        hint=FieldHint.architecture,
         valid=check_field(Assert.gt, 0),
     )
     add_linear_biases: bool | AddLinearBiasChoices = Field(
         default=True,
         desc="Add biases to all, none or Q, K, V layers. Accepted values: True, False, or AddLinearBiasChoices.",
-        hint=FieldHint.core,
+        hint=FieldHint.architecture,
     )
     ffn_hidden_size: int = Field(
         default=None,
         desc="Hidden dimension of the MLP intermediate state. Default: 4 * hidden_size.",
-        hint=FieldHint.core,
+        hint=FieldHint.architecture,
         valid=check_field(Assert.gt, 0),
     )
     projection_size: int = Field(
@@ -302,178 +302,44 @@ class TransformerArchitectureConfig(BaseModelArchitectureConfig):
     kv_channels: int = Field(
         default=None,
         desc="Number of key and value channels, i.e., hidden dimension of each attention head. Default: hidden_size // num_attention_heads",
-        hint=FieldHint.core,
+        hint=FieldHint.architecture,
         valid=check_field(Assert.gt, 0),
     )
-    rotary: RotaryArchitectureConfig = Field(
-        default_factory=RotaryArchitectureConfig,
-        desc="Configuration for the rotary positional embeddings.",
-        hint=FieldHint.feature,
-    )
-    gated: bool = Field(default=False, desc="Enable gated MLP.", hint=FieldHint.feature)
-    activation_type: ActivationType = Field(
-        default=None,
-        desc="The MLP intermediate activation type. Default: SiLU for gated MLP, GeLU otherwise.",
-        hint=FieldHint.core,
-    )
+    gated: bool = Field(default=False, desc="Enable gated MLP.", hint=FieldHint.architecture)
     num_experts: int = Field(
         default=1,
         desc="Number of MLP experts in a Mixture of Expert (MoE) model",
-        hint=FieldHint.feature,
+        hint=FieldHint.architecture,
         valid=check_field(Assert.gt, 0),
     )
     num_shared_experts: int = Field(
         default=0,
         desc="Number of MLP experts that are shared between all tokens, i.e., always enabled.",
-        hint=FieldHint.feature,
+        hint=FieldHint.architecture,
         valid=check_field(Assert.geq, 0),
     )
     num_unshared_experts: int = Field(
         init=False,
         desc="Number of MLP experts excluding shared ones",
-        hint=FieldHint.feature,
+        hint=FieldHint.architecture,
         valid=check_field(Assert.geq, 0),
     )
     num_experts_per_token: int = Field(
         default=1,
         desc="Active experts for each token in a MoE model.",
-        hint=FieldHint.feature,
+        hint=FieldHint.architecture,
         valid=check_field(Assert.gt, 0),
     )
     expert_routing_type: RoutingType = Field(
         default=RoutingType.topk,
         desc="The routing method, i.e., the method used to assign experts to tokens.",
-        hint=FieldHint.feature,
+        hint=FieldHint.architecture,
     )
-
-    def _validate(self) -> None:
-        with self._set_implicit_default():
-            if self.ffn_hidden_size is None:
-                self.ffn_hidden_size = 4 * self.hidden_size
-            if self.kv_channels is None:
-                self.kv_channels = div(self.hidden_size, self.num_attention_heads)
-            if self.activation_type is None:
-                self.activation_type = ActivationType.silu if self.gated else ActivationType.gelu
-        self.projection_size = self.num_attention_heads * self.kv_channels
-        self.num_unshared_experts = self.num_experts - self.num_shared_experts
-
-        super()._validate()
-
-        if not TritonConfig.TRITON_ENABLED:
-            warnings.warn("Triton is disabled, but triton rotary kernel will be used anyway.")
-
-        Assert.leq(self.num_shared_experts, self.num_experts)
-        Assert.leq(self.num_shared_experts + self.num_experts_per_token, self.num_experts)
-        Assert.multiple(self.num_attention_heads, self.head_groups)
-
-    @property
-    def add_mlp_bias(self) -> bool:
-        if isinstance(self.add_linear_biases, bool):
-            return self.add_linear_biases
-        if self.add_linear_biases == AddLinearBiasChoices.everywhere:
-            return True
-        return False
-
-    @property
-    def add_attn_qkv_bias(self) -> bool:
-        if isinstance(self.add_linear_biases, bool):
-            return self.add_linear_biases
-        if self.add_linear_biases == AddLinearBiasChoices.nowhere:
-            return False
-        return True
-
-    @property
-    def add_attn_dense_bias(self) -> bool:
-        if isinstance(self.add_linear_biases, bool):
-            return self.add_linear_biases
-        if self.add_linear_biases == AddLinearBiasChoices.everywhere:
-            return True
-        return False
-
-    @classmethod
-    def _from_dict(
-        cls,
-        default: dict[str, typing.Any],
-        strict: bool = True,
-        flat: bool = False,
-    ) -> typing.Self:
-        # TODO v0.x: Remove backward compatibility.
-        cls._handle_renamed_field(
-            default,
-            "use_rotary_embeddings",
-            ("rotary", "type"),
-            lambda x: RotaryEmbeddingType.default if x else RotaryEmbeddingType.none,
-        )
-        cls._handle_renamed_field(default, "rotary_embedding_scale", ("rotary", "theta"), lambda x: math.exp(-x))
-        cls._handle_renamed_field(default, "triton_rotary", ("rotary", "triton"))
-        return super()._from_dict(default, strict, flat)
-
-    def setup_tensor_space(self, tensor_space: TensorSpace) -> None:
-        tensor = tensor_space.distributed_config.get_distributed_dim(DistributedDimNames.tensor)
-
-        # Hidden dimension
-        tensor_space.add_tensor_dim(TensorDim(TransformerDimNames.hidden, self.hidden_size))
-
-        # Self-attention dimensions
-        tensor_space.add_tensor_dim(
-            head_groups := TensorDim(
-                TransformerDimNames.head_groups, self.head_groups, tensor if self.head_groups > 1 else None
-            )
-        )
-        tensor_space.add_tensor_dim(
-            group_heads := TensorDim(
-                TransformerDimNames.group_heads,
-                div(self.num_attention_heads, self.head_groups),
-                None if self.head_groups > 1 else tensor,
-            )
-        )
-        tensor_space.add_tensor_dim(key_and_value := TensorDim(TransformerDimNames.key_and_value, 2))
-        tensor_space.add_tensor_dim(kv_channels := TensorDim(TransformerDimNames.kv_channels, self.kv_channels))
-        tensor_space.add_tensor_dim(
-            CompositeTensorDim(TransformerDimNames.composite_heads, (head_groups, group_heads))
-        )
-        tensor_space.add_tensor_dim(
-            CompositeTensorDim(TransformerDimNames.composite_query, (head_groups, group_heads, kv_channels))
-        )
-        tensor_space.add_tensor_dim(
-            CompositeTensorDim(TransformerDimNames.composite_key_value, (key_and_value, head_groups, kv_channels))
-        )
-        tensor_space.add_tensor_dim(
-            CompositeTensorDim(TransformerDimNames.composite_dense, (head_groups, group_heads, kv_channels))
-        )
-
-        # MLP dimensions
-        tensor_space.add_tensor_dim(mlp := TensorDim(TransformerDimNames.mlp, self.ffn_hidden_size, tensor))
-        tensor_space.add_tensor_dim(gate_and_up := TensorDim(TransformerDimNames.gate_and_up, 2 if self.gated else 1))
-        tensor_space.add_tensor_dim(CompositeTensorDim(TransformerDimNames.composite_gated_mlp, (gate_and_up, mlp)))
-        tensor_space.add_tensor_dim(experts := TensorDim(TransformerDimNames.experts, self.num_experts))
-        tensor_space.add_tensor_dim(CompositeTensorDim(TransformerDimNames.composite_expert_mlp, (experts, mlp)))
-        tensor_space.add_tensor_dim(
-            CompositeTensorDim(TransformerDimNames.composite_gated_expert_mlp, (experts, gate_and_up, mlp))
-        )
-        tensor_space.add_tensor_dim(TensorDim(TransformerDimNames.top_experts, self.num_experts_per_token))
-        tensor_space.add_tensor_dim(TensorDim(TransformerDimNames.unshared_experts, self.num_unshared_experts))
-
-        # shared_experts
-        if self.num_shared_experts:
-            tensor_space.add_tensor_dim(
-                shared_experts := TensorDim(TransformerDimNames.shared_experts, self.num_shared_experts)
-            )
-            tensor_space.add_tensor_dim(
-                CompositeTensorDim(TransformerDimNames.composite_shared_expert_mlp, (shared_experts, mlp))
-            )
-            tensor_space.add_tensor_dim(
-                CompositeTensorDim(
-                    TransformerDimNames.composite_gated_shared_expert_mlp, (shared_experts, gate_and_up, mlp)
-                )
-            )
-
-
-@config_class()
-class TransformerConfig(TransformerArchitectureConfig, BaseModelConfig):
-    normalization: NormalizationConfig = FieldUpdate(default_factory=NormalizationConfig)
-    rotary: RotaryConfig = FieldUpdate(default_factory=RotaryConfig)
-    peft: TransformerPeftConfig = FieldUpdate(default_factory=TransformerPeftConfig)
+    activation_type: ActivationType = Field(
+        default=None,
+        desc="The MLP intermediate activation type. Default: SiLU for gated MLP, GeLU otherwise.",
+        hint=FieldHint.core,
+    )
     # Default: hidden_size**-0.5
     # TODO: Allow custom initialization (InitializationConfig?)
     init_method_std: float = Field(
@@ -669,6 +535,12 @@ class TransformerConfig(TransformerArchitectureConfig, BaseModelConfig):
 
     def _validate(self) -> None:
         with self._set_implicit_default():
+            if self.ffn_hidden_size is None:
+                self.ffn_hidden_size = 4 * self.hidden_size
+            if self.kv_channels is None:
+                self.kv_channels = div(self.hidden_size, self.num_attention_heads)
+            if self.activation_type is None:
+                self.activation_type = ActivationType.silu if self.gated else ActivationType.gelu
             if self.init_method_std is None:
                 self.init_method_std = self.hidden_size**-0.5
             if self.init_method_std_qkv is None:
@@ -707,7 +579,16 @@ class TransformerConfig(TransformerArchitectureConfig, BaseModelConfig):
                 Assert.leq(self.init_method_min_mlp_1, self.init_method_max_mlp_1)
             if self.init_method_min_mlp_2 is not None and self.init_method_max_mlp_2 is not None:
                 Assert.leq(self.init_method_min_mlp_2, self.init_method_max_mlp_2)
+        self.num_unshared_experts = self.num_experts - self.num_shared_experts
+
         super()._validate()
+
+        if not TritonConfig.TRITON_ENABLED:
+            warnings.warn("Triton is disabled, but triton rotary kernel will be used anyway.")
+
+        Assert.leq(self.num_shared_experts, self.num_experts)
+        Assert.leq(self.num_shared_experts + self.num_experts_per_token, self.num_experts)
+        Assert.multiple(self.num_attention_heads, self.head_groups)
         Assert.geq(self.attention_dropout, 0)
         Assert.geq(self.hidden_dropout, 0)
 
@@ -718,6 +599,113 @@ class TransformerConfig(TransformerArchitectureConfig, BaseModelConfig):
                     Assert.geq(scale, 0)
         elif self.mlp_lr_scale is not None:
             Assert.geq(self.mlp_lr_scale, 0)
+
+    @functools.cached_property
+    def projection_size(self):
+        assert self._validated
+        return self.num_attention_heads * self.kv_channels
+
+    @property
+    def add_mlp_bias(self) -> bool:
+        if isinstance(self.add_linear_biases, bool):
+            return self.add_linear_biases
+        if self.add_linear_biases == AddLinearBiasChoices.everywhere:
+            return True
+        return False
+
+    @property
+    def add_attn_qkv_bias(self) -> bool:
+        if isinstance(self.add_linear_biases, bool):
+            return self.add_linear_biases
+        if self.add_linear_biases == AddLinearBiasChoices.nowhere:
+            return False
+        return True
+
+    @property
+    def add_attn_dense_bias(self) -> bool:
+        if isinstance(self.add_linear_biases, bool):
+            return self.add_linear_biases
+        if self.add_linear_biases == AddLinearBiasChoices.everywhere:
+            return True
+        return False
+
+    @classmethod
+    def _from_dict(
+        cls,
+        default: dict[str, typing.Any],
+        strict: bool = True,
+        flat: bool = False,
+    ) -> typing.Self:
+        # TODO v0.x: Remove backward compatibility.
+        cls._handle_renamed_field(
+            default,
+            "use_rotary_embeddings",
+            ("rotary", "type"),
+            lambda x: RotaryEmbeddingType.default if x else RotaryEmbeddingType.none,
+        )
+        cls._handle_renamed_field(default, "rotary_embedding_scale", ("rotary", "theta"), lambda x: math.exp(-x))
+        cls._handle_renamed_field(default, "triton_rotary", ("rotary", "triton"))
+        return super()._from_dict(default, strict, flat)
+
+    def setup_tensor_space(self, tensor_space: TensorSpace) -> None:
+        tensor = tensor_space.distributed_config.get_distributed_dim(DistributedDimNames.tensor)
+
+        # Hidden dimension
+        tensor_space.add_tensor_dim(TensorDim(TransformerDimNames.hidden, self.hidden_size))
+
+        # Self-attention dimensions
+        tensor_space.add_tensor_dim(
+            head_groups := TensorDim(
+                TransformerDimNames.head_groups, self.head_groups, tensor if self.head_groups > 1 else None
+            )
+        )
+        tensor_space.add_tensor_dim(
+            group_heads := TensorDim(
+                TransformerDimNames.group_heads,
+                div(self.num_attention_heads, self.head_groups),
+                None if self.head_groups > 1 else tensor,
+            )
+        )
+        tensor_space.add_tensor_dim(key_and_value := TensorDim(TransformerDimNames.key_and_value, 2))
+        tensor_space.add_tensor_dim(kv_channels := TensorDim(TransformerDimNames.kv_channels, self.kv_channels))
+        tensor_space.add_tensor_dim(
+            CompositeTensorDim(TransformerDimNames.composite_heads, (head_groups, group_heads))
+        )
+        tensor_space.add_tensor_dim(
+            CompositeTensorDim(TransformerDimNames.composite_query, (head_groups, group_heads, kv_channels))
+        )
+        tensor_space.add_tensor_dim(
+            CompositeTensorDim(TransformerDimNames.composite_key_value, (key_and_value, head_groups, kv_channels))
+        )
+        tensor_space.add_tensor_dim(
+            CompositeTensorDim(TransformerDimNames.composite_dense, (head_groups, group_heads, kv_channels))
+        )
+
+        # MLP dimensions
+        tensor_space.add_tensor_dim(mlp := TensorDim(TransformerDimNames.mlp, self.ffn_hidden_size, tensor))
+        tensor_space.add_tensor_dim(gate_and_up := TensorDim(TransformerDimNames.gate_and_up, 2 if self.gated else 1))
+        tensor_space.add_tensor_dim(CompositeTensorDim(TransformerDimNames.composite_gated_mlp, (gate_and_up, mlp)))
+        tensor_space.add_tensor_dim(experts := TensorDim(TransformerDimNames.experts, self.num_experts))
+        tensor_space.add_tensor_dim(CompositeTensorDim(TransformerDimNames.composite_expert_mlp, (experts, mlp)))
+        tensor_space.add_tensor_dim(
+            CompositeTensorDim(TransformerDimNames.composite_gated_expert_mlp, (experts, gate_and_up, mlp))
+        )
+        tensor_space.add_tensor_dim(TensorDim(TransformerDimNames.top_experts, self.num_experts_per_token))
+        tensor_space.add_tensor_dim(TensorDim(TransformerDimNames.unshared_experts, self.num_unshared_experts))
+
+        # shared_experts
+        if self.num_shared_experts:
+            tensor_space.add_tensor_dim(
+                shared_experts := TensorDim(TransformerDimNames.shared_experts, self.num_shared_experts)
+            )
+            tensor_space.add_tensor_dim(
+                CompositeTensorDim(TransformerDimNames.composite_shared_expert_mlp, (shared_experts, mlp))
+            )
+            tensor_space.add_tensor_dim(
+                CompositeTensorDim(
+                    TransformerDimNames.composite_gated_shared_expert_mlp, (shared_experts, gate_and_up, mlp)
+                )
+            )
 
     def do_use_flash_attention(self, distributed_config: DistributedConfig) -> bool:
         use_flash_attention = self.use_flash_attention and distributed_config.training_dtype in (

--- a/fast_llm/layers/transformer/config.py
+++ b/fast_llm/layers/transformer/config.py
@@ -257,8 +257,8 @@ class TransformerConfig(BaseModelConfig):
         desc="Configuration for the rotary positional embeddings.",
         hint=FieldHint.architecture,
     )
-    peft: PeftConfig = Field(
-        default_factory=PeftConfig,
+    peft: TransformerPeftConfig = Field(
+        default_factory=TransformerPeftConfig,
         desc="Configuration for the parameter-efficient fine tuning.",
         hint=FieldHint.architecture,
     )
@@ -291,12 +291,6 @@ class TransformerConfig(BaseModelConfig):
         default=None,
         desc="Hidden dimension of the MLP intermediate state. Default: 4 * hidden_size.",
         hint=FieldHint.architecture,
-        valid=check_field(Assert.gt, 0),
-    )
-    projection_size: int = Field(
-        init=False,
-        desc="Hidden dimension of the attention projection (= num_attention_heads * kv_channels).",
-        hint=FieldHint.derived,
         valid=check_field(Assert.gt, 0),
     )
     kv_channels: int = Field(

--- a/fast_llm/layers/transformer/transformer.py
+++ b/fast_llm/layers/transformer/transformer.py
@@ -23,7 +23,6 @@ class BaseBlock(Layer, abc.ABC):
     A transformer-like decoder base block block with abstract mixer.
     """
 
-    name = "Transformer layer"
     _mixer_module_name = "self_attn"
 
     def __init__(
@@ -137,7 +136,7 @@ class BaseBlock(Layer, abc.ABC):
 
 
 class TransformerLayer(BaseBlock):
-    name = "Transformer layer"
+    _name = "Transformer layer"
     _mixer_module_name = "self_attn"
 
     def __init__(

--- a/fast_llm/models/custom/config.py
+++ b/fast_llm/models/custom/config.py
@@ -2,13 +2,7 @@ import typing
 
 from fast_llm.config import FieldUpdate, config_class
 from fast_llm.data.data.gpt.config import GPTDataConfig
-from fast_llm.models.gpt.config import (
-    GPTArchitectureConfig,
-    GPTBaseModelConfig,
-    GPTModelConfig,
-    GPTTrainerConfig,
-    PretrainedGPTModelConfig,
-)
+from fast_llm.models.gpt.config import GPTBaseModelConfig, GPTModelConfig, GPTTrainerConfig, PretrainedGPTModelConfig
 
 if typing.TYPE_CHECKING:
     from fast_llm.models.custom.huggingface import HuggingfaceCustomModelForCausalLM
@@ -23,15 +17,9 @@ class CustomDataConfig(GPTDataConfig):
 
 
 @config_class()
-class CustomArchitectureConfig(GPTArchitectureConfig):
-    # TODO: Add custom base model architecture config parameters, if any.
-    pass
-
-
-@config_class()
-class CustomBaseModelConfig(GPTBaseModelConfig, CustomArchitectureConfig):
+class CustomBaseModelConfig(GPTBaseModelConfig):
     # TODO: Add custom other base model config parameters, if any.
-    architecture_class = CustomArchitectureConfig
+    pass
 
 
 @config_class()

--- a/fast_llm/models/gpt/conversion.py
+++ b/fast_llm/models/gpt/conversion.py
@@ -28,7 +28,7 @@ from fast_llm.functional.rotary import convert_rotary_complex_to_real, convert_r
 from fast_llm.layers.common.config import NormalizationType
 from fast_llm.layers.transformer.config import RotaryEmbeddingType, RoutingType, TransformerConfig
 from fast_llm.models.gpt.config import (
-    GPTArchitectureConfig,
+    GPTBaseModelConfig,
     GPTModelConfig,
     LlamaGPTHuggingfaceCheckpointFormat,
     MistralGPTHuggingfaceCheckpointFormat,
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 
 class QueryWeightConverter(WeightConverter):
     # Hf uses the real format for rotary embeddings.
-    _config: GPTArchitectureConfig
+    _config: GPTBaseModelConfig
 
     def export_weight(
         self, weight: tuple[torch.Tensor | SafeTensorSlice, ...]
@@ -71,7 +71,7 @@ class QueryWeightConverter(WeightConverter):
 
 class KeyValueWeightConverter(WeightConverter):
     # Hf uses the real format for rotary embeddings, and keeps the key and value separate.
-    _config: GPTArchitectureConfig
+    _config: GPTBaseModelConfig
 
     def export_weight(
         self, weight: tuple[torch.Tensor | SafeTensorSlice, ...]
@@ -95,7 +95,7 @@ class KeyValueWeightConverter(WeightConverter):
 class MLPLayer2Converter(WeightConverter):
     # Similar to SplitWeightConverter, but handles the optional MLP transpose.
     # Still ok for non-gated (trivial split) and biases (trivial 1d transpose)
-    _config: GPTArchitectureConfig
+    _config: GPTBaseModelConfig
 
     def export_weight(
         self, weight: tuple[torch.Tensor | SafeTensorSlice, ...]

--- a/fast_llm/models/ssm/config.py
+++ b/fast_llm/models/ssm/config.py
@@ -8,32 +8,31 @@ from fast_llm.engine.checkpoint.config import CheckpointFormat, CheckpointHandle
 from fast_llm.engine.config_utils.tensor_space import TensorDim, TensorSpace
 from fast_llm.engine.multi_stage.config import FastLLMModelConfig, PretrainedFastLLMModelConfig
 from fast_llm.engine.training.config import TrainerConfig
-from fast_llm.layers.language_model.config import LanguageModelArchitectureConfig, LanguageModelBaseConfig
-from fast_llm.layers.ssm.config import SSMDimNames
+from fast_llm.layers.language_model.config import LanguageModelBaseConfig
+from fast_llm.layers.ssm.config import SSMConfig, SSMDimNames
 from fast_llm.models.gpt.config import GPTBatchConfig
 from fast_llm.utils import Assert
 
 if typing.TYPE_CHECKING:
+    from fast_llm.models.ssm.huggingface import HuggingfaceHybridSSMModelForCausalLM
     from fast_llm.models.ssm.model import HybridSSMModel
+    from fast_llm.models.ssm.trainer import SSMTrainer
 
 logger = logging.getLogger(__name__)
 
 
-@config_class
-class HybridSSMArchitectureConfig(LanguageModelArchitectureConfig):
-    _abstract = False
-
+@config_class()
+class HybridSSMBaseModelConfig(LanguageModelBaseConfig):
+    ssm: SSMConfig = Field(
+        default_factory=SSMConfig,
+        desc="Configuration for the transformer architecture.",
+        hint=FieldHint.architecture,
+    )
     hybrid_block_layout: list[str] = Field(
         default_factory=lambda: ["m2"],
         desc="Pattern of blocks to use in the model. 't' for Transformer, 'm' for Mamba1, 'm2' for Descrete Mamba2.",
-        hint=FieldHint.core,
+        hint=FieldHint.architecture,
     )
-
-
-@config_class()
-class HybridSSMBaseModelConfig(LanguageModelBaseConfig, HybridSSMArchitectureConfig):
-    architecture_class = HybridSSMArchitectureConfig
-
     use_megatron_initialization: bool = Field(
         default=False, desc="Exactly match the initialization of a Megatron model.", hint=FieldHint.testing
     )  # TODO: is this needed?

--- a/fast_llm/models/ssm/config.py
+++ b/fast_llm/models/ssm/config.py
@@ -23,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 @config_class()
 class HybridSSMBaseModelConfig(LanguageModelBaseConfig):
+    _abstract = False
+
     ssm: SSMConfig = Field(
         default_factory=SSMConfig,
         desc="Configuration for the transformer architecture.",

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -251,7 +251,7 @@ def _compare_model_configs(config_ref: FastLLMModelConfig, config_test: FastLLMM
 
 
 def _compare_architectures(config_ref: FastLLMModelConfig, config_test: FastLLMModelConfig):
-    config_ref.base_model.get_architecture().compare(config_test.base_model.get_architecture())
+    config_ref.base_model.compare_architecture(config_test.base_model)
 
 
 @pytest.mark.depends(on=["test_converted_distributed"])

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -35,7 +35,6 @@ TEST_MODEL_CONFIG_CLS = model_registry[TEST_MODEL_TYPE]
 TEST_MODEL_HF_CLS = TEST_MODEL_CONFIG_CLS.get_huggingface_model_class()
 TEST_MODEL_CLS = TEST_MODEL_CONFIG_CLS.get_model_class()
 TEST_BASE_MODEL_CONFIG_CLS = TEST_MODEL_CONFIG_CLS.get_base_model_config_class()
-TEST_ARCHITECTURE_CONFIG_CLS = TEST_BASE_MODEL_CONFIG_CLS.architecture_class
 
 WEIGHT_SHARD_SAVE_NAME = f"{ShardName.weights}_shard"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ from fast_llm.data.dataset.gpt.config import GPTSamplingConfig
 from fast_llm.engine.checkpoint.config import CheckpointSaveMetadataConfig, ModelConfigType
 from fast_llm.engine.config_utils.data_type import DataType
 from fast_llm.engine.distributed.config import DistributedConfig
-from fast_llm.layers.transformer.config import AddLinearBiasChoices, TransformerArchitectureConfig, TransformerConfig
+from fast_llm.layers.transformer.config import TransformerConfig
 from fast_llm.models.auto import trainer_registry
 from fast_llm.models.gpt.config import GPTModelConfig, PretrainedGPTModelConfig
 from fast_llm.utils import Assert, check_equal_nested
@@ -90,35 +90,6 @@ def test_do_use_flash_attention():
         config.do_use_flash_attention(mock_distributed_config)
 
 
-def test_add_mlp_bias():
-    assert TransformerArchitectureConfig(add_linear_biases=True).add_mlp_bias is True
-    assert TransformerArchitectureConfig(add_linear_biases=False).add_mlp_bias is False
-    assert TransformerArchitectureConfig(add_linear_biases=AddLinearBiasChoices.everywhere).add_mlp_bias is True
-    assert TransformerArchitectureConfig(add_linear_biases=AddLinearBiasChoices.nowhere).add_mlp_bias is False
-    assert TransformerArchitectureConfig(add_linear_biases=AddLinearBiasChoices.only_attn_qkv).add_mlp_bias is False
-
-
-def test_add_attn_qkv_bias():
-    assert TransformerArchitectureConfig(add_linear_biases=True).add_attn_qkv_bias is True
-    assert TransformerArchitectureConfig(add_linear_biases=False).add_attn_qkv_bias is False
-    assert TransformerArchitectureConfig(add_linear_biases=AddLinearBiasChoices.everywhere).add_attn_qkv_bias is True
-    assert TransformerArchitectureConfig(add_linear_biases=AddLinearBiasChoices.nowhere).add_attn_qkv_bias is False
-    assert (
-        TransformerArchitectureConfig(add_linear_biases=AddLinearBiasChoices.only_attn_qkv).add_attn_qkv_bias is True
-    )
-
-
-def test_add_attn_dense_bias():
-    assert TransformerArchitectureConfig(add_linear_biases=True).add_attn_dense_bias is True
-    assert TransformerArchitectureConfig(add_linear_biases=False).add_attn_dense_bias is False
-    assert TransformerArchitectureConfig(add_linear_biases=AddLinearBiasChoices.everywhere).add_attn_dense_bias is True
-    assert TransformerArchitectureConfig(add_linear_biases=AddLinearBiasChoices.nowhere).add_attn_dense_bias is False
-    assert (
-        TransformerArchitectureConfig(add_linear_biases=AddLinearBiasChoices.only_attn_qkv).add_attn_dense_bias
-        is False
-    )
-
-
 @pytest.mark.parametrize(
     ("cls", "default"),
     ((GPTSamplingConfig, {}), (GPTModelConfig, {"distributed": {"world_size": 1, "rank": 0, "local_world_size": 1}})),
@@ -145,7 +116,6 @@ def test_pretrained_config(load_config: ModelConfigType):
                     "activation_type": "silu",  # Implicit default, non-default value
                     "head_groups": 4,
                 },
-                "ssm": {"dt_rank": -1, "activation_type": "silu"},
                 "tie_word_embeddings": False,
             },
             "multi_stage": {"zero_stage": 3},
@@ -166,7 +136,6 @@ def test_pretrained_config(load_config: ModelConfigType):
             "hidden_size": 512,  # Override, affects derived value (kv channels)
             "head_groups": 1,  # Override to default
         },
-        "ssm": {"dt_rank": 10, "activation_type": "silu"},
         "vocab_size": 1000,
     }
     pretrained_config = PretrainedGPTModelConfig.from_dict(
@@ -198,7 +167,6 @@ def test_pretrained_config(load_config: ModelConfigType):
                 "head_groups": 1,
                 "window_size": 32,
             },
-            "ssm": {"dt_rank": 10, "activation_type": "silu"},
             "tie_word_embeddings": False,
             "vocab_size": 1000,
         }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,7 +185,7 @@ def test_pretrained_config(load_config: ModelConfigType):
     if load_config == ModelConfigType.fast_llm:
         expected_config["multi_stage"] = {"zero_stage": 3}
     expected_config["distributed"].update({"seed": 1234, "training_dtype": "float16"})
-    if load_config in (ModelConfigType.architecture, ModelConfigType.fast_llm, ModelConfigType.model):
+    if load_config in (ModelConfigType.fast_llm, ModelConfigType.model):
         expected_config["base_model"] = {
             "transformer": {
                 "normalization": {"type": "rms_norm", "implementation": "triton"},
@@ -196,13 +196,12 @@ def test_pretrained_config(load_config: ModelConfigType):
                 "ffn_hidden_size": 4096,
                 "activation_type": "silu",
                 "head_groups": 1,
+                "window_size": 32,
             },
             "ssm": {"dt_rank": 10, "activation_type": "silu"},
             "tie_word_embeddings": False,
             "vocab_size": 1000,
         }
-        if load_config != ModelConfigType.architecture:
-            expected_config["base_model"]["transformer"]["window_size"] = 32
     else:
         expected_config["base_model"] = base_model_update
 


### PR DESCRIPTION
# ✨ Description

Fix: #237

Remove the class-based split between architecture and non-architecture parameters. 
Use a special field hint to mark the architecture parameters instead. (Not ideal but much simpler than alternatives). 
The "architecture" load_config mode has been removed, the new default is the whole model. This implies a potential breaking change for configs that loaded distributed or fast-llm checkpoints. Added a warning to mitigate.

Also fix a few bugs, issues and failing tests in main.

## 🔍 Type of change

Select all that apply:

- [ ] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [ ] 🚀 **New feature** (non-breaking change that adds functionality)
- [x] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [x] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)
