### PR TITLE
Fix dict ordering

### DIFF
--- a/fast_llm/config.py
+++ b/fast_llm/config.py
@@ -555,9 +555,9 @@ class Config(metaclass=ConfigMeta):
         errors = []
         new_value = {}
         old_keys = {}
-        for key, value_ in value.items():
+        for key in sorted(value):
             new_key = cls._validate_nested(key, args[0], f"{name}(key {key})", None, errors, True)
-            new_value_ = cls._validate_nested(value_, args[1], f"{name}[{key}]", None, errors, True)
+            new_value_ = cls._validate_nested(value[key], args[1], f"{name}[{key}]", None, errors, True)
             if key in new_value:
                 errors.append(f"Duplicate key `{new_key}` after validation (from `{old_keys[new_key]}`, `{key}`)")
             old_keys[new_key] = key

--- a/fast_llm/config.py
+++ b/fast_llm/config.py
@@ -555,13 +555,15 @@ class Config(metaclass=ConfigMeta):
         errors = []
         new_value = {}
         old_keys = {}
-        for key in sorted(value):
+        for key, value_ in value.items():
             new_key = cls._validate_nested(key, args[0], f"{name}(key {key})", None, errors, True)
-            new_value_ = cls._validate_nested(value[key], args[1], f"{name}[{key}]", None, errors, True)
+            new_value_ = cls._validate_nested(value_, args[1], f"{name}[{key}]", None, errors, True)
             if key in new_value:
                 errors.append(f"Duplicate key `{new_key}` after validation (from `{old_keys[new_key]}`, `{key}`)")
             old_keys[new_key] = key
             new_value[new_key] = new_value_
+        # Ensure dicts are sorted W.R.T validated keys.
+        new_value = {new_key: new_value[new_key] for new_key in sorted(new_value)}
         if errors:
             raise ValidationError(*errors)
         return new_value

--- a/tests/config/common.py
+++ b/tests/config/common.py
@@ -31,7 +31,7 @@ class ExampleConfig(Config):
     type_field: type[int] = Field(default=int, hint=FieldHint.optional)
     enum_field: ExampleEnum = Field(default=ExampleEnum.a, hint=FieldHint.optional)
     core_field: int = Field(default=4, hint=FieldHint.core)
-    complex_field: dict[str | int, list[tuple[str, int]] | None] = Field(default_factory=dict, hint=FieldHint.optional)
+    complex_field: dict[str, list[tuple[str, int]] | None] = Field(default_factory=dict, hint=FieldHint.optional)
 
     def _validate(self) -> None:
         with self._set_implicit_default():

--- a/tests/config/test_field.py
+++ b/tests/config/test_field.py
@@ -184,8 +184,8 @@ def test_core_field():
     "value",
     (
         {},
-        {3: None, "text": [], 0: [["", 3], ["a", -7]]},
-        {0: [[".", 8]]},
+        {"3": None, "text": [], "0": [["", 3], ["a", -7]]},
+        {"0": [[".", 8]]},
     ),
 )
 def test_complex_field(value):
@@ -194,7 +194,7 @@ def test_complex_field(value):
 
 @pytest.mark.parametrize(
     "value",
-    ({3: None, "text": [], False: [["", 3], ["a", -7]]},),
+    ({"3": None, "text": [], False: [["", 3], ["a", -7]]},),
 )
 def test_complex_field_invalid(value):
     check_invalid_config({"complex_field": value})

--- a/tests/layers/test_lm_head.py
+++ b/tests/layers/test_lm_head.py
@@ -117,7 +117,7 @@ class LMHeadTestConfig:
                 device=device,
             )
             if LanguageModelKwargs.loss_mask in kwargs:
-                labels = torch.where(kwargs[LanguageModelKwargs.loss_mask], -100, labels)
+                labels = torch.where(kwargs[LanguageModelKwargs.loss_mask], labels, -100)
             kwargs[LanguageModelKwargs.labels] = labels
 
         if self.distillation_loss is not False:


### PR DESCRIPTION
Fix: #455 

Ensure dicts in configs are internally stored in alphabetical order to prevent subtle ordering issues.