### PR TITLE
[build] Extract package version from __init__.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [metadata]
 name = fast_llm
-# TODO: Take from __init__.py instead?
-version = 0.2.0
+# Version is now read from fast_llm/__init__.py via setup.py
 
 [options]
 packages = find_namespace:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = fast_llm
-# Version is now read from fast_llm/__init__.py via setup.py
 
 [options]
 packages = find_namespace:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import sys
 import re
-from pathlib import Path
+import pathlib
 
 try:
     import pybind11
@@ -20,7 +20,7 @@ if setuptools.__version__ < _SETUPTOOLS_MIN_VERSION:
 
 def get_version():
     """Read version from fast_llm/__init__.py"""
-    init_file = Path(__file__).parent.joinpath("fast_llm", "__init__.py").read_text()
+    init_file = pathlib.Path(__file__).parent.joinpath("fast_llm", "__init__.py").read_text()
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", init_file, re.M)
     if version_match:
         return version_match.group(1)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 import sys
+import re
+from pathlib import Path
 
 try:
     import pybind11
@@ -16,6 +18,14 @@ if setuptools.__version__ < _SETUPTOOLS_MIN_VERSION:
     print(f"Error: setuptools version {_SETUPTOOLS_MIN_VERSION} " "or greater is required")
     sys.exit(1)
 
+def get_version():
+    """Read version from fast_llm/__init__.py"""
+    init_file = Path(__file__).parent.joinpath("fast_llm", "__init__.py").read_text()
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", init_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string in fast_llm/__init__.py")
+
 cpp_extension = setuptools.Extension(
     "fast_llm.csrc.data",
     sources=["fast_llm/csrc/data.cpp"],
@@ -27,4 +37,5 @@ cpp_extension = setuptools.Extension(
 
 setuptools.setup(
     ext_modules=[cpp_extension],
+    version=get_version(),
 )


### PR DESCRIPTION
# ✨ Description

This PR implements a clean solution for the TODO in `setup.cfg` by extracting the version from `fast_llm/__init__.py` using **regex**. Now, the version is defined in just one place, making it easier to maintain and ensuring the package metadata always matches the actual code version.

## 🔍 Type of change

Select all that apply:

- [ ] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [ ] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [x] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [x] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)

## 📝 Changes

List the key changes introduced in this PR:

1. Added a `get_version()` function to setup.py that uses regex to extract the version from `fast_llm/__init__.py`
2. Modified setup.py to pass the extracted version to setuptools.setup()
3. Removed the hardcoded version from setup.cfg and added a comment explaining the version is now read from `fast_llm/__init__.py`
4. This change addresses the TODO comment in setup.cfg: 
- > `# TODO: Take from __init__.py instead?`

## ✅ Checklist

Make sure the following tasks are completed before submitting the PR:

### General

- [x] 📜 I have read and followed the [contributing guidelines](https://servicenow.github.io/Fast-LLM/contributing/contributing).
- [x] 🏷️ I am using a clear and descriptive PR title that summarizes the key change or feature introduced.
- [x] 🎉 The functionality is complete, and I have tested the changes.
- [x] 📝 I have updated the documentation if needed.
- [x] ⚠️ The change does not introduce any new issues (e.g., runtime warnings, type checker errors, linting problems, unhandled edge cases).
- [x] 🧩 I have commented my code, especially in hard-to-understand areas.

### Testing

- [x] ✔️ New and existing tests pass locally with my changes.

### Performance Impact

- [x] ✅ No performance impact (build process changes only)

---

## 🗒️ Additional Notes

The implementation uses a standard approach to version extraction via regex which is widely used.

Chose regex for simplicity; setuptools-scm could be added later if git-based versioning is needed.

Verified with `python setup.py --version`