### PR TITLE
Save and quit on sigint and sigterm

### DIFF
--- a/fast_llm/engine/training/trainer.py
+++ b/fast_llm/engine/training/trainer.py
@@ -9,7 +9,7 @@ import typing
 import torch
 
 from fast_llm.config import Configurable
-from fast_llm.core.distributed import safe_barrier
+from fast_llm.core.distributed import allreduce_scalar, safe_barrier
 from fast_llm.data.data.abstract import Data
 from fast_llm.data.dataset.config import SamplingParameters
 from fast_llm.engine.config_utils.run import Run, is_main_rank, log_main_rank, log_pipeline_parallel_main_rank
@@ -23,7 +23,7 @@ from fast_llm.engine.schedule.schedule import Schedule
 from fast_llm.engine.training.config import TrainerConfig, TrainingCheckpointBaseConfig, TrainingCheckpointConfig
 from fast_llm.engine.training.wandb import Wandb
 from fast_llm.logging import format_metrics, get_memory_usage_mib, log_memory_usage
-from fast_llm.utils import Assert
+from fast_llm.utils import Assert, Interrupter
 
 logger = logging.getLogger(__name__)
 
@@ -214,6 +214,7 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
             distributed_config=self._config.model.distributed, start_step=self._completed_steps
         )
 
+        interrupter = Interrupter(self._config.training.checkpoint.enabled())
         train_iterator = self._get_data_iterator(
             PhaseType.training.value,
             self._completed_steps,
@@ -231,7 +232,7 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
         start_iteration = self._completed_steps
         last_iteration = start_iteration
         stop = False
-        with profiler:
+        with profiler, interrupter:
             while not stop:
                 # Iteration starts at 1, so we increment at the beginning.
                 self._completed_steps += 1
@@ -317,8 +318,14 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
                 profiler.step()
 
                 done = self._completed_steps >= self._config.training.train_iters
-                # TODO: Signal-based stop.
+
                 stop = done or self._config.training.shutdown.enabled(self._completed_steps)
+
+                if interrupter.enabled:
+                    stop = stop or allreduce_scalar(
+                        interrupter.interrupted, torch.int32, self._distributed.world_group
+                    )
+
                 # Evaluation
                 # TODO: Adjust valid iterator length.
                 if PhaseType.validation in self._samples_per_split and (

--- a/fast_llm/utils.py
+++ b/fast_llm/utils.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
 import math
+import signal
 import typing
 from typing import Callable
 
@@ -336,3 +337,34 @@ def compare_nested(config_a, config_b, errors: list | None = None, prefix: tuple
 def check_equal_nested(config_a, config_b):
     if errors := compare_nested(config_a, config_b):
         raise ValueError("\n".join(errors))
+
+
+class Interrupter:
+    def __init__(self, enabled: bool = True, signals: typing.Sequence[int] = (signal.SIGINT, signal.SIGKILL)):
+        self._enabled = enabled
+        self._signals = signals
+
+    def __enter__(self):
+        self._old_signals = (
+            {signum: signal.signal(signum, self._handle_signal) for signum in self._signals} if self._enabled else {}
+        )
+        self._interrupted = False
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for signum, handler in self._old_signals.items():
+            signal.signal(signum, handler)
+
+    def _handle_signal(self, signum, frame):
+        logger.info(f"Interrupt signal {signum} received.")
+        if self._interrupted:
+            # Raise for a repeated signal, ex. if a user really wants to ctrl-C.
+            self._old_signals[signum](signum, frame)
+        self._interrupted = True
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def interrupted(self):
+        return self._interrupted

--- a/fast_llm/utils.py
+++ b/fast_llm/utils.py
@@ -340,22 +340,22 @@ def check_equal_nested(config_a, config_b):
 
 
 class Interrupter:
-    def __init__(self, enabled: bool = True, signals: typing.Sequence[int] = (signal.SIGINT, signal.SIGKILL)):
+    def __init__(self, enabled: bool = True, signals: typing.Sequence[int] = (signal.SIGINT, signal.SIGTERM)):
         self._enabled = enabled
         self._signals = signals
 
     def __enter__(self):
+        self._interrupted = False
         self._old_signals = (
             {signum: signal.signal(signum, self._handle_signal) for signum in self._signals} if self._enabled else {}
         )
-        self._interrupted = False
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         for signum, handler in self._old_signals.items():
             signal.signal(signum, handler)
 
     def _handle_signal(self, signum, frame):
-        logger.info(f"Interrupt signal {signum} received.")
+        logger.info(f"Interrupt signal {signal.Signals(signum).name} received.")
         if self._interrupted:
             # Raise for a repeated signal, ex. if a user really wants to ctrl-C.
             self._old_signals[signum](signum, frame)

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -129,6 +129,7 @@ def test_transformer_mtp(config_dict: dict[str, typing.Any]):
     loss.backward()
 
 
+@pytest.mark.skip(reason="Too slow")
 @requires_cuda
 @pytest.mark.skipif(not run_hybrid_test, reason="No CUDA available or Mamba not installed")
 @pytest.mark.parametrize(


### PR DESCRIPTION
# ✨ Description

Add a signal handler for training that catches interrupts. When a signal is received, the trainer finishes the current batch, then  saves a checkpoint and stops gracefully.

This should be usually enough to save and quit within the allotted time, with some exceptions:
* The validation phase is not interrupted, so a batch with validation may not have time to save. Addressing this would require saving a validation state so we can resume mid-validation.
* Exports may take a while, so a batch with export may not have time to save.

Nevertheless, this PR is an improvement and should be good enough for #241.

## 🔍 Type of change

Select all that apply:

- [ ] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [x] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)
