### PR TITLE
Fix KDA equivalence tests and add accelerate dependency

### DIFF
--- a/fast_llm_external_models/tests/test_apriel2/test_mixer_equivalence.py
+++ b/fast_llm_external_models/tests/test_apriel2/test_mixer_equivalence.py
@@ -144,7 +144,7 @@ def kda_mixer_config(kda_config):
         "heads": num_heads,
         "head_dim": head_dim,
         "convolution_layer": {"kernel_size": 4},
-        "normalization": {"epsilon": 1e-5},
+        "normalization": {"epsilon": 1e-5, "activation": "sigmoid"},
     }
 
 
@@ -1088,9 +1088,8 @@ class TestKDAEquivalence:
         fla_cache = FLACache()
         apriel_cache = Apriel2Cache(make_apriel2_config(kda_hidden_size, kda_mixer_config))
 
-        # Force chunk mode for prefill
-        fla_kda.mode = "chunk"
-        apriel_kda.mode = "chunk"
+        # Match Apriel2's mode selection: fused_recurrent for seq_len<=64 in eval
+        fla_kda.mode = "fused_recurrent"
 
         # ========== PHASE 1: Initial Prefill ==========
         prefill_input = hidden_states[:, :prefill_len, :]
@@ -1125,7 +1124,6 @@ class TestKDAEquivalence:
 
         # ========== PHASE 2: Decode (single tokens) ==========
         fla_kda.mode = "fused_recurrent"
-        apriel_kda.mode = "fused_recurrent"
 
         for i in range(decode_steps):
             pos = prefill_len + i
@@ -1160,9 +1158,7 @@ class TestKDAEquivalence:
         )
 
         # ========== PHASE 3: Prefill again (decode→prefill transition) ==========
-        # FLA KDA correctly uses initial_state in chunk mode, so this should match
-        fla_kda.mode = "chunk"
-        apriel_kda.mode = "chunk"
+        fla_kda.mode = "fused_recurrent"
 
         prefill2_start = prefill_len + decode_steps
         prefill2_input = hidden_states[:, prefill2_start : prefill2_start + prefill2_len, :]

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ OPTIONAL =
 # Huggingface tools
 HUGGINGFACE =
     transformers>=4.57.3,<5.0.0
+    accelerate>=1.4.0
     hf-transfer>=0.1.9
     datasets>=4.4.1
     huggingface-hub>=0.36.0


### PR DESCRIPTION
## Summary

- **KDA gate activation**: the `kda_mixer_config` test fixture was missing `"activation": "sigmoid"` in its normalization config. Apriel2 defaults to `silu` but FLA's `KimiDeltaAttention` hardcodes `sigmoid`, causing ~0.5 max diff and 324 test failures on GPU. Fixed by making the test explicit about the activation it's testing against.
- **Mode alignment**: removed forced `mode = "chunk"` on both models since both FLA and Apriel2 share the same `fused_recurrent` auto-heuristic for `seq_len <= 64` in eval — the override was always silently ignored on Apriel2's side.
- **`accelerate` dependency**: transformers 4.57 introduced auto-detection of the torch CUDA context and sets `device_map` implicitly, which then requires `accelerate`. Added `accelerate>=1.4.0` to the `HUGGINGFACE` extras in `setup.cfg`.

## Test plan

- [x] All 2117 remote GPU tests pass, 42 skipped, 0 failures
- [x] All 371 local CPU tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)