### PR TITLE
Fix two test failures from transformers v5 support

### DIFF
--- a/fast_llm_external_models/apriel2/modeling_apriel2.py
+++ b/fast_llm_external_models/apriel2/modeling_apriel2.py
@@ -2330,18 +2330,20 @@ class Apriel2PreTrainedModel(PreTrainedModel):
             return
         model_kwargs["past_key_values"] = Apriel2Cache(config=self.config)
 
-    def _init_weights(self, module):
-        std = self.config.initializer_range if hasattr(self.config, "initializer_range") else 0.02
-        if isinstance(module, nn.Linear):
-            module.weight.data.normal_(mean=0.0, std=std)
-            if module.bias is not None:
-                module.bias.data.zero_()
-        elif isinstance(module, nn.Embedding):
-            module.weight.data.normal_(mean=0.0, std=std)
-            if module.padding_idx is not None:
-                module.weight.data[module.padding_idx].zero_()
-        elif isinstance(module, MistralRMSNorm):
-            module.weight.data.fill_(1.0)
+    if _TRANSFORMERS_V4:
+
+        def _init_weights(self, module):
+            std = self.config.initializer_range if hasattr(self.config, "initializer_range") else 0.02
+            if isinstance(module, nn.Linear):
+                module.weight.data.normal_(mean=0.0, std=std)
+                if module.bias is not None:
+                    module.bias.data.zero_()
+            elif isinstance(module, nn.Embedding):
+                module.weight.data.normal_(mean=0.0, std=std)
+                if module.padding_idx is not None:
+                    module.weight.data[module.padding_idx].zero_()
+            elif isinstance(module, MistralRMSNorm):
+                module.weight.data.fill_(1.0)
 
     def tie_weights(self, **kwargs):
         super().tie_weights(**kwargs)

--- a/tests/layers/test_lm_head.py
+++ b/tests/layers/test_lm_head.py
@@ -147,6 +147,7 @@ class LMHeadTestConfig:
                 torch.full(input_.shape[:-1], float((labels_ >= 0).sum()), dtype=torch.float32, device=device)
                 for labels_ in kwargs[LanguageModelKwargs.labels]
             ]
+            kwargs[LanguageModelKwargs.num_documents_in_batch] = 1
         return input_, kwargs
 
     def get_reference_outputs(


### PR DESCRIPTION
## Summary

- **`modeling_apriel2.py`**: Guard `_init_weights` under `if _TRANSFORMERS_V4`. In transformers v5, `from_pretrained` calls `initialize_weights()` after loading the checkpoint, which re-invokes `_init_weights` on every module via `smart_apply`. The raw `.data.normal_()` calls bypass `guard_torch_init_functions` patching (which gates on `_is_hf_initialized`), so all loaded weights were silently overwritten with fresh random values. In v5 the inherited `PreTrainedModel._init_weights` default already uses `init.*` functions correctly and handles `nn.Linear`, `nn.Embedding`, and `*RMSNorm` modules.

- **`test_lm_head.py`**: Add `num_documents_in_batch=1` to GRPO test kwargs. `LanguageModelGRPOLoss._forward_backward` reads this key when computing the `new_logprobs` metric, but the test never populated it.

## Test plan

- [x] `pytest -v tests/layers/test_lm_head.py -k grpo` — all 4 GRPO variants pass
- [x] `pytest -v tests/models/test_hf_roundtrip.py -k apriel2` — both apriel2 roundtrip cases pass
- [x] `pytest -v -n 8 tests/` — 2007 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)