### PR TITLE
Fix vLLM coordinator crash for pure-recurrent placements

### DIFF
--- a/fast_llm_external_models/apriel2/vllm/modeling_apriel2.py
+++ b/fast_llm_external_models/apriel2/vllm/modeling_apriel2.py
@@ -157,6 +157,62 @@ def _patch_kv_cache_grouping() -> None:
 _patch_kv_cache_grouping()
 
 
+# ---------------------------------------------------------------------------
+# Monkey-patch: fix coordinator selection for pure-recurrent configurations
+# ---------------------------------------------------------------------------
+# When ALL layers use MambaSpec (e.g. all-GDN or all-KDA placement), vLLM
+# creates a single KV cache group and selects UnitaryKVCacheCoordinator.
+# That coordinator asserts hash_block_size == block_size, but for MambaSpec
+# block_size = max_model_len (e.g. 4096) while hash_block_size comes from
+# cache_config.block_size (16 on CUDA).  Prefix caching is meaningless for
+# pure recurrent state anyway (can't share state prefixes across requests),
+# so we fall back to KVCacheCoordinatorNoPrefixCache in this case.
+def _patch_coordinator_selection() -> None:
+    import vllm.v1.core.kv_cache_coordinator as _coord
+
+    _original = _coord.get_kv_cache_coordinator
+
+    def _patched(kv_cache_config, max_model_len, use_eagle, enable_caching,
+                 enable_kv_cache_events, dcp_world_size, pcp_world_size,
+                 hash_block_size, metrics_collector=None):
+        # Detect pure-recurrent: single group whose spec is MambaSpec with
+        # block_size != hash_block_size (would trip UnitaryCoordinator assert)
+        if (enable_caching
+                and len(kv_cache_config.kv_cache_groups) == 1
+                and isinstance(
+                    kv_cache_config.kv_cache_groups[0].kv_cache_spec,
+                    MambaSpec)
+                and kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size
+                != hash_block_size):
+            apriel2_logger.info(
+                "Pure recurrent config detected (MambaSpec block_size=%d != "
+                "hash_block_size=%d). Disabling prefix caching for this "
+                "config (recurrent state is not prefix-shareable).",
+                kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size,
+                hash_block_size,
+            )
+            return _coord.KVCacheCoordinatorNoPrefixCache(
+                kv_cache_config,
+                max_model_len,
+                use_eagle,
+                enable_kv_cache_events,
+                dcp_world_size=dcp_world_size,
+                pcp_world_size=pcp_world_size,
+                hash_block_size=hash_block_size,
+                metrics_collector=metrics_collector,
+            )
+        return _original(
+            kv_cache_config, max_model_len, use_eagle, enable_caching,
+            enable_kv_cache_events, dcp_world_size, pcp_world_size,
+            hash_block_size, metrics_collector=metrics_collector,
+        )
+
+    _coord.get_kv_cache_coordinator = _patched
+
+
+_patch_coordinator_selection()
+
+
 # =============================================================================
 # KV Cache Spec Computation
 # =============================================================================


### PR DESCRIPTION


  Base branch: feature/vllm-apriel2-models

  Summary

  - Fixes a crash when serving Apriel2 with pure-recurrent placements (all-GDN, all-KDA, or GDN+KDA only — no attention/SWA layers)
  - Root cause: UnitaryKVCacheCoordinator asserts hash_block_size == block_size, but for MambaSpec block_size = max_model_len (e.g. 4096) while hash_block_size = cache_config.block_size (16 on CUDA)
  - Fix: monkey-patch get_kv_cache_coordinator to detect pure-recurrent single-group configs and fall back to KVCacheCoordinatorNoPrefixCache — prefix caching is meaningless for recurrent state anyway (can't share state prefixes across requests)
  - Mixed configs with any attention-type layer (FA or SWA) are unaffected and continue using the normal coordinator with prefix caching

  Details

  When all layers return MambaSpec, vLLM creates a single KV cache group and picks UnitaryKVCacheCoordinator (kv_cache_coordinator.py:538). That coordinator asserts:

  assert not enable_caching or (hash_block_size == self.block_size)

  - hash_block_size = cache_config.block_size = 16 (CUDA default)
  - self.block_size = MambaSpec.block_size = max_model_len = 4096

  For attention specs, both equal 16 so the assert passes. For pure MambaSpec, 16 ≠ 4096 → crash.

  The HybridKVCacheCoordinator (used when there are 2+ cache group types) doesn't have this assertion, which is why any mix with at least one attention-type layer works. This is also why it was never caught — all production presets include SWA layers.

  Test plan

  - Tested on SuperApriel-0.5b-Base with all 8 placement combinations:

  | Config         | Before | After |
  |----------------|--------|-------|
  | all-attention  | OK     | OK    |
  | all-swa        | OK     | OK    |
  | all-gdn        | CRASH  | OK    |
  | all-kda        | CRASH  | OK    |
  | mixed-attn-gdn | OK     | OK    |
  | mixed-swa-kda  | OK     | OK    |
  | mixed-gdn-kda  | CRASH  | OK    |
  | mixed-all-4    | OK     | OK    |

  - Pure-recurrent configs log an info message and auto-disable prefix caching
  - Mixed configs with attention layers are unaffected (no code path change)
  - 15B model: not tested (weights not available on test machine), but the fix is model-agnostic — it patches get_kv_cache_coordinator which is independent of model size
