### PR TITLE
Add PyTorch backup implementations for GDN and KDA SSM layers

### DIFF
--- a/fast_llm/layers/ssm/gdn.py
+++ b/fast_llm/layers/ssm/gdn.py
@@ -38,85 +38,175 @@ def _l2norm(x: torch.Tensor, dim: int = -1, eps: float = 1e-6) -> torch.Tensor:
 
 
 @torch.compile
-def torch_chunk_gated_delta_rule(
-    query,
-    key,
-    value,
-    g,
-    beta,
-    chunk_size=64,
-    initial_state=None,
-    output_final_state=False,
-    use_qk_l2norm_in_kernel=False,
-    cu_seqlens=None,
-):
-    initial_dtype = query.dtype
+def _torch_chunk_gated_delta_rule_single(
+    query: torch.Tensor,  # batch, sequence, heads, key_head_dim
+    key: torch.Tensor,  # batch, sequence, heads, key_head_dim
+    value: torch.Tensor,  # batch, sequence, heads, value_head_dim
+    g: torch.Tensor,  # batch, sequence, heads (log decay rates)
+    beta: torch.Tensor,  # batch, sequence, heads (write gate strengths)
+    chunk_size: int = 64,
+    initial_state: torch.Tensor | None = None,  # batch, heads, key_head_dim, value_head_dim
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    input_dtype = query.dtype
+
     if use_qk_l2norm_in_kernel:
         query = _l2norm(query, dim=-1, eps=1e-6)
         key = _l2norm(key, dim=-1, eps=1e-6)
+
+    # Transpose to head-first layout and upcast for numerical stability.
+    # batch, sequence, heads, dim -> batch, heads, sequence, dim
     query, key, value, beta, g = (
         x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
     )
 
-    batch_size, num_heads, sequence_length, k_head_dim = key.shape
-    v_head_dim = value.shape[-1]
+    batch_size, num_heads, sequence_length, key_head_dim = key.shape
+    value_head_dim = value.shape[-1]
+
+    # Pad sequence length to a multiple of chunk_size.
     pad_size = (chunk_size - sequence_length % chunk_size) % chunk_size
     query = torch.nn.functional.pad(query, (0, 0, 0, pad_size))
     key = torch.nn.functional.pad(key, (0, 0, 0, pad_size))
     value = torch.nn.functional.pad(value, (0, 0, 0, pad_size))
     beta = torch.nn.functional.pad(beta, (0, pad_size))
     g = torch.nn.functional.pad(g, (0, pad_size))
-    total_sequence_length = sequence_length + pad_size
-    scale = 1 / (query.shape[-1] ** 0.5)
-    query = query * scale
+    padded_sequence_length = sequence_length + pad_size
+    num_chunks = padded_sequence_length // chunk_size
 
-    v_beta = value * beta.unsqueeze(-1)
-    k_beta = key * beta.unsqueeze(-1)
-    # reshape to chunks
-    query, key, value, k_beta, v_beta = (
-        x.reshape(x.shape[0], x.shape[1], -1, chunk_size, x.shape[-1]) for x in (query, key, value, k_beta, v_beta)
+    query = query * (key_head_dim**-0.5)
+
+    # Beta-weighted keys and values for the delta rule write operations.
+    key_beta = key * beta.unsqueeze(-1)  # batch, heads, sequence, key_head_dim
+    value_beta = value * beta.unsqueeze(-1)  # batch, heads, sequence, value_head_dim
+
+    # Reshape into chunks: batch, heads, num_chunks, chunk_size, dim
+    query, key, value, key_beta, value_beta = (
+        x.reshape(batch_size, num_heads, num_chunks, chunk_size, x.shape[-1])
+        for x in (query, key, value, key_beta, value_beta)
     )
-    g = g.reshape(g.shape[0], g.shape[1], -1, chunk_size)
-    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=0)
+    g = g.reshape(batch_size, num_heads, num_chunks, chunk_size)
 
-    # chunk decay
-    g = g.cumsum(dim=-1)
-    decay_mask = ((g.unsqueeze(-1) - g.unsqueeze(-2)).tril().exp().float()).tril()
-    attn = -((k_beta @ key.transpose(-1, -2)) * decay_mask).masked_fill(mask, 0)
-    for i in range(1, chunk_size):
-        row = attn[..., i, :i].clone()
-        sub = attn[..., :i, :i].clone()
-        attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)
-    attn = attn + torch.eye(chunk_size, dtype=attn.dtype, device=attn.device)
-    value = attn @ v_beta
-    k_cumdecay = attn @ (k_beta * g.exp().unsqueeze(-1))
-    last_recurrent_state = (
-        torch.zeros(batch_size, num_heads, k_head_dim, v_head_dim).to(value)
-        if initial_state is None
-        else initial_state.to(value)
+    # Cumulative sum of log-decay rates within each chunk.
+    # log_decay_cumsum[..., t] = sum_{s=0}^{t} g[s]
+    log_decay_cumsum = g.cumsum(dim=-1)  # batch, heads, num_chunks, chunk_size
+
+    # Intra-chunk decay matrix: entry [t, s] = exp(log_decay_cumsum[t] - log_decay_cumsum[s]) for t >= s.
+    intra_chunk_decay = (log_decay_cumsum.unsqueeze(-1) - log_decay_cumsum.unsqueeze(-2)).tril().exp()
+    # batch, heads, num_chunks, chunk_size, chunk_size
+
+    # --- Intra-chunk delta rule transformation ---
+    # Build the triangular transformation matrix that encodes how prior writes within a chunk
+    # are corrected by later writes (the delta rule update).
+    # Initial: T[t, s] = -(key_beta[t] · key[s]) * decay[t, s], strictly lower-triangular.
+    upper_triangular_mask = torch.triu(
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=0
     )
-    core_attn_out = torch.zeros_like(value)
-    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1)
+    intra_chunk_transform = -(key_beta @ key.transpose(-1, -2) * intra_chunk_decay).masked_fill(
+        upper_triangular_mask, 0
+    )
+    # Iteratively apply the delta rule to build up the full transformation.
+    for chunk_pos in range(1, chunk_size):
+        row = intra_chunk_transform[..., chunk_pos, :chunk_pos].clone()
+        above = intra_chunk_transform[..., :chunk_pos, :chunk_pos].clone()
+        intra_chunk_transform[..., chunk_pos, :chunk_pos] = row + (row.unsqueeze(-1) * above).sum(-2)
+    intra_chunk_transform = intra_chunk_transform + torch.eye(
+        chunk_size, dtype=intra_chunk_transform.dtype, device=query.device
+    )
 
-    # for each chunk
-    for i in range(0, total_sequence_length // chunk_size):
-        q_i, k_i, v_i = query[:, :, i], key[:, :, i], value[:, :, i]
-        attn = (q_i @ k_i.transpose(-1, -2) * decay_mask[:, :, i]).masked_fill_(mask, 0)
-        v_prime = (k_cumdecay[:, :, i]) @ last_recurrent_state
-        v_new = v_i - v_prime
-        attn_inter = (q_i * g[:, :, i, :, None].exp()) @ last_recurrent_state
-        core_attn_out[:, :, i] = attn_inter + attn @ v_new
-        last_recurrent_state = (
-            last_recurrent_state * g[:, :, i, -1, None, None].exp()
-            + (k_i * (g[:, :, i, -1, None] - g[:, :, i]).exp()[..., None]).transpose(-1, -2) @ v_new
+    # Apply the transformation to get: corrected intra-chunk values and keys scaled by cumulative decay.
+    intra_chunk_value = intra_chunk_transform @ value_beta
+    # batch, heads, num_chunks, chunk_size, value_head_dim
+    key_cumulative_decay = intra_chunk_transform @ (key_beta * log_decay_cumsum.exp().unsqueeze(-1))
+    # batch, heads, num_chunks, chunk_size, key_head_dim
+
+    # --- Recurrent loop over chunks ---
+    if initial_state is None:
+        recurrent_state = torch.zeros(
+            batch_size, num_heads, key_head_dim, value_head_dim, device=query.device, dtype=query.dtype
+        )
+    else:
+        recurrent_state = initial_state.to(query)
+    output = torch.zeros_like(intra_chunk_value)
+    causal_mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1)
+
+    for chunk_index in range(num_chunks):
+        q = query[:, :, chunk_index]  # batch, heads, chunk_size, key_head_dim
+        k = key[:, :, chunk_index]  # batch, heads, chunk_size, key_head_dim
+        v = intra_chunk_value[:, :, chunk_index]  # batch, heads, chunk_size, value_head_dim
+        log_decay = log_decay_cumsum[:, :, chunk_index]  # batch, heads, chunk_size
+
+        # Intra-chunk causal attention weighted by decay.
+        intra_chunk_attn = (q @ k.transpose(-1, -2) * intra_chunk_decay[:, :, chunk_index]).masked_fill_(
+            causal_mask, 0
+        )  # batch, heads, chunk_size, chunk_size
+
+        # Delta rule correction: subtract the recurrent state's contribution from the values.
+        state_contribution = key_cumulative_decay[:, :, chunk_index] @ recurrent_state
+        corrected_value = v - state_contribution  # batch, heads, chunk_size, value_head_dim
+
+        # Combine cross-chunk output (from recurrent state) and intra-chunk output.
+        cross_chunk_output = (q * log_decay.exp().unsqueeze(-1)) @ recurrent_state
+        output[:, :, chunk_index] = cross_chunk_output + intra_chunk_attn @ corrected_value
+
+        # Update recurrent state: decay existing state and add new writes from this chunk.
+        last_log_decay = log_decay[:, :, -1]  # batch, heads
+        recurrent_state = (
+            recurrent_state * last_log_decay.exp()[..., None, None]
+            + (k * (last_log_decay.unsqueeze(-1) - log_decay).exp().unsqueeze(-1)).transpose(-1, -2) @ corrected_value
         )
 
     if not output_final_state:
-        last_recurrent_state = None
-    core_attn_out = core_attn_out.reshape(core_attn_out.shape[0], core_attn_out.shape[1], -1, core_attn_out.shape[-1])
-    core_attn_out = core_attn_out[:, :, :sequence_length]
-    core_attn_out = core_attn_out.transpose(1, 2).contiguous().to(initial_dtype)
-    return core_attn_out, last_recurrent_state
+        recurrent_state = None
+
+    # Restore original layout: batch, sequence, heads, value_head_dim
+    output = output.reshape(batch_size, num_heads, padded_sequence_length, value_head_dim)
+    output = output[:, :, :sequence_length]
+    output = output.transpose(1, 2).contiguous().to(input_dtype)
+
+    return output, recurrent_state
+
+
+def torch_chunk_gated_delta_rule(
+    query: torch.Tensor,  # batch, sequence, heads, key_head_dim
+    key: torch.Tensor,  # batch, sequence, heads, key_head_dim
+    value: torch.Tensor,  # batch, sequence, heads, value_head_dim
+    g: torch.Tensor,  # batch, sequence, heads (log decay rates)
+    beta: torch.Tensor,  # batch, sequence, heads (write gate strengths)
+    chunk_size: int = 64,
+    initial_state: torch.Tensor | None = None,  # batch, heads, key_head_dim, value_head_dim
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    if cu_seqlens is None:
+        return _torch_chunk_gated_delta_rule_single(
+            query,
+            key,
+            value,
+            g,
+            beta,
+            chunk_size=chunk_size,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+    # Process each document independently and concatenate results.
+    # Inputs have batch=1 with documents packed along the sequence dimension.
+    sequence_boundaries = cu_seqlens.tolist()
+    outputs = []
+    for seq_start, seq_end in zip(sequence_boundaries, sequence_boundaries[1:]):
+        out, _ = _torch_chunk_gated_delta_rule_single(
+            query[:, seq_start:seq_end],
+            key[:, seq_start:seq_end],
+            value[:, seq_start:seq_end],
+            g[:, seq_start:seq_end],
+            beta[:, seq_start:seq_end],
+            chunk_size=chunk_size,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+        outputs.append(out)
+    return torch.cat(outputs, dim=1), None
 
 
 class GatedDeltaNet[ConfigType: GatedDeltaNetConfig](BlockWithBias[ConfigType]):

--- a/fast_llm/layers/ssm/kda.py
+++ b/fast_llm/layers/ssm/kda.py
@@ -2,6 +2,7 @@ import logging
 import typing
 
 import torch
+import torch.nn.functional
 
 from fast_llm.engine.base_model.config import ResourceUsageConfig
 from fast_llm.engine.config_utils.initialization import LambdaInitializer, init_normal_, init_ones_
@@ -25,6 +26,182 @@ except (ImportError, RuntimeError):
     _kda_available = False
 
 
+def _l2norm(x: torch.Tensor, dim: int = -1, eps: float = 1e-6) -> torch.Tensor:
+    return x * torch.rsqrt((x * x).sum(dim=dim, keepdim=True) + eps)
+
+
+def torch_kda_gate(
+    g: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor | None = None,
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Pure PyTorch backup for fused_kda_gate."""
+    num_heads, head_dim = g.shape[-2:]
+    g = g.float()
+    if dt_bias is not None:
+        g = g + dt_bias.view(num_heads, head_dim)
+    return (-A_log.view(num_heads, 1).float().exp() * torch.nn.functional.softplus(g)).to(output_dtype)
+
+
+@torch.compile
+def _torch_chunk_kda_single(
+    q: torch.Tensor,  # batch, sequence, heads, head_dim
+    k: torch.Tensor,  # batch, sequence, heads, head_dim
+    v: torch.Tensor,  # batch, sequence, heads, head_dim
+    g: torch.Tensor,  # batch, sequence, heads, head_dim (log decay rates per dim)
+    beta: torch.Tensor,  # batch, sequence, heads (write gate strengths)
+    chunk_size: int = 64,
+    initial_state: torch.Tensor | None = None,  # batch, heads, head_dim, head_dim
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    input_dtype = q.dtype
+
+    if use_qk_l2norm_in_kernel:
+        q = _l2norm(q, dim=-1, eps=1e-6)
+        k = _l2norm(k, dim=-1, eps=1e-6)
+
+    # Transpose to head-first layout and upcast for numerical stability.
+    # batch, sequence, heads, dim -> batch, heads, sequence, dim
+    q, k, v, g = (x.transpose(1, 2).contiguous().to(torch.float32) for x in (q, k, v, g))
+    beta = beta.transpose(1, 2).contiguous().to(torch.float32)
+
+    batch_size, num_heads, sequence_length, head_dim = q.shape
+
+    # Pad sequence length to a multiple of chunk_size.
+    pad_size = (chunk_size - sequence_length % chunk_size) % chunk_size
+    q = torch.nn.functional.pad(q, (0, 0, 0, pad_size))
+    k = torch.nn.functional.pad(k, (0, 0, 0, pad_size))
+    v = torch.nn.functional.pad(v, (0, 0, 0, pad_size))
+    g = torch.nn.functional.pad(g, (0, 0, 0, pad_size))
+    beta = torch.nn.functional.pad(beta, (0, pad_size))
+    padded_sequence_length = sequence_length + pad_size
+    num_chunks = padded_sequence_length // chunk_size
+
+    q = q * (head_dim**-0.5)
+
+    # Reshape to chunks: (batch, heads, num_chunks, chunk_size, head_dim)
+    q, k, v, g = (x.reshape(batch_size, num_heads, num_chunks, chunk_size, head_dim) for x in (q, k, v, g))
+    # beta: (batch, heads, num_chunks, chunk_size)
+    beta = beta.reshape(batch_size, num_heads, num_chunks, chunk_size)
+
+    # Cumulative sum of log-decays within each chunk (over the position dimension).
+    g = g.cumsum(dim=-2)  # batch, heads, num_chunks, chunk_size, head_dim
+
+    # Build the per-chunk intra-sequence delta-rule transform matrix A.
+    # decay_matrix[..., c, i, d] = exp(g[c, d] - g[i, d]) — decay from position i to position c.
+    # g.unsqueeze(-2): (batch, heads, num_chunks, chunk_size, 1, head_dim) — "c" positions
+    # g.unsqueeze(-3): (batch, heads, num_chunks, 1, chunk_size, head_dim) — "i" positions
+    decay_matrix = (g.unsqueeze(-2) - g.unsqueeze(-3)).exp()
+    # intra_chunk_A[..., c, i] = sum_d(k[c, d] * k[i, d] * decay_matrix[c, i, d])
+    intra_chunk_A = (k.unsqueeze(-2) * k.unsqueeze(-3) * decay_matrix).sum(-1)
+    # Multiply each row c by beta[c] (write gate applied before delta-rule correction).
+    intra_chunk_A = intra_chunk_A * beta.unsqueeze(-1)
+    # Mask upper triangular (including diagonal) and flip sign for delta-rule update.
+    upper_triangular_mask = torch.triu(
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), diagonal=0
+    )
+    intra_chunk_A = -intra_chunk_A.masked_fill(upper_triangular_mask, 0)
+    # Iterative delta-rule refinement.
+    for chunk_pos in range(1, chunk_size):
+        row = intra_chunk_A[..., chunk_pos, :chunk_pos].clone()
+        above = intra_chunk_A[..., :chunk_pos, :chunk_pos].clone()
+        intra_chunk_A[..., chunk_pos, :chunk_pos] = row + (row.unsqueeze(-1) * above).sum(-2)
+    # Add identity and multiply each column i by beta[i] (write gate applied after correction).
+    intra_chunk_A = (
+        intra_chunk_A + torch.eye(chunk_size, dtype=intra_chunk_A.dtype, device=q.device)
+    ) * beta.unsqueeze(-2)
+
+    # Precompute per-chunk write keys and corrected values for the recurrent state update.
+    # intra_chunk_w[..., c, d] = sum_i(A[c, i] * exp(g[i, d]) * k[i, d])
+    intra_chunk_w = intra_chunk_A @ (g.exp() * k)  # batch, heads, num_chunks, chunk_size, head_dim
+    # intra_chunk_u[..., c, d] = sum_i(A[c, i] * v[i, d])
+    intra_chunk_u = intra_chunk_A @ v  # batch, heads, num_chunks, chunk_size, head_dim
+
+    # Precompute intra-chunk causal attention scores.
+    # intra_chunk_attn[..., c, j] = sum_d(q[c, d] * k[j, d] * decay_matrix[c, j, d])
+    intra_chunk_attn = (q.unsqueeze(-2) * k.unsqueeze(-3) * decay_matrix).sum(-1)
+    causal_mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), diagonal=1)
+    intra_chunk_attn = intra_chunk_attn.masked_fill(causal_mask, 0)
+
+    if initial_state is None:
+        recurrent_state = torch.zeros(batch_size, num_heads, head_dim, head_dim, device=q.device, dtype=q.dtype)
+    else:
+        recurrent_state = initial_state.to(q)
+
+    output = torch.zeros_like(intra_chunk_u)
+    for chunk_index in range(num_chunks):
+        q_chunk = q[:, :, chunk_index]  # batch, heads, chunk_size, head_dim
+        k_chunk = k[:, :, chunk_index]
+        u_chunk = intra_chunk_u[:, :, chunk_index]
+        w_chunk = intra_chunk_w[:, :, chunk_index]
+        g_chunk = g[:, :, chunk_index]
+        attn_chunk = intra_chunk_attn[:, :, chunk_index]
+
+        # Remove the state's contribution from the intra-chunk corrected values.
+        value_corrected = u_chunk - w_chunk @ recurrent_state  # batch, heads, chunk_size, head_dim
+        # Cross-chunk contribution: queries attend to the recurrent state via the cumulative decay.
+        cross_chunk_output = (q_chunk * g_chunk.exp()) @ recurrent_state
+        output[:, :, chunk_index] = cross_chunk_output + attn_chunk @ value_corrected
+
+        # Decay the state by the cumulative log-decay at the last position in the chunk.
+        last_g = g_chunk[:, :, -1]  # batch, heads, head_dim
+        recurrent_state = recurrent_state * last_g.exp().unsqueeze(-1)  # broadcast over value dim
+        # Write new key-value associations, weighted by the decay from each position to the chunk end.
+        inter_chunk_decay = (last_g.unsqueeze(-2) - g_chunk).exp()  # batch, heads, chunk_size, head_dim
+        recurrent_state = recurrent_state + (inter_chunk_decay * k_chunk).transpose(-1, -2) @ value_corrected
+
+    if not output_final_state:
+        recurrent_state = None
+
+    # Remove padding and restore sequence-first layout.
+    output = output.reshape(batch_size, num_heads, padded_sequence_length, head_dim)
+    output = output[:, :, :sequence_length]
+    output = output.transpose(1, 2).contiguous().to(input_dtype)
+    return output, recurrent_state
+
+
+def torch_chunk_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    chunk_size: int = 64,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    if cu_seqlens is None:
+        return _torch_chunk_kda_single(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            chunk_size=chunk_size,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+    sequence_boundaries = cu_seqlens.tolist()
+    outputs = []
+    for seq_start, seq_end in zip(sequence_boundaries, sequence_boundaries[1:]):
+        out, _ = _torch_chunk_kda_single(
+            q[:, seq_start:seq_end],
+            k[:, seq_start:seq_end],
+            v[:, seq_start:seq_end],
+            g[:, seq_start:seq_end],
+            beta[:, seq_start:seq_end],
+            chunk_size=chunk_size,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+        outputs.append(out)
+    return torch.cat(outputs, dim=1), None
+
+
 class KimiDeltaAttention[ConfigType: KimiDeltaAttentionConfig](BlockWithBias[ConfigType]):
     """
     Implementation of the Kimi Delta Attention mixer.
@@ -46,11 +223,6 @@ class KimiDeltaAttention[ConfigType: KimiDeltaAttentionConfig](BlockWithBias[Con
         super().__init__(
             config, distributed_config, hidden_dim=hidden_dim, lr_scale=lr_scale, peft=peft, return_bias=return_bias
         )
-        if not _kda_available:
-            raise ImportError(
-                "KimiDeltaAttention requires the `fla-core` package. "
-                "Please install it with `pip install -U fla-core`."
-            )
 
         self._parallel_dim = self._distributed_config.get_distributed_dim(DistributedDimNames.tensor)
         self._heads_dim = TensorDim(
@@ -188,6 +360,17 @@ class KimiDeltaAttention[ConfigType: KimiDeltaAttentionConfig](BlockWithBias[Con
             peft=self._peft,
         )
 
+        if _kda_available and distributed_config.use_cuda:
+            self._chunk_kda = chunk_kda
+            self._kda_gate = fused_kda_gate
+        else:
+            logger.warning(
+                "Fast implementation for KimiDeltaAttention is not available. "
+                "Please ensure that 'fla-core' is properly installed."
+            )
+            self._chunk_kda = torch_chunk_kda
+            self._kda_gate = torch_kda_gate
+
     def _forward(
         self,
         input_: torch.Tensor,
@@ -226,9 +409,9 @@ class KimiDeltaAttention[ConfigType: KimiDeltaAttentionConfig](BlockWithBias[Con
         g_kernel = (
             self.f_b_proj(self.f_a_proj(input_)).unsqueeze(0).unflatten(-1, (self._local_heads, self._config.head_dim))
         )
-        g_kernel = fused_kda_gate(g_kernel, self.A_log.float(), dt_bias=self.dt_bias)
+        g_kernel = self._kda_gate(g_kernel, self.A_log.float(), dt_bias=self.dt_bias)
 
-        out, _ = chunk_kda(
+        out, _ = self._chunk_kda(
             q=q,
             k=k,
             v=v,

--- a/tests/layers/test_ssm.py
+++ b/tests/layers/test_ssm.py
@@ -10,6 +10,7 @@ from fast_llm.engine.distributed.config import DistributedConfig
 from fast_llm.engine.distributed.distributed import Distributed
 from fast_llm.layers.decoder.config import MixerConfig
 from fast_llm.layers.ssm.config import GatedDeltaNetConfig, KimiDeltaAttentionConfig, MambaConfig
+from fast_llm.layers.ssm.gdn import _fast_gdn_available
 from fast_llm.layers.ssm.kda import _kda_available
 from fast_llm.utils import Assert
 from tests.utils.utils import get_stage
@@ -24,6 +25,7 @@ try:
 except ImportError:
     Apriel2GatedDeltaNet = None
     Apriel2Mamba = None
+    KimiDeltaAttention = None
     is_fast_path_available = False
 
 HIDDEN_SIZE = 16
@@ -98,7 +100,20 @@ def _compare_mixers(
 @pytest.mark.slow
 # Arguments ('seq_idx',) not implemented for torch implementation of 1d convolution.
 @pytest.mark.skipif(not is_fast_path_available, reason="GDN deps missing")
-def test_gdn(testing_device):
+@pytest.mark.parametrize(
+    "use_backup",
+    [
+        pytest.param(False, marks=pytest.mark.skipif(not _fast_gdn_available, reason="FLA not available")),
+        True,
+    ],
+    ids=["fast", "backup"],
+)
+def test_gdn(testing_device, use_backup, monkeypatch):
+    if use_backup:
+        import fast_llm.layers.ssm.gdn as gdn_module
+
+        monkeypatch.setattr(gdn_module, "_fast_gdn_available", False)
+
     dtype = torch.bfloat16
 
     NUM_V_HEADS = 4
@@ -120,12 +135,27 @@ def test_gdn(testing_device):
         .eval()
     )
     fast_llm_config = GatedDeltaNetConfig.from_dict(config_common, {"normalization": {"epsilon": 1e-5}})
-    _compare_mixers(fast_llm_config, hf_layer, {})
+    # The backup uses float32 arithmetic while the reference uses the FLA kernel, so
+    # bfloat16-level numerical differences are expected; use a looser threshold.
+    _compare_mixers(fast_llm_config, hf_layer, {}, threshold=1e-2 if use_backup else 1e-5)
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(not _kda_available, reason="KDA fused kernels not available")
-def test_kda():
+@pytest.mark.skipif(KimiDeltaAttention is None, reason="KDA external model not available")
+@pytest.mark.parametrize(
+    "use_backup",
+    [
+        pytest.param(False, marks=pytest.mark.skipif(not _kda_available, reason="KDA fused kernels not available")),
+        True,
+    ],
+    ids=["fast", "backup"],
+)
+def test_kda(testing_device, use_backup, monkeypatch):
+    if use_backup:
+        import fast_llm.layers.ssm.kda as kda_module
+
+        monkeypatch.setattr(kda_module, "_kda_available", False)
+
     NUM_HEADS = 4
     HEAD_DIM = 4
     KERNEL_SIZE = 4
@@ -141,7 +171,9 @@ def test_kda():
 
     fast_llm_config = KimiDeltaAttentionConfig.from_dict(kda_config, {})
 
-    _compare_mixers(fast_llm_config, hf_layer, {})
+    # The backup uses float32 arithmetic while the reference uses FLA kernels, so
+    # bfloat16-level numerical differences are expected; use a looser threshold.
+    _compare_mixers(fast_llm_config, hf_layer, {}, threshold=1e-2 if use_backup else 1e-5)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
- Refactor torch_chunk_gated_delta_rule (GDN) for readability: rename variables, add type hints and section comments, split into a compiled inner function (_torch_chunk_gated_delta_rule_single) and a public wrapper that handles cu_seqlens by iterating over document boundaries.
- Add torch_chunk_kda / _torch_chunk_kda_single and torch_kda_gate as pure-PyTorch fallbacks for KimiDeltaAttention (KDA), following the same pattern. KDA's per-dim vector decay and post-correction beta application differ structurally from GDN.
- GatedDeltaNet and KimiDeltaAttention now fall back gracefully to the backup when FLA kernels are unavailable instead of raising ImportError.
- Parametrize test_gdn and test_kda with fast/backup variants; backup uses threshold=1e-2 to accommodate float32-vs-kernel precision gaps.
