### PR TITLE
Security improvements

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,13 +8,12 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -43,6 +42,8 @@ jobs:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -82,11 +82,16 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/servicenow/fast-llm:cache,mode=max
 
       - name: Output build info
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          BRANCH: ${{ inputs.branch }}
+          FULL_SHA: ${{ steps.commit_info.outputs.full_sha }}
+          SHORT_SHA: ${{ steps.commit_info.outputs.short_sha }}
         run: |
           echo "Built Docker image with tags:"
-          echo "${{ steps.meta.outputs.tags }}"
+          echo "$TAGS"
           echo ""
           echo "Build details:"
-          echo "Branch: ${{ inputs.branch }}"
-          echo "Commit: ${{ steps.commit_info.outputs.full_sha }}"
-          echo "Short SHA: ${{ steps.commit_info.outputs.short_sha }}"
+          echo "Branch: $BRANCH"
+          echo "Commit: $FULL_SHA"
+          echo "Short SHA: $SHORT_SHA"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,20 +9,15 @@ RUN apt-get update \
 
 # Set the working directory.
 WORKDIR /app
-# Set the permission to 777 for all files and directories in `/app`, `/home` and python install directories:
-#   1. Create directories explicitly because docker use the wrong permission for explicit creation.
-#   2. For the rest, set the default ACL to 777 for all users.
+# Make /app and /home world-rwx so the cluster's dynamically-assigned UIDs can write to them.
+# Subdirs are created explicitly because Docker uses the wrong permissions for implicit creation;
+# the default ACL then propagates to files copied or created under each path. Our primary cluster
+# mounts /home from the outside, but other deployments may run the image as-is with the
+# in-image /home, so we keep it permissive here. /usr/local/lib/python3.12 deliberately stays at
+# default perms so a compromised process can't tamper with installed Python packages or system
+# binaries.
 RUN mkdir -m 777 /app/Megatron-LM /app/examples /app/fast_llm /app/tests /app/tools \
-    && setfacl -m d:u::rwx,d:g::rwx,d:o::rwx,u::rwx,g::rwx,o::rwx \
-      /app \
-      /home \
-      /usr \
-      /usr/local \
-      /usr/local/bin \
-      /usr/local/lib \
-      /usr/local/lib/python3.12 \
-      /usr/local/lib/python3.12/dist-packages \
-      /usr/local/lib/python3.12/dist-packages/__pycache__
+    && setfacl -m d:u::rwx,d:g::rwx,d:o::rwx,u::rwx,g::rwx,o::rwx /app /home
 
 # The base image enforces versions for things like pytest for no good reason.
 ENV PIP_CONSTRAINT=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,22 +27,23 @@ ENV PIP_CONSTRAINT=""
 RUN MAX_JOBS=2 pip install --no-build-isolation "causal-conv1d @ git+https://github.com/Dao-AILab/causal-conv1d@v1.5.4"
 RUN MAX_JOBS=2 pip install --no-build-isolation mamba-ssm==2.2.6.post3
 RUN MAX_JOBS=2 pip install --no-build-isolation "flash-linear-attention @ git+https://github.com/fla-org/flash-linear-attention@67eee20c8503cd19eeb52aa1b99821308e9260c5"
-# Copy dependency files with universal write permissions for all users.
-COPY --chmod=777 setup.py setup.cfg pyproject.toml ./
-COPY --chmod=777 ./fast_llm_external_models/__init__.py fast_llm_external_models/
-COPY --chmod=777 ./fast_llm/__init__.py fast_llm/
-COPY --chmod=777 ./fast_llm/csrc/ fast_llm/csrc/
+# Copy dependency files. Source files end up root-owned and read-only for non-root processes;
+# /app itself stays writable so the runtime UID can create new files (logs, __pycache__, etc.).
+COPY setup.py setup.cfg pyproject.toml ./
+COPY ./fast_llm_external_models/__init__.py fast_llm_external_models/
+COPY ./fast_llm/__init__.py fast_llm/
+COPY ./fast_llm/csrc/ fast_llm/csrc/
 
 # Install dependencies within the virtual environment.
 RUN pip install --no-cache-dir --no-build-isolation -e ".[CORE,OPTIONAL,HUGGINGFACE,SSM,VISION,GENERATION,STREAMING,DEV]" triton==3.5.1 "transformers>=5.0.0,<6.0.0"
 
-# Copy the remaining source code with universal write permissions.
-COPY --chmod=777 ./Megatron-LM Megatron-LM
-COPY --chmod=777 ./examples examples
-COPY --chmod=777 ./tests tests
-COPY --chmod=777 ./tools tools
-COPY --chmod=777 ./fast_llm_external_models fast_llm_external_models
-COPY --chmod=777 --exclude=./fast_llm/csrc/ ./fast_llm/ fast_llm/
+# Copy the remaining source code (read-only for non-root, see the note on dependency files above).
+COPY ./Megatron-LM Megatron-LM
+COPY ./examples examples
+COPY ./tests tests
+COPY ./tools tools
+COPY ./fast_llm_external_models fast_llm_external_models
+COPY --exclude=./fast_llm/csrc/ ./fast_llm/ fast_llm/
 
 # Set a dummy default user so we don't run in root by default.
 # The image is still compatible with any user id.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -278,6 +278,8 @@ Save the following as `./fast-llm-tutorial/prepare-config.yaml``:
     1. Processing speed scales linearly with the number of CPUs.
     2.  99% train, 1% validation. These settings need to be adjusted based on the size of your dataset.
 
