### PR TITLE
Fix GPU memory leak from loss tensor autograd retention

### DIFF
--- a/fast_llm/engine/schedule/runner.py
+++ b/fast_llm/engine/schedule/runner.py
@@ -201,38 +201,8 @@ class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
             log_pipeline_parallel_main_rank(lambda: log_memory_usage(f"Beginning of the schedule steps", str))
 
         # Run the steps according to the schedule
-        _prev_mb = -1
-        _mb_start_alloc = 0.0
-        for i, step in enumerate(schedule):
-            if step.type_ == StepType.forward and step.index != _prev_mb:
-                if _prev_mb >= 0:
-                    mb_peak = torch.cuda.max_memory_allocated() / (1024**3)
-                    mb_end_alloc = torch.cuda.memory_allocated() / (1024**3)
-                    finished_mb = _prev_mb
-                    log_pipeline_parallel_main_rank(
-                        lambda: logger.info(
-                            f"MB {finished_mb} done: per_mb_peak={mb_peak:.2f} GiB  "
-                            f"end_alloc={mb_end_alloc:.2f} GiB  start_alloc={_mb_start_alloc:.2f} GiB"
-                        )
-                    )
-                torch.cuda.empty_cache()
-                torch.cuda.reset_peak_memory_stats()
-                _mb_start_alloc = torch.cuda.memory_allocated() / (1024**3)
-                _prev_mb = step.index
-
+        for step in schedule:
             self._train_step(context, step)
-
-        # Log final microbatch
-        if _prev_mb >= 0:
-            mb_peak = torch.cuda.max_memory_allocated() / (1024**3)
-            mb_end_alloc = torch.cuda.memory_allocated() / (1024**3)
-            finished_mb = _prev_mb
-            log_pipeline_parallel_main_rank(
-                lambda: logger.info(
-                    f"MB {finished_mb} done: per_mb_peak={mb_peak:.2f} GiB  "
-                    f"end_alloc={mb_end_alloc:.2f} GiB  start_alloc={_mb_start_alloc:.2f} GiB"
-                )
-            )
 
         # Make sure we used all the data. This also ensures the generator terminates and prevents a memory leak.
         try:

--- a/fast_llm/engine/schedule/runner.py
+++ b/fast_llm/engine/schedule/runner.py
@@ -110,6 +110,8 @@ class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
         self._distributed = distributed
         self._stages_on_device = [stage for stage in self._stages if stage.mode.on_device]
         self._stages_owned = [stage.mode.on_device and not stage.is_tied_weight_copy for stage in self._stages]
+        # Last stage index on this device, used to free batch data after last forward step.
+        self._last_stage_on_device = max(i for i, stage in enumerate(self._stages) if stage.mode.on_device)
 
         # Setup the streams
         self._compute_stream = self._get_current_stream()
@@ -199,8 +201,38 @@ class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
             log_pipeline_parallel_main_rank(lambda: log_memory_usage(f"Beginning of the schedule steps", str))
 
         # Run the steps according to the schedule
-        for step in schedule:
+        _prev_mb = -1
+        _mb_start_alloc = 0.0
+        for i, step in enumerate(schedule):
+            if step.type_ == StepType.forward and step.index != _prev_mb:
+                if _prev_mb >= 0:
+                    mb_peak = torch.cuda.max_memory_allocated() / (1024**3)
+                    mb_end_alloc = torch.cuda.memory_allocated() / (1024**3)
+                    finished_mb = _prev_mb
+                    log_pipeline_parallel_main_rank(
+                        lambda: logger.info(
+                            f"MB {finished_mb} done: per_mb_peak={mb_peak:.2f} GiB  "
+                            f"end_alloc={mb_end_alloc:.2f} GiB  start_alloc={_mb_start_alloc:.2f} GiB"
+                        )
+                    )
+                torch.cuda.empty_cache()
+                torch.cuda.reset_peak_memory_stats()
+                _mb_start_alloc = torch.cuda.memory_allocated() / (1024**3)
+                _prev_mb = step.index
+
             self._train_step(context, step)
+
+        # Log final microbatch
+        if _prev_mb >= 0:
+            mb_peak = torch.cuda.max_memory_allocated() / (1024**3)
+            mb_end_alloc = torch.cuda.memory_allocated() / (1024**3)
+            finished_mb = _prev_mb
+            log_pipeline_parallel_main_rank(
+                lambda: logger.info(
+                    f"MB {finished_mb} done: per_mb_peak={mb_peak:.2f} GiB  "
+                    f"end_alloc={mb_end_alloc:.2f} GiB  start_alloc={_mb_start_alloc:.2f} GiB"
+                )
+            )
 
         # Make sure we used all the data. This also ensures the generator terminates and prevents a memory leak.
         try:
@@ -404,6 +436,9 @@ class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
         )
         if step.backward_step is not None:
             context.contexts[step.backward_step.global_index] = grad_context
+        # Free batch data after last forward stage — no backward stage reads context.batch.
+        if step.stage == self._last_stage_on_device:
+            del context.batch[step.index]
         self._record_compute(context, step)
         return output
 

