### PR TITLE
Distributed load padding correction

### DIFF
--- a/fast_llm/engine/multi_stage/fsdp.py
+++ b/fast_llm/engine/multi_stage/fsdp.py
@@ -270,7 +270,9 @@ class FSDP:
         # Also ensures a correct parameter count in loading context.
         shard_meta = self._weight_shard_meta if shard_name == ShardName.weights else self._grad_shard_meta
         shard_meta.validate(shard)
-        if self._shard_pad > 0:
+        # Only count padding for non-empty shards. Frozen FSDPs have empty optimizer shards
+        # (numel()==0) but non-zero shard_pad, which would incorrectly inflate the count.
+        if self._shard_pad > 0 and shard.numel() > 0:
             shard[-self._shard_pad :].zero_()
             return self._shard_pad
         return 0


### PR DESCRIPTION
# ✨ Description
When loading a distributed checkpoint with frozen weights using a DP count that is different from thew one used to create this checkpoint (e.g. on less nodes) it can happen that some optimiser shards are empty. 

In the current implementation the padding from this shards will still count towards `self._loaded` in `SafeLoad`, but it should not.

## 🔍 Type of change

Select all that apply:

- [x] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [ ] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)

## 📝 Changes

`reset_shard_pad` returns 0 for empty shards.

## ✅ Checklist

Make sure the following tasks are completed before submitting the PR:

### General

- [ ] 📜 I have read and followed the [contributing guidelines](https://servicenow.github.io/Fast-LLM/contributing/contributing).
- [ ] 🏷️ I am using a clear and descriptive PR title that summarizes the key change or feature introduced.
- [ ] 🎉 The functionality is complete, and I have tested the changes.
- [ ] 📝 I have updated the documentation if needed.
- [ ] ⚠️ The change does not introduce any new issues (e.g., runtime warnings, type checker errors, linting problems, unhandled edge cases).
- [ ] 🧩 I have commented my code, especially in hard-to-understand areas.

### Dependencies and Configuration

- [ ] 🐋 I have updated the Docker configuration or dependencies, if applicable.
- [ ] 🔄 I have ensured compatibility with the existing setup after dependency changes.

### Testing

- [ ] 🧪 I have added or updated tests to cover my changes.
- [ ] ✔️ New and existing tests pass locally with my changes.
- [ ] 🚦 I have tested these changes on GPUs and verified training stability.
- [ ] 🏋️ I have tested the changes on realistic training workloads, if applicable.

### Performance Impact

- [ ] 📊 I have run benchmarks where applicable to evaluate the performance impact.
- [ ] ✅ The benchmarks show no performance regression.
- [ ] 🚀 The benchmarks indicate a potential performance improvement.
- [ ] ⚠️ The benchmarks indicate a potential performance degradation.
- [ ] 📈 I have provided benchmark results and detailed any performance impact below, if applicable.

## 📊 Performance Impact Details

If there is any impact on performance, describe it and provide benchmark results, if applicable:

---

## 🗒️ Additional Notes

Include any additional context, information, or considerations here, such as known issues, follow-up tasks, or backward compatibility concerns.