+Some HuggingFace datasets ship custom Python loaders that run on download. The `trust_remote_code: true` field above only takes effect when you also pass `--trust-remote-code` on the `fast-llm prepare` command line; the field alone is intentionally a no-op so that opening someone else's config can never trigger remote-code execution. Both opt-ins are required (`--trust-remote-code` is the master switch and `trust_remote_code: true` enables it for that specific call). If you would rather opt in once for every call in the run, pass `--trust-all-remote-code` instead.
+
 Fast-LLM ships with a `prepare` command that will download and preprocess the dataset for you.
 
 === "Prebuilt Docker"
@@ -285,7 +287,7 @@ Fast-LLM ships with a `prepare` command that will download and preprocess the da
     Run data preparation with the following command:
 
     ```bash
-    fast-llm prepare gpt_memmap --config fast-llm-tutorial/prepare-config.yaml
+    fast-llm prepare gpt_memmap --trust-remote-code --config fast-llm-tutorial/prepare-config.yaml
     ```
 
 === "Custom Installation"
@@ -293,7 +295,7 @@ Fast-LLM ships with a `prepare` command that will download and preprocess the da
     Run data preparation with the following command:
 
     ```bash
-    fast-llm prepare gpt_memmap --config fast-llm-tutorial/prepare-config.yaml
+    fast-llm prepare gpt_memmap --trust-remote-code --config fast-llm-tutorial/prepare-config.yaml
     ```
 
 === "Slurm"
@@ -331,6 +333,7 @@ Fast-LLM ships with a `prepare` command that will download and preprocess the da
                      --rdzv_conf=timeout=3600 \
                      --no_python \
                      fast-llm prepare gpt_memmap \
+                     --trust-remote-code \
                      --config fast-llm-tutorial/prepare-config.yaml"
     EOF
     ```
@@ -390,6 +393,7 @@ Fast-LLM ships with a `prepare` command that will download and preprocess the da
                                --rdzv_conf=timeout=3600 \
                                --no_python \
                                fast-llm prepare gpt_memmap \
+                               --trust-remote-code \
                                --config fast-llm-tutorial/prepare-config.yaml
                   env:
                     - name: PYTHONHASHSEED
@@ -445,6 +449,7 @@ Fast-LLM ships with a `prepare` command that will download and preprocess the da
                                --rdzv_conf=timeout=3600 \
                                --no_python \
                                fast-llm prepare gpt_memmap \
+                               --trust-remote-code \
                                --config fast-llm-tutorial/prepare-config.yaml
                   env:
                     - name: PYTHONHASHSEED

--- a/docs/recipes/data-preparation.md
+++ b/docs/recipes/data-preparation.md
@@ -90,6 +90,8 @@ tokenizer:
 
 Save it as `./prep-stack-tutorial/the-stack-prepare.yaml`
 
+Some HuggingFace datasets ship custom Python loaders that run on download. The `trust_remote_code: true` field above only takes effect when you also pass `--trust-remote-code` on the `fast-llm prepare` command line; the field alone is intentionally a no-op so that opening someone else's config can never trigger remote-code execution. Both opt-ins are required (`--trust-remote-code` is the master switch and `trust_remote_code: true` enables it for that specific call). If you would rather opt in once for every call in the run, pass `--trust-all-remote-code` instead.
+
 ## 🚀 Step 3: Launch data preparation job
 
 Fast-LLM's prepare command processes the dataset by tokenizing and saving it in Fast-LLM's memory-mapped indexed dataset format.
@@ -99,7 +101,7 @@ Fast-LLM's prepare command processes the dataset by tokenizing and saving it in 
     ```bash
     docker run -it --rm ghcr.io/servicenow/fast-llm:latest \
         -v ./prep-stack-tutorial:/app/prep-stack-tutorial \
-        fast-llm prepare gpt_memmap --config /app/prep-stack-tutorial/the-stack-prepare.yaml
+        fast-llm prepare gpt_memmap --trust-remote-code --config /app/prep-stack-tutorial/the-stack-prepare.yaml
     ```
 
 === "Custom Installation"
@@ -109,7 +111,7 @@ Fast-LLM's prepare command processes the dataset by tokenizing and saving it in 
     Then, run the following command:
 
     ```bash
-    fast-llm prepare gpt_memmap --config ./prep-stack-tutorial/the-stack-prepare.yaml
+    fast-llm prepare gpt_memmap --trust-remote-code --config ./prep-stack-tutorial/the-stack-prepare.yaml
     ```
 
 === "Slurm"
@@ -145,6 +147,7 @@ Fast-LLM's prepare command processes the dataset by tokenizing and saving it in 
                      --rdzv_conf=timeout=3600 \
                      --no_python \
                      fast-llm prepare gpt_memmap \
+                     --trust-remote-code \
                      --config /app/prep-stack-tutorial/the-stack-prepare.yaml"
     EOF
     ```
@@ -251,6 +254,7 @@ Fast-LLM's prepare command processes the dataset by tokenizing and saving it in 
                                --rdzv_conf=timeout=3600 \
                                --no_python \
                                fast-llm prepare gpt_memmap \
+                               --trust-remote-code \
                                --config prep-stack-tutorial/the-stack-prepare.yaml
                   env:
                     - name: PYTHONHASHSEED
@@ -306,6 +310,7 @@ Fast-LLM's prepare command processes the dataset by tokenizing and saving it in 
                                --rdzv_conf=timeout=3600 \
                                --no_python \
                                fast-llm prepare gpt_memmap \
+                               --trust-remote-code \
                                --config prep-stack-tutorial/the-stack-prepare.yaml
                   env:
                     - name: PYTHONHASHSEED