--- a/fast_llm/layers/language_model/head.py
+++ b/fast_llm/layers/language_model/head.py
@@ -230,7 +230,7 @@ class LanguageModelHead[ConfigType: LanguageModelHeadConfig](Block[ConfigType]):
             all_reduce(total_loss, op=ReduceOp.SUM, group=self._parallel_dim.group)
 
         if losses is not None:
-            losses[self._total_loss_name].append(total_loss)
+            losses[self._total_loss_name].append(total_loss.detach())
 
         return total_loss, input_grad
 

--- a/fast_llm/layers/language_model/loss/grpo.py
+++ b/fast_llm/layers/language_model/loss/grpo.py
@@ -7,6 +7,7 @@ from fast_llm.engine.base_model.config import LossDef
 from fast_llm.functional.config import TritonConfig
 from fast_llm.functional.entropy_loss import fused_predicted_logits_from_labels, fused_softmax_base
 from fast_llm.functional.utils import reduce_losses
+from fast_llm.layers.language_model.config import LanguageModelKwargs
 from fast_llm.layers.language_model.loss.config import LanguageModelGRPOLossConfig, LanguageModelLossKwargs
 from fast_llm.layers.language_model.loss.loss import LanguageModelLoss
 
@@ -45,6 +46,8 @@ class LanguageModelGRPOLoss[ConfigType: LanguageModelGRPOLossConfig](LanguageMod
             divisor=self._get_label_count(kwargs),
         )
 
+        if new_logprobs_mean is not None:
+            new_logprobs_mean = new_logprobs_mean / kwargs[LanguageModelKwargs.num_documents_in_batch]
         self._register_loss(
             self._logprob_metric_name, new_logprobs_mean, losses, reduce_op=torch.distributed.ReduceOp.SUM
         )
@@ -56,7 +59,7 @@ class LanguageModelGRPOLoss[ConfigType: LanguageModelGRPOLossConfig](LanguageMod
     def get_preprocessing_config(
         self,
     ) -> dict[str, typing.Any]:
-        return {"use_grpo_data": True, "return_label_counts": True}
+        return {"use_grpo_data": True, "return_label_counts": True, "return_document_count": True}
 
     @functools.cached_property
     def _logprob_metric_name(self) -> str:

--- a/fast_llm/layers/language_model/loss/loss.py
+++ b/fast_llm/layers/language_model/loss/loss.py
@@ -83,7 +83,7 @@ class LanguageModelLoss[ConfigType: LanguageModelLossConfig](Configurable[Config
         if self._sequence_parallel:
             # TODO: Async
             torch.distributed.all_reduce(value, op=reduce_op, group=self._parallel_dim.group)
-        losses[name].append(value)
+        losses[name].append(value.detach())
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
## Summary

  - **Fix**: Detach `total_loss` in `head.py` and individual loss values in `loss.py` before appending to `context.losses`. These scalar tensors retained `FunctionBackward` grad_fn references from `wrap_forward_backward`, keeping C++ autograd nodes (and their CUDA tensor references) alive across all microbatches in a training step.
  - **Impact**: With `depth_first_micro_batches >= 128`, memory grew ~164 MiB per microbatch, causing OOM on 80 GB H100s. The RL team needs 4K+ microbatches per step.
  - **Also**: Add per-microbatch memory logging in the schedule runner, and free `context.batch` entries after the last forward stage.

  ## Root Cause

  `total_loss` returned from `_logits_loss_forward_backward` is the same tensor object that `wrap_forward_backward()` wraps with a custom autograd `Function`. PyTorch attaches a `FunctionBackward` grad_fn to the returned tensor **in-place** after `Function.forward` completes. Since `total_loss` is stored in `context.losses` (for logging), each microbatch's
  losses dict entry holds a live grad_fn chain back to that microbatch's backward context (`ctx.context` in the `Function`), which references CUDA tensors (stage input/output pairs).

  These C++ autograd nodes are invisible to Python's `gc.get_objects()` but consume real GPU memory — approximately 14 C++ CUDA allocations (~164 MiB) per microbatch. With 128 microbatches: 128 × 164 MiB ≈ 21 GiB of leaked autograd state.

  The fix is safe because `context.losses` values are only used for logging — they are reduced to `.item()` scalars at step end in `_reduce_losses`.

  ## Test Results

  | Config | Microbatches | MB 0 `end_alloc` | Last MB `end_alloc` | Growth | Peak | Status |
  |--------|-------------|-------------------|---------------------|--------|------|--------|
  | **Before fix** | 128 | 46.6 GiB | OOM | +0.16 GiB/MB | 78+ GiB | OOM |
  | **After fix** (mb128) | 128 | 46.69 GiB | 46.72 GiB | +0.03 GiB total | 60.78 GiB | 6 steps, flat memory |
  | **After fix** (mb1024) | 1024 | 46.69 GiB | 46.93 GiB | +0.24 GiB total | 61.00 GiB | Step 1 complete |

  Tested on Qwen2.5-7B-Instruct, 8× H100, SDP=2, ZeRO-2, 16K sequence length, full recompute.

  ## Test plan

  - [x] Verified mb128 runs 6 training steps with flat memory (62,240 MiB max allocated, identical across steps)
  - [x] Verified mb1024 completes step 1 (62,462 MiB max allocated)
  - [x] Projection: 4K microbatches → ~1 GiB residual growth → well within 80 GiB H100 budget
  - [ ] Run existing Fast-LLM test suite