### PR TITLE
data preparation timeout

### DIFF
--- a/fast_llm/data/preparator/gpt_memmap/config.py
+++ b/fast_llm/data/preparator/gpt_memmap/config.py
@@ -147,7 +147,7 @@ class DatasetPreparatorDistributedConfig(Config):
         desc="Distributed backend to use.",
         hint=FieldHint.optional,
     )
-    timeout_seconds: int = Field(
+    timeout: int = Field(
         default=3600,
         desc="Timeout in seconds for torch distributed operations. Default is 3600.",
         hint=FieldHint.optional,

--- a/fast_llm/data/preparator/gpt_memmap/prepare.py
+++ b/fast_llm/data/preparator/gpt_memmap/prepare.py
@@ -143,7 +143,7 @@ class GPTMemmapDatasetPreparator[ConfigType: GPTMemmapDatasetPreparatorConfig](D
                 backend=self._config.distributed.backend,
                 rank=self._config.distributed.rank,
                 world_size=self._config.distributed.world_size,
-                timeout=datetime.timedelta(seconds=self._config.distributed.timeout_seconds),
+                timeout=datetime.timedelta(seconds=self._config.distributed.timeout),
             )
 
         # Prepare output directory


### PR DESCRIPTION
# ✨ Description

Increase torch distributed timeout in data preparation and make it configurable.
Useful for datasets where some shards take significantly longer to prepare