--- a/docs/recipes/instruction-finetuning.md
+++ b/docs/recipes/instruction-finetuning.md
@@ -105,6 +105,8 @@ splits:
   validation: 0.002
 ```
 
+Some HuggingFace datasets ship custom Python loaders that run on download. The `trust_remote_code: true` field above only takes effect when you also pass `--trust-remote-code` on the `fast-llm prepare` command line; the field alone is intentionally a no-op so that opening someone else's config can never trigger remote-code execution. Both opt-ins are required (`--trust-remote-code` is the master switch and `trust_remote_code: true` enables it for that specific call). If you would rather opt in once for every call in the run, pass `--trust-all-remote-code` instead.
+
 ## ⚙️ Step 4: Configure Fast-LLM
 
 It's time to configure the Fast-LLM training config. This is very similar to [Quick Start](../quick-start.md) with one additional option, namely `truncate_documents`, which is important for improving the task performance of instruction-tuned models.

--- a/fast_llm/csrc/data.cpp
+++ b/fast_llm/csrc/data.cpp
@@ -31,6 +31,8 @@
 */
 
 #include <iostream>
+#include <stdexcept>
+#include <string>
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 
@@ -50,12 +52,30 @@ py::array build_sample_idx(const py::array_t<int32_t>& sizes_,
        where [..., 0] contains the index into `doc_idx` and [..., 1] is the
        starting offset in that document.*/
 
-    // Consistency checks.
-    assert(seq_length > 1);
-    assert(num_epochs > 0);
-    assert(tokens_per_epoch > 1);
+    // Use exceptions rather than `assert`, which compiles to a no-op under -DNDEBUG.
+    if (seq_length <= 1) throw std::invalid_argument("seq_length must be > 1");
+    if (num_epochs <= 0) throw std::invalid_argument("num_epochs must be > 0");
+    if (tokens_per_epoch <= 1) throw std::invalid_argument("tokens_per_epoch must be > 1");
+    if (sizes_.shape(0) <= 0) throw std::invalid_argument("sizes must be non-empty");
+    if (doc_idx_.shape(0) <= 0) throw std::invalid_argument("doc_idx must be non-empty");
 
-    // Remove bound checks.
+    // Bounds-check `doc_idx` once up front so the inner loops can use unchecked accesses.
+    // Without this the inner-loop `sizes[doc_idx[i]]` is an out-of-bounds heap read on a
+    // malformed `doc_idx`.
+    {
+        auto doc_idx_check = doc_idx_.unchecked<1>();
+        const int64_t sizes_len = sizes_.shape(0);
+        for (int64_t i = 0; i < doc_idx_.shape(0); ++i) {
+            const int32_t value = doc_idx_check[i];
+            if (value < 0 || value >= sizes_len) {
+                throw std::out_of_range(
+                    "doc_idx[" + std::to_string(i) + "] = " + std::to_string(value)
+                    + " out of range [0, " + std::to_string(sizes_len) + ")");
+            }
+        }
+    }
+
+    // Remove bound checks for the hot inner loops.
     auto sizes = sizes_.unchecked<1>();
     auto doc_idx = doc_idx_.unchecked<1>();
 
@@ -138,6 +158,10 @@ py::array build_padded_token_cumsum(const py::array_t<int32_t>& sizes_,
   Build token cumsums at regular intervals from document sizes with padding in mind.
   We inject 0 or more padding tokens at the end of every sequence to fill the sequence length.
   */
+  if (seq_length <= 0) throw std::invalid_argument("seq_length must be > 0");
+  // `samples % token_cumsum_rate == 0` would be undefined behavior at zero.
+  if (token_cumsum_rate <= 0) throw std::invalid_argument("token_cumsum_rate must be > 0");
+
   int32_t seq_size = 0;
   int64_t sizes_idx = 0;
   int32_t samples = 0;

--- a/fast_llm/data/dataset/config.py
+++ b/fast_llm/data/dataset/config.py
@@ -299,6 +299,10 @@ class RedisConfig(Config):
     def get_client(self):
         import redis
 
+        # TODO: Add `password` and `ssl` fields if we ever run Redis off-localhost. Streaming
+        # broadcasts tokenized training data, so an unauthenticated remote server lets anyone on
+        # the network read or poison the stream. Acceptable today only because the Redis server
+        # is colocated within a trusted cluster network.
         return redis.Redis(self.host, self.port)
 
 

--- a/fast_llm/data/dataset/gpt/config.py
+++ b/fast_llm/data/dataset/gpt/config.py
@@ -78,6 +78,14 @@ class GPTDatasetFromFileConfig[DocumentType: LanguageModelDocument](SamplableDat
                 self._convert_paths(value)
             if "path" in config:
                 assert isinstance(config["path"], (str, pathlib.Path))
+                # Reject absolute paths and `..` segments so a malicious dataset config can't pull
+                # in arbitrary files outside its containing directory.
+                inner_path = pathlib.PurePosixPath(str(config["path"]))
+                if inner_path.is_absolute() or ".." in inner_path.parts:
+                    raise ValueError(
+                        f"Dataset config path {config['path']!r} must be relative and stay within "
+                        f"{self.path.parent}."
+                    )
                 config["path"] = self.path.parent / config["path"]
         elif isinstance(config, list):
             for value in config:

--- a/fast_llm/data/dataset/gpt/legacy_memmap.py
+++ b/fast_llm/data/dataset/gpt/legacy_memmap.py
@@ -62,6 +62,13 @@ class LegacyMemmapDataset[DocumentType: LanguageModelDocument](IndexedDataset[Do
 
         self._index_bin_buffer_mmap = np.memmap(self._prefix.with_suffix(".idx"), mode="r", order="C")
         self._index_bin_buffer = memoryview(self._index_bin_buffer_mmap)
+        buffer_size = self._index_bin_buffer_mmap.size
+
+        # Reject header counts that don't fit the buffer before they flow into `np.frombuffer`,
+        # otherwise a corrupt or malicious file can trigger a multi-GB allocation here.
+        assert (
+            0 <= self._num_documents <= buffer_size
+        ), f"Invalid num_documents {self._num_documents} for index file of size {buffer_size}."
 
         # read document sizes
         self._document_sizes = np.frombuffer(
@@ -85,8 +92,17 @@ class LegacyMemmapDataset[DocumentType: LanguageModelDocument](IndexedDataset[Do
                 count=self._num_documents,
                 offset=offset + self._document_sizes.nbytes + self._pointers.nbytes,
             )
+            assert (self._num_spans >= 0).all(), "Negative span count in index file."
             span_offset = offset + self._document_sizes.nbytes + self._pointers.nbytes + self._num_spans.nbytes
             self._num_spans_cumsum = np.r_[0, np.cumsum(self._num_spans[:-1], dtype=np.int64)]
+            total_span_bytes = (
+                (int(self._num_spans_cumsum[-1]) + int(self._num_spans[-1] if self._num_documents else 0))
+                * 2
+                * np.dtype(np.int32).itemsize
+            )
+            assert (
+                span_offset + total_span_bytes <= buffer_size
+            ), f"Span data extends past index file (need {span_offset + total_span_bytes}, have {buffer_size})."
             for idx in range(self._num_documents):
                 self._spans.append(
                     np.frombuffer(
@@ -102,6 +118,10 @@ class LegacyMemmapDataset[DocumentType: LanguageModelDocument](IndexedDataset[Do
             self._chosen_spans = []
             self._rejected_spans = []
             chosen_span_offset = offset + self._document_sizes.nbytes + self._pointers.nbytes
+            preference_span_bytes = self._num_documents * 2 * np.dtype(np.int32).itemsize
+            assert (
+                chosen_span_offset + 2 * preference_span_bytes <= buffer_size
+            ), f"Preference spans extend past index file (need {chosen_span_offset + 2 * preference_span_bytes}, have {buffer_size})."
             for idx in range(self._num_documents):
                 self._chosen_spans.append(
                     np.frombuffer(
@@ -112,9 +132,7 @@ class LegacyMemmapDataset[DocumentType: LanguageModelDocument](IndexedDataset[Do
                     )
                 )
 
-            rejected_span_offset = (
-                offset + self._document_sizes.nbytes + self._pointers.nbytes + np.array(self._chosen_spans).nbytes
-            )
+            rejected_span_offset = chosen_span_offset + preference_span_bytes
             for idx in range(self._num_documents):
                 self._rejected_spans.append(
                     np.frombuffer(

--- a/fast_llm/data/dataset/memmap/memmap.py
+++ b/fast_llm/data/dataset/memmap/memmap.py
@@ -29,13 +29,15 @@ class MemmapDataset[DocumentType: Document](IndexedDataset[DocumentType]):
         self._path = path
 
         path = pathlib.Path(path) if isinstance(path, str) else path
+        file_size = path.stat().st_size
         with path.open("rb") as stream:
-            # Verify file type.
-            assert stream.read(len(FILE_HEADER)) == FILE_HEADER
-            # Go to reader configs.
-            stream.seek(int.from_bytes(stream.read(8), signed=False))
-            # Read the reader config.
-            config_bytes = stream.read(int.from_bytes(stream.read(4), signed=False))
+            assert stream.read(len(FILE_HEADER)) == FILE_HEADER, f"Invalid file header in {path}."
+            config_offset = int.from_bytes(stream.read(8), signed=False)
+            assert config_offset + 4 <= file_size, f"Config offset {config_offset} out of range for {path}."
+            stream.seek(config_offset)
+            config_size = int.from_bytes(stream.read(4), signed=False)
+            assert config_offset + 4 + config_size <= file_size, f"Config size {config_size} out of range for {path}."
+            config_bytes = stream.read(config_size)
             reader_config = MemmapIndexDatasetReaderConfig.from_dict(json.loads(config_bytes.decode("utf-8")))
 
         self._memmap = np.memmap(self._path, mode="c")

--- a/fast_llm/data/preparation/gpt_memmap/config.py
+++ b/fast_llm/data/preparation/gpt_memmap/config.py
@@ -220,7 +220,9 @@ class GPTHuggingfaceDatasetConfig(Config):
     )
     trust_remote_code: bool = Field(
         default=False,
-        desc="Trust remote code when downloading the dataset.",
+        desc="Allow this dataset to load custom Python code shipped with its repository."
+        " Has no effect unless `--trust-remote-code` is also passed on the command line; both"
+        " are required so a config file alone cannot enable remote-code execution.",
         hint=FieldHint.optional,
     )
     disable_disk_space_check: bool = Field(

--- a/fast_llm/data/preparation/gpt_memmap/prepare.py
+++ b/fast_llm/data/preparation/gpt_memmap/prepare.py
@@ -41,6 +41,7 @@ from fast_llm.data.preparation.gpt_memmap.config import (
 from fast_llm.data.preparation.tokenizer import Tokenizer
 from fast_llm.engine.config_utils.data_type import DataType, get_unsigned_integer_type
 from fast_llm.engine.config_utils.run import log_main_rank
+from fast_llm.engine.config_utils.runnable import get_trust_remote_code
 from fast_llm.utils import normalize_probabilities, padded_cumsum
 
 logger = logging.getLogger(__name__)
@@ -74,7 +75,7 @@ class GPTMemmapDatasetPreparator[ConfigType: GPTMemmapDatasetPreparatorConfig](D
                 data_files=self._config.dataset.data_files,
                 split=self._config.dataset.split,
                 num_proc=self._config.num_workers,
-                trust_remote_code=self._config.dataset.trust_remote_code,
+                trust_remote_code=get_trust_remote_code(self._config.dataset.trust_remote_code),
             )
         assert isinstance(dataset, datasets.Dataset)
         return dataset

--- a/fast_llm/data/preparation/tokenizer.py
+++ b/fast_llm/data/preparation/tokenizer.py
@@ -5,6 +5,7 @@ import typing
 from fast_llm.config import Config, Configurable, Field, FieldHint, config_class
 from fast_llm.engine.config_utils.data_type import DataType
 from fast_llm.engine.config_utils.run import log_main_rank
+from fast_llm.engine.config_utils.runnable import get_trust_remote_code
 from fast_llm.utils import Assert
 
 if typing.TYPE_CHECKING:
@@ -37,6 +38,13 @@ class TokenizerConfig(Config):
         desc="Constrain output tokens to a specific range. Used for testing.",
         hint=FieldHint.testing,
     )
+    trust_remote_code: bool = Field(
+        default=False,
+        desc="Allow this tokenizer to load custom Python code shipped with its repository."
+        " Has no effect unless `--trust-remote-code` is also passed on the command line; both"
+        " are required so a config file alone cannot enable remote-code execution.",
+        hint=FieldHint.feature,
+    )
 
     def get_tokenizer(self) -> "Tokenizer":
         return Tokenizer(self)
@@ -56,7 +64,7 @@ class Tokenizer[ConfigType: TokenizerConfig](Configurable[ConfigType]):
             pretrained_model_name_or_path=self._config.path,
             errors="replace",
             max_len=None,
-            trust_remote_code=True,
+            trust_remote_code=get_trust_remote_code(self._config.trust_remote_code),
             use_fast=True,
         )
         if self._config.bos_token is not None:

--- a/fast_llm/engine/config_utils/runnable.py
+++ b/fast_llm/engine/config_utils/runnable.py
@@ -16,6 +16,20 @@ from fast_llm.engine.config_utils.logging import configure_logging
 logger = logging.getLogger(__name__)
 
 
+# Process-wide opt-in for executing Python code shipped with HuggingFace tokenizers/models/datasets.
+# Set on the CLI by `--trust-remote-code` (master switch, AND-ed with each call's own config field)
+# or `--trust-all-remote-code` (master switch + ignore the config field, trusting every call).
+# Both are intentionally CLI-only: a malicious YAML config can't flip them on by itself, so
+# opening someone else's training config can't trigger remote-code execution unless the user
+# opts in explicitly on the command line.
+_trust_remote_code = False
+_trust_all_remote_code = False
+
+
+def get_trust_remote_code(config_flag: bool) -> bool:
+    return _trust_all_remote_code or (_trust_remote_code and config_flag)
+
+
 @config_class(registry=True)
 class RunnableConfig(Config):
     @classmethod
@@ -26,6 +40,9 @@ class RunnableConfig(Config):
             # Allow chained dynamic type selection without the `type=`, ex. `train gpt`.
             return cls.get_subclass(args[0]).parse_and_run(args[1:])
         parsed, unparsed = cls._get_parser().parse_known_args(args)
+        global _trust_remote_code, _trust_all_remote_code
+        _trust_all_remote_code = parsed.trust_all_remote_code
+        _trust_remote_code = parsed.trust_remote_code or parsed.trust_all_remote_code
         with NoAutoValidate():
             config: "RunnableConfig" = cls._from_parsed_args(parsed, unparsed)
         try:
@@ -86,6 +103,20 @@ class RunnableConfig(Config):
             help="The name of the hydra base configuration as would be provided in a typical Hydra application."
             " Mutually exclusive with `--config`, which it replaces."
             " Requires --hydra-path to be set.",
+        )
+        parser.add_argument(
+            "--trust-remote-code",
+            action="store_true",
+            help="Allow HuggingFace `from_pretrained` calls to execute custom Python code shipped"
+            " with the loaded model, tokenizer, or dataset. Acts as a master switch: each call"
+            " also requires its own `trust_remote_code: true` in the config. Off by default;"
+            " only pass this for sources you trust, because the code runs with your user privileges.",
+        )
+        parser.add_argument(
+            "--trust-all-remote-code",
+            action="store_true",
+            help="Like --trust-remote-code, but also ignore the per-call `trust_remote_code` config"
+            " field and trust every `from_pretrained` call in the run. Use sparingly.",
         )
         return parser
 
@@ -157,12 +188,24 @@ class RunnableConfig(Config):
         else:
             raise FileNotFoundError(parsed.config)
 
+    # Hosts the config loader is allowed to fetch from. Restricted to prevent the auth token below
+    # from being sent to an attacker-controlled host if a user is tricked into pointing `--config`
+    # at the wrong URL.
+    _ALLOWED_CONFIG_HOSTS: typing.ClassVar[frozenset[str]] = frozenset(
+        {"github.com", "raw.githubusercontent.com", "api.github.com"}
+    )
+
     @classmethod
     def _load_url(cls, config_url: str, config_auth_token_file: pathlib.Path | None = None) -> typing.Any:
         """
         Read a config from a URL, typically a config file hosted on GitHub.
         """
-
+        parsed_url = urllib.parse.urlparse(config_url)
+        if parsed_url.scheme != "https" or parsed_url.hostname not in cls._ALLOWED_CONFIG_HOSTS:
+            raise ValueError(
+                f"Refusing to fetch config from {config_url}: only https URLs on "
+                f"{sorted(cls._ALLOWED_CONFIG_HOSTS)} are allowed."
+            )
         headers = {"Accept": "application/vnd.github.v3.raw"}
         if config_auth_token_file is not None:
             config_auth_token = config_auth_token_file.read_text().strip()

--- a/fast_llm/engine/evaluation/lm_eval/evaluator.py
+++ b/fast_llm/engine/evaluation/lm_eval/evaluator.py
@@ -26,13 +26,19 @@ class LmEvalEvaluator[ConfigType: LmEvalEvaluatorConfig](Evaluator[ConfigType]):
         run_count: int,
     ) -> None:
         if "HUGGINGFACE_API_KEY_PATH" in os.environ:
-            os.environ["HF_TOKEN"] = pathlib.Path(os.environ["HUGGINGFACE_API_KEY_PATH"]).read_text().strip()
-        else:
-            if not "HF_TOKEN" in os.environ:
-                logger.warning(
-                    "No `HF_TOKEN` or `HUGGINGFACE_API_KEY_PATH` environment variable provided. "
-                    "Assuming the user has already logged in to the Hugging Face Hub."
-                )
+            import huggingface_hub
+
+            # Log in via the SDK so the token is cached for downstream HF calls without leaking
+            # it into `os.environ` (and from there into any subprocess we spawn).
+            huggingface_hub.login(
+                token=pathlib.Path(os.environ["HUGGINGFACE_API_KEY_PATH"]).read_text().strip(),
+                add_to_git_credential=False,
+            )
+        elif "HF_TOKEN" not in os.environ:
+            logger.warning(
+                "No `HF_TOKEN` or `HUGGINGFACE_API_KEY_PATH` environment variable provided. "
+                "Assuming the user has already logged in to the Hugging Face Hub."
+            )
 
         from fast_llm.engine.evaluation.lm_eval.fast_llm_wrapper import FastLLMLmEvalWrapper
 

--- a/fast_llm/engine/training/config.py
+++ b/fast_llm/engine/training/config.py
@@ -1,9 +1,6 @@
 import abc
 import functools
-import os
 import pathlib
-import shlex
-import subprocess
 import typing
 
 from fast_llm.config import (
@@ -40,36 +37,6 @@ if typing.TYPE_CHECKING:
     from fast_llm.engine.multi_stage.fast_llm_model import FastLLMModel
     from fast_llm.engine.training.streaming import StreamingTrainerCallback
     from fast_llm.engine.training.trainer import Trainer
-
-
-def _validate_script(value: str | list[str]) -> list[str]:
-    if isinstance(value, str):
-        value = shlex.split(value)
-    Assert.geq(len(value), 1)
-    return value
-
-
-@config_class()
-class CallbackConfig(Config):
-    """Configuration for an optional shell script callback invoked after a checkpoint, export, or shutdown event."""
-
-    script: list[str] | None = Field(
-        default=None,
-        desc="Shell script to run.",
-        hint=FieldHint.feature,
-        valid=skip_valid_if_none(_validate_script),
-    )
-    environment: dict[str, str] = Field(
-        default_factory=dict,
-        desc="Environment variables to add to the script.",
-        hint=FieldHint.feature,
-    )
-
-    def run(self) -> None:
-        if self.script is not None:
-            environment = os.environ.copy()
-            environment.update(self.environment)
-            subprocess.Popen(self.script, env=environment)
 
 
 @config_class()
@@ -128,10 +95,6 @@ class TrainingCheckpointBaseConfig(IntervalConfig):
 
     _abstract = True
     save_name: typing.ClassVar[str] = "save"
-    callback: CallbackConfig = Field(
-        desc="Callback (shell script).",
-        hint=FieldHint.core,
-    )
     keep: int | None = Field(
         default=None,
         desc="The maximum number of saves to keep. When exceeding this value, checkpoints are deleted starting from the older ones.",
@@ -174,7 +137,6 @@ class TrainingCheckpointConfig(TrainingCheckpointBaseConfig):
         desc="The number of training iterations between each checkpoint. Setting to None will disable checkpoints."
     )
     offset = FieldOverride(desc="Offset for the first checkpoint.")
-    callback: CallbackConfig = FieldOverride(desc="Callback (shell script) to run after checkpoint.")
     keep: int | None = FieldOverride(default=5)
 
     def get_save_directory(self, experiment_directory: pathlib.Path) -> pathlib.Path:
@@ -209,7 +171,6 @@ class TrainingExportConfig(TrainingCheckpointBaseConfig, CheckpointStateSaveConf
         desc="The number of training iterations between each export." " Setting to None will disable exports."
     )
     offset = FieldOverride(desc="Offset for the first export.")
-    callback: CallbackConfig = FieldOverride(desc="Callback (shell script) to run after export.")
 
     def get_save_directory(self, experiment_directory: pathlib.Path) -> pathlib.Path:
         return experiment_directory / "export" / self.format.name

--- a/fast_llm/engine/training/trainer.py
+++ b/fast_llm/engine/training/trainer.py
@@ -415,8 +415,6 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
                 except OSError as e:
                     logger.warning(f"Could not remove {config.save_name} directory: {e.args}")
 
-            config.callback.run()
-
     def _load_checkpoint(self, config: TrainingCheckpointConfig, iteration: int) -> None:
         checkpoint_directory = config.get_save_directory(self._run.experiment_directory) / str(iteration)
         Assert.custom(pathlib.Path.is_file, checkpoint_directory / "ok")

--- a/fast_llm/engine/training/wandb.py
+++ b/fast_llm/engine/training/wandb.py
@@ -14,12 +14,14 @@ class Wandb:
         self._is_setup = True
         self._run = run
         if self._config.entity_name is not None and self._run.is_main_rank:
+            import wandb
             import wandb.sdk.lib.runid
 
-            # Wandb login from file
+            # Read the W&B key from a file and pass it to `wandb.login` directly. Avoid putting it
+            # in `os.environ`, where any subprocess we spawn would inherit it.
             api_key_path = os.environ.get("WANDB_API_KEY_PATH")
             if api_key_path:
-                os.environ["WANDB_API_KEY"] = pathlib.Path(api_key_path).read_text().strip()
+                wandb.login(key=pathlib.Path(api_key_path).read_text().strip())
             wandb_path = (
                 None
                 if self._run.experiment_directory is None

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -339,7 +339,6 @@ nav:
         - reference/configuration/engine/schedule/ScheduleConfig.md
       - Training:
         - reference/configuration/engine/training/index.md
-        - reference/configuration/engine/training/CallbackConfig.md
         - reference/configuration/engine/training/MetricsLogsConfig.md
         - reference/configuration/engine/training/ShutdownConfig.md
         - reference/configuration/engine/training/StreamingTrainerCallbackConfig.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ packages =
 include_package_data = True
 python_requires = >=3.12
 install_requires =
-    requests>=2.32.5
+    requests>=2.33.0
     PyYAML>=6.0.3
     pybind11>=3.0.1
     packaging>=25.0
@@ -75,7 +75,7 @@ DEV =
     # Pre-commit git hook
     pre-commit>=4.5.1
     # Required for testing
-    pytest>=9.0.2
+    pytest>=9.0.3
     pytest-xdist>=3.8.0
     # Somehow needed for Megatron to work with base image 24.11
     setuptools>=80.9.0

--- a/tests/data/test_streaming.py
+++ b/tests/data/test_streaming.py
@@ -204,13 +204,14 @@ def _run_test_data_streaming(
 def check_data_streaming_results(path: pathlib.Path, distributed_config: DistributedConfig):
     sample_indexes = set()
     for batch_data_rank in range(distributed_config.batch_data_parallel):
-        batches_tokens = torch.load(path / f"rank_{batch_data_rank}_0.pt")
+        batches_tokens = torch.load(path / f"rank_{batch_data_rank}_0.pt", weights_only=True)
         Assert.eq(batches_tokens.shape, (_NUM_BATCHES, _SEQUENCE_LENGTH))
         for model_and_sequence_data_rank in range(
             1, distributed_config.get_distributed_dim(DistributedDimNames.model_and_sequence_data).size
         ):
             Assert.all_equal(
-                torch.load(path / f"rank_{batch_data_rank}_{model_and_sequence_data_rank}.pt"), batches_tokens
+                torch.load(path / f"rank_{batch_data_rank}_{model_and_sequence_data_rank}.pt", weights_only=True),
+                batches_tokens,
             )
         sample_indexes.update(batches_tokens.flatten().tolist())
     Assert.eq(len(sample_indexes), distributed_config.batch_data_parallel * _NUM_BATCHES)

--- a/tests/test_trust_remote_code.py
+++ b/tests/test_trust_remote_code.py
@@ -1,0 +1,53 @@
+import pytest
+
+from fast_llm.engine.config_utils import runnable
+from fast_llm.engine.config_utils.runnable import RunnableConfig, get_trust_remote_code
+
+
+@pytest.fixture(autouse=True)
+def _reset_trust_flags():
+    # The flags are process-wide module globals, so save and restore around each test.
+    saved = (runnable._trust_remote_code, runnable._trust_all_remote_code)
+    yield
+    runnable._trust_remote_code, runnable._trust_all_remote_code = saved
+
+
+@pytest.mark.parametrize(
+    ("master", "trust_all", "config_flag", "expected"),
+    [
+        # Default: every call is denied, no matter what the config says.
+        (False, False, False, False),
+        (False, False, True, False),
+        # Master switch on: per-call config field decides.
+        (True, False, False, False),
+        (True, False, True, True),
+        # `--trust-all-remote-code` overrides the per-call field and implies the master switch.
+        (True, True, False, True),
+        (True, True, True, True),
+        (False, True, False, True),
+        (False, True, True, True),
+    ],
+)
+def test_get_trust_remote_code(master: bool, trust_all: bool, config_flag: bool, expected: bool):
+    runnable._trust_remote_code = master or trust_all
+    runnable._trust_all_remote_code = trust_all
+    assert get_trust_remote_code(config_flag) is expected
+
+
+def test_cli_flags_are_off_by_default():
+    parser = RunnableConfig._get_parser()
+    parsed = parser.parse_args([])
+    assert parsed.trust_remote_code is False
+    assert parsed.trust_all_remote_code is False
+
+
+def test_cli_flags_set_module_globals():
+    # Round-trip the flags through the parser into the module globals to lock down the wiring.
+    parser = RunnableConfig._get_parser()
+    parsed = parser.parse_args(["--trust-remote-code"])
+    assert parsed.trust_remote_code is True
+    assert parsed.trust_all_remote_code is False
+
+    parsed = parser.parse_args(["--trust-all-remote-code"])
+    assert parsed.trust_remote_code is False
+    assert parsed.trust_all_remote_code is True

--- a/tests/utils/compare_tensor_logs.py
+++ b/tests/utils/compare_tensor_logs.py
@@ -60,7 +60,7 @@ class CompareConfig:
             for p in rank_path.iterdir():
                 if p.name.startswith(_TENSOR_LOG_PREFIX) and p.suffix == ".pt":
                     step_name = p.stem[len(_TENSOR_LOG_PREFIX) :]
-                    for step_log in torch.load(p):
+                    for step_log in torch.load(p, weights_only=True):
                         tensor_name = step_log["name"]
                         sub_config = self._get_sub_config(step_name, tensor_name)
                         if not sub_config.ignore_tensors:

--- a/tools/push_model.py
+++ b/tools/push_model.py
@@ -95,8 +95,10 @@ class PushConfig(RunnableConfig):
 
     def _setup(self) -> hf_hub.HfApi:
         self.to_logs()
-        os.environ["HF_TOKEN"] = pathlib.Path(os.environ["HUGGINGFACE_API_KEY_PATH"]).open("r").read().strip()
-        hf_api = hf_hub.HfApi()
+        # Pass the token through `HfApi(token=...)` rather than `os.environ`, so it isn't inherited
+        # by the `git pull` subprocess we spawn below.
+        self._token = pathlib.Path(os.environ["HUGGINGFACE_API_KEY_PATH"]).read_text().strip()
+        hf_api = hf_hub.HfApi(token=self._token)
         self._git_add_safe_directory(self.tmp_checkpoint_dir)
         hf_api.create_repo(self.repo_name, private=True, exist_ok=True)
         return hf_api
@@ -109,7 +111,12 @@ class PushConfig(RunnableConfig):
 
         # Get list of checkpoints in the repo
         logger.info(f"Cloning repo into {self.tmp_checkpoint_dir}...")
-        hf_repo = hf_hub.Repository(local_dir=self.tmp_checkpoint_dir, clone_from=self.repo_name, skip_lfs_files=True)
+        hf_repo = hf_hub.Repository(
+            local_dir=self.tmp_checkpoint_dir,
+            clone_from=self.repo_name,
+            skip_lfs_files=True,
+            token=self._token,
+        )
 
         # Pull latest changes
         env = os.environ.copy()


### PR DESCRIPTION
## Summary

General security and robustness pass on the repo. Seven self-contained commits, all driven by an internal review.

## What changed

### Config opt-ins for `trust_remote_code`

- `TokenizerConfig.trust_remote_code` and `GPTMemmapDatasetConfig.dataset.trust_remote_code` are now ANDed with a process-wide CLI flag. Both are off by default. To opt in: `--trust-remote-code` on the command line plus `trust_remote_code: true` in the YAML. `--trust-all-remote-code` is the broader bypass that ignores the config field. Settings in YAML alone do nothing.
- New unit test (`tests/test_trust_remote_code.py`) locks down the resulting truth table and the CLI parser wiring.
- Tutorial pages updated: every `fast-llm prepare gpt_memmap` example now passes `--trust-remote-code`, with a paragraph next to each YAML explaining the two-step opt-in.

### Memmap parser validation

- New memmap format (`fast_llm/data/dataset/memmap/memmap.py`): config offset and config size are now bounded against the file size before seeking and reading.
- Legacy memmap format (`fast_llm/data/dataset/gpt/legacy_memmap.py`): `num_documents` and span counts are bounded against the index buffer size before flowing into `np.frombuffer`.

### Removed: `CallbackConfig`

The `callback:` field on training save configs ran an arbitrary `subprocess.Popen` after each save. Feature removed entirely. The orphaned doc nav entry was removed too.

### Config / network handling

- `--config <https://...>` URL fetcher restricted to an allowlist (`github.com`, `raw.githubusercontent.com`, `api.github.com`).
- `_convert_paths` rejects absolute paths and `..` segments in nested dataset configs.
- HF and W&B tokens are passed via SDK login / `HfApi(token=...)` / `Repository(token=...)` instead of `os.environ`, so subprocesses don't inherit them.

