### PR TITLE
Fix backward compat for dataset config format

### DIFF
--- a/fast_llm/data/dataset/gpt/config.py
+++ b/fast_llm/data/dataset/gpt/config.py
@@ -65,7 +65,6 @@ class GPTDatasetFromFileConfig[SampleType: LanguageModelSample](SamplableDataset
     def _load_config(self) -> SampledDatasetConfig[SampleType]:
         assert self.path.is_file(), f"File {self.path} does not exist."
         config = yaml.safe_load(self.path.open("r"))
-        Assert.eq(config.keys(), {"config", "metadata"})
         if config.keys() == {"config", "metadata"}:
             # Newer format with metadata
             config = config["config"]


### PR DESCRIPTION
## Summary
- Remove assertion that requires new `{config, metadata}` format for dataset configs
- Allows old dataset configs (without metadata wrapper) to continue working

The assertion was breaking existing dataset configs that don't use the new format.

## Test plan
- [x] Verified old dataset configs load without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)