### PR TITLE
Sample full layouts instead of independent per layer mixer sampling

### DIFF
--- a/fast_llm/layers/block/config.py
+++ b/fast_llm/layers/block/config.py
@@ -46,6 +46,7 @@ class BlockKwargs:
     hidden_states = "hidden_states"
     output_hidden_states = "output_hidden_states"
     activation_mask = "activation_mask"
+    num_blocks_in_sequence = "num_blocks_in_sequence"
 
 
 @config_class(registry=True)

--- a/fast_llm/layers/block/sequence.py
+++ b/fast_llm/layers/block/sequence.py
@@ -9,7 +9,7 @@ from fast_llm.engine.base_model.config import LossDef
 from fast_llm.engine.config_utils.tensor_dim import TensorDim
 from fast_llm.engine.distributed.config import DistributedConfig
 from fast_llm.layers.block.block import BlockBase
-from fast_llm.layers.block.config import FixedBlockSequenceConfig, PatternBlockSequenceConfig
+from fast_llm.layers.block.config import BlockKwargs, FixedBlockSequenceConfig, PatternBlockSequenceConfig
 from fast_llm.layers.common.peft.config import PeftConfig
 
 
@@ -56,6 +56,7 @@ class FixedBlockSequence[ConfigType: FixedBlockSequenceConfig](BlockBase[ConfigT
         return self._layers_with_namespace
 
     def preprocess(self, kwargs: dict[str, typing.Any]) -> None:
+        kwargs[BlockKwargs.num_blocks_in_sequence] = self._config.num_blocks
         self._layers_with_namespace[0].preprocess(kwargs)
 
     def get_loss_definitions(self, count: int = 1) -> list[LossDef]:
@@ -110,7 +111,8 @@ class PatternBlockSequence[ConfigType: PatternBlockSequenceConfig](BlockBase[Con
         return self._layers_with_namespace
 
     def preprocess(self, kwargs: dict[str, typing.Any]) -> None:
-        for _, index in self._config.preprocessing_layers.items():
+        for name, index in self._config.preprocessing_layers.items():
+            kwargs[BlockKwargs.num_blocks_in_sequence] = self._config.expanded_pattern.count(name)
             self._layers_with_namespace[index].preprocess(kwargs)
 
     def get_loss_definitions(self, count: int = 1) -> list[LossDef]:

--- a/fast_llm/layers/decoder/config.py
+++ b/fast_llm/layers/decoder/config.py
@@ -21,6 +21,8 @@ class StochasticMixerKwargs(BlockKwargs):
 
     mixer_name = "stochastic_mixer_name"
     generator = "stochastic_mixer_generator"
+    layout = "stochastic_mixer_layout"
+    layout_counter = "stochastic_mixer_layout_counter"
 
 
 @config_class()
@@ -91,6 +93,7 @@ class StochasticMixerSamplingStrategy(enum.StrEnum):
 
     uniform = "uniform"
     weighted = "weighted"
+    full_layout = "full_layout"
 
 
 @config_class(registry=True)
@@ -124,7 +127,8 @@ class StochasticMixerConfig(MixerConfig):
 
     _abstract = False
 
-    mixers: dict[str, MixerConfig] = Field(
+    mixers: dict[str, MixerConfig] | None = Field(
+        default=None,
         desc="Dict of mixer options to sample from (must contain at least 1). "
         "Keys are mixer names used for debugging and namespacing.",
         hint=FieldHint.architecture,
@@ -162,7 +166,9 @@ class StochasticMixerConfig(MixerConfig):
     def _validate(self) -> None:
         super()._validate()
 
-        # Validate mixers dict is not empty
+        # Validate mixers dict is provided and not empty
+        if self.mixers is None:
+            raise ValueError("mixers must be provided for StochasticMixerConfig")
         Assert.gt(len(self.mixers), 0)
 
         # Set main_mixer_name to first mixer if not specified
@@ -173,6 +179,10 @@ class StochasticMixerConfig(MixerConfig):
         # Validate main mixer name exists
         if self.main_mixer_name not in self.mixers:
             raise ValueError(f"main_mixer_name '{self.main_mixer_name}' not found in mixers")
+
+        # Validate full_layout incompatibilities
+        if self.sampling_strategy == StochasticMixerSamplingStrategy.full_layout and self.sampling_weights is not None:
+            raise ValueError("sampling_weights is not compatible with full_layout sampling strategy")
 
         # Validate and normalize sampling weights
         if self.sampling_weights is not None:

--- a/fast_llm/layers/decoder/stochastic_mixer.py
+++ b/fast_llm/layers/decoder/stochastic_mixer.py
@@ -66,7 +66,9 @@ class StochasticMixer[ConfigType: StochasticMixerConfig](BlockWithBias[ConfigTyp
             }
         )
 
-        if self._config.sampling_strategy == StochasticMixerSamplingStrategy.uniform:
+        if self._config.sampling_strategy == StochasticMixerSamplingStrategy.full_layout:
+            self._sampling_probs = None
+        elif self._config.sampling_strategy == StochasticMixerSamplingStrategy.uniform:
             self._sampling_probs = torch.ones(len(self.mixers), device="cpu") / len(self.mixers)
         elif self._config.sampling_strategy == StochasticMixerSamplingStrategy.weighted:
             if self._config.sampling_weights is None:
@@ -107,6 +109,13 @@ class StochasticMixer[ConfigType: StochasticMixerConfig](BlockWithBias[ConfigTyp
     def _sample_mixer_name(self, kwargs: dict[str, typing.Any]) -> str:
         if not self.training:
             return self._config.main_mixer_name
+
+        if self._config.sampling_strategy == StochasticMixerSamplingStrategy.full_layout:
+            layout = kwargs[StochasticMixerKwargs.layout]
+            counter = kwargs[StochasticMixerKwargs.layout_counter]
+            idx = counter[0]
+            counter[0] += 1
+            return layout[idx]
 
         generator = kwargs[StochasticMixerKwargs.generator]
         mixer_idx = torch.multinomial(self._sampling_probs, num_samples=1, generator=generator).item()
@@ -150,6 +159,33 @@ class StochasticMixer[ConfigType: StochasticMixerConfig](BlockWithBias[ConfigTyp
 
         return self.mixers[mixer_name]._forward(input_, kwargs, losses, metrics)
 
+    def _sample_allocation(self, num_layers: int, generator: torch.Generator) -> list[int]:
+        """
+        Sample a composition of num_layers into num_mixers bins uniformly.
+
+        Uses stars-and-bars: picks (M-1) bar positions from {0, ..., N+M-2},
+        giving each mixer a count. All integer partitions are equally likely.
+        """
+        M = len(self.mixers)
+        N = num_layers
+        if M == 1:
+            return [N]
+        bars = torch.randperm(N + M - 1, generator=generator)[: M - 1].sort().values
+        padded = torch.cat([torch.tensor([-1]), bars, torch.tensor([N + M - 1])])
+        counts = (padded[1:] - padded[:-1] - 1).tolist()
+        return counts
+
+    def _sample_placement(self, counts: list[int], num_layers: int, generator: torch.Generator) -> list[str]:
+        """
+        Given per-mixer counts, create a shuffled layout.
+        """
+        mixer_names = list(self.mixers.keys())
+        layout = []
+        for name, count in zip(mixer_names, counts):
+            layout.extend([name] * count)
+        perm = torch.randperm(num_layers, generator=generator)
+        return [layout[i] for i in perm.tolist()]
+
     def preprocess(self, kwargs: dict[str, typing.Any]) -> None:
         from fast_llm.engine.distributed.config import MAX_SEED
         from fast_llm.layers.block.config import BlockKwargs
@@ -159,6 +195,13 @@ class StochasticMixer[ConfigType: StochasticMixerConfig](BlockWithBias[ConfigTyp
         seed = (self._distributed_config.seed + self._config.seed_shift + iteration) % MAX_SEED
         generator.manual_seed(seed)
         kwargs[StochasticMixerKwargs.generator] = generator
+
+        if self._config.sampling_strategy == StochasticMixerSamplingStrategy.full_layout:
+            num_layers = kwargs[BlockKwargs.num_blocks_in_sequence]
+            counts = self._sample_allocation(num_layers, generator)
+            layout = self._sample_placement(counts, num_layers, generator)
+            kwargs[StochasticMixerKwargs.layout] = layout
+            kwargs[StochasticMixerKwargs.layout_counter] = [0]
 
         for mixer in self.mixers.values():
             mixer.preprocess(kwargs)
@@ -173,8 +216,12 @@ class StochasticMixer[ConfigType: StochasticMixerConfig](BlockWithBias[ConfigTyp
         """
         usages = [mixer.get_compute_usage(input_, kwargs, config) for mixer in self.mixers.values()]
 
-        # Weight by sampling probability and return the expected value
-        expected_usage = sum(usage * prob.item() for usage, prob in zip(usages, self._sampling_probs))
+        if self._sampling_probs is not None:
+            # Weight by sampling probability and return the expected value
+            expected_usage = sum(usage * prob.item() for usage, prob in zip(usages, self._sampling_probs))
+        else:
+            # full_layout: uniform over compositions, so equal expected weight per mixer
+            expected_usage = sum(usages) / len(usages)
 
         return int(expected_usage)
 


### PR DESCRIPTION
# ✨ Description
Add full_layout sampling strategy for StochasticMixer                                                                                                                                                                       
                                                                                                                                                                                                                                
  Adds a new sampling mode where all layer compositions are equally probable, including non-uniform ones (e.g., all-attention). Currently, independent per-layer sampling concentrates on ~N/M of each type due to the law of   
  large numbers, making extreme compositions vanishingly unlikely.                                                                                                                                                              

  How it works

  1. _sample_allocation: Uses stars-and-bars to uniformly sample how many of each mixer type (all integer partitions equally likely)
  2. _sample_placement: Randomly assigns mixer types to layer positions

  Layout is resampled each iteration. Configured via sampling_strategy: full_layout.

  Changes

  - fast_llm/layers/decoder/config.py — Add full_layout enum value, layout kwargs keys, validation
  - fast_llm/layers/decoder/stochastic_mixer.py — Add _sample_allocation, _sample_placement, update preprocess and _sample_mixer_name
  - fast_llm/layers/block/config.py — Add BlockKwargs.num_blocks_in_sequence
  - fast_llm/layers/block/sequence.py — Pass block count via kwargs in preprocess
  - Make StochasticMixerConfig.mixers optional (default None) to allow partial config overrides from pretrained checkpoints


## 🔍 Type of change

Select all that apply:

- [ ] 🐛 **Bug fix** (non-breaking change that addresses a specific issue)
- [x] 🚀 **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (a change that could affect existing functionality)
- [ ] 📈 **Performance improvement/optimization** (improves speed, memory usage, or efficiency)
- [ ] 🛠️ **Code refactor** (non-functional changes that improve code readability, structure, etc.)
- [ ] 📦 **Dependency bump** (updates dependencies, including Dockerfile or package changes)
- [ ] 📝 **Documentation change** (updates documentation, including new content or typo fixes)
- [ ] 🔧 **Infrastructure/Build change** (affects build process, CI/CD, or dependencies)

## 📝 Changes

List the key changes introduced in this PR:

1. Change A
2. Change B

## ✅ Checklist

Make sure the following tasks are completed before submitting the PR:

### General

- [ ] 📜 I have read and followed the [contributing guidelines](https://servicenow.github.io/Fast-LLM/contributing/contributing).
- [ ] 🏷️ I am using a clear and descriptive PR title that summarizes the key change or feature introduced.
- [ ] 🎉 The functionality is complete, and I have tested the changes.
- [ ] 📝 I have updated the documentation if needed.
- [ ] ⚠️ The change does not introduce any new issues (e.g., runtime warnings, type checker errors, linting problems, unhandled edge cases).
- [ ] 🧩 I have commented my code, especially in hard-to-understand areas.

### Dependencies and Configuration

- [ ] 🐋 I have updated the Docker configuration or dependencies, if applicable.
- [ ] 🔄 I have ensured compatibility with the existing setup after dependency changes.

### Testing

- [ ] 🧪 I have added or updated tests to cover my changes.
- [ ] ✔️ New and existing tests pass locally with my changes.
- [ ] 🚦 I have tested these changes on GPUs and verified training stability.
- [ ] 🏋️ I have tested the changes on realistic training workloads, if applicable.

### Performance Impact

- [ ] 📊 I have run benchmarks where applicable to evaluate the performance impact.
- [ ] ✅ The benchmarks show no performance regression.
- [ ] 🚀 The benchmarks indicate a potential performance improvement.
- [ ] ⚠️ The benchmarks indicate a potential performance degradation.
- [ ] 📈 I have provided benchmark results and detailed any performance impact below, if applicable.

## 📊 Performance Impact Details

If there is any impact on performance, describe it and provide benchmark results, if applicable:

---

## 🗒️ Additional Notes

Include any additional context, information, or considerations here, such as known issues, follow-up tasks, or backward compatibility concerns.