### CI / workflow scoping

- `manual-build.yml`: `${{ inputs.* }}` interpolations moved into an `env:` block instead of being dropped directly into `run:`.
- `docs.yaml`: the workflow-level `contents: write` is gone; `build` (which runs on PRs) requests `contents: read`, `deploy` (gated to `push`) requests `contents: write`.

### C++ extension (`fast_llm/csrc/data.cpp`)

- `assert(...)` of scalar args replaced with `throw std::invalid_argument` so the checks survive `-DNDEBUG`.
- One upfront range check on `doc_idx` in `build_sample_idx` so the inner loop's `unchecked<1>()` access is provably safe.
- Added scalar guards on `build_padded_token_cumsum`.

### Dockerfile

- World-writable surface narrowed to `/app` and `/home`. The `mkdir -m 777 /app/...` and the `/app` default ACL are kept — verified empirically that the cluster scheduler assigns dynamic UIDs with no shared GID, so this is currently the simplest mode-bit pattern that satisfies the runtime contract.
- `--chmod=777` dropped from `COPY` commands. Source files end up root-owned `0644` — readable and importable, not modifiable from inside the container by non-root.

### Other

- Three test-only `torch.load` call sites pass `weights_only=True` (silences PyTorch 2.6+ deprecation warning, aligns with the rest of the codebase).
- TODO comment at the Redis client connection site noting the future need for `password` / `ssl` fields if the deployment ever moves off cluster-internal networking.
- `setup.cfg` floors bumped: `requests>=2.33.0`, `pytest>=9.0.3` (cleared by `pip-audit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)