### PR TITLE
Reverse kl manual gradients

### DIFF
--- a/fast_llm/functional/cross_entropy.py
+++ b/fast_llm/functional/cross_entropy.py
@@ -288,6 +288,7 @@ def _reverse_kl_forward_backward(
         loss /= valid_tokens
 
         if grad_output is not None:
+            # need to calculate gradient manually, backprop through all reduce can be problematic, see https://github.com/pytorch/pytorch/issues/58005
             log_ratio = student_log_probs - teacher_log_probs
             expected = torch.sum(torch.exp(student_log_probs) * log_ratio, dim=-1, keepdim=True)
             grad_base = torch.exp(student_log_probs) * (log_ratio - expected)

--- a/fast_llm/functional/cross_entropy.py
+++ b/fast_llm/functional/cross_entropy.py
@@ -58,13 +58,11 @@ def _fused_softmax_base(
         logits *= logits_scale_factor
     logits_max = torch.max(logits, dim=dim, keepdim=True)[0]
     if group is not None:
-        # Use autograd-aware all_reduce with correct gradient behavior
         all_reduce(logits_max, op=ReduceOp.MAX, group=group)
     logits_norm = (logits - logits_max).float()
     exp_logits = logits_norm.exp()
     sum_exp_logits = exp_logits.sum(dim=dim, keepdim=True)
     if group is not None:
-        # Use autograd-aware all_reduce with correct gradient behavior
         all_reduce(sum_exp_logits, op=ReduceOp.SUM, group=group)
     return logits_norm, exp_logits, sum_exp_logits
 


### PR DESCRIPTION
# ✨ Description

Back-propagation through all reduce is problematic, see https://github.com/pytorch/pytorch/issues/58005.

We need to manually calculate the reverse KL gradients. 

## 🔍 Type of change

Select all that apply:

- [x] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [ ] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)

## 📝 Changes

Manual gradient calculation for reverse KL.

## ✅ Checklist

Make sure the following tasks are completed before submitting the PR:

### General

- [x] 📜 I have read and followed the [contributing guidelines](https://servicenow.github.io/Fast-LLM/contributing/contributing).
- [ ] 🏷️ I am using a clear and descriptive PR title that summarizes the key change or feature introduced.
- [ ] 🎉 The functionality is complete, and I have tested the changes.
- [ ] 📝 I have updated the documentation if needed.
- [ ] ⚠️ The change does not introduce any new issues (e.g., runtime warnings, type checker errors, linting problems, unhandled edge cases).
- [ ] 🧩 I have commented my code, especially in hard-to-understand areas.

### Dependencies and Configuration

- [ ] 🐋 I have updated the Docker configuration or dependencies, if applicable.
- [ ] 🔄 I have ensured compatibility with the existing setup after dependency changes.

### Testing

- [x] 🧪 I have added or updated tests to cover my changes.
- [ ] ✔️ New and existing tests pass locally with my changes.
- [ ] 🚦 I have tested these changes on GPUs and verified training stability.
- [ ] 🏋️ I have tested the changes on realistic training workloads, if applicable.

### Performance Impact

- [ ] 📊 I have run benchmarks where applicable to evaluate the performance impact.
- [ ] ✅ The benchmarks show no performance regression.
- [ ] 🚀 The benchmarks indicate a potential performance improvement.
- [ ] ⚠️ The benchmarks indicate a potential performance degradation.
- [ ] 📈 I have provided benchmark results and detailed any performance impact below, if applicable.

## 📊 Performance Impact Details

If there is any impact on performance, describe it and provide benchmark results, if applicable:

---

## 🗒️ Additional Notes

Include any additional context, information, or considerations here, such as known issues, follow-up tasks, or backward compatibility concerns.
