### PR TITLE
Require diff-reading on PR re-reviews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,3 +187,4 @@ When reviewing PRs (`/review` reads this section as part of its checklist):
 - **Simplification**: actively look for non-trivial simplifications and refactoring opportunities, not just style nitpicks.
 - **Correctness**: edge cases, off-by-ones, error handling, race conditions. Read the code; don't trust comments.
 - **Test coverage**: new code paths should have tests; modified behavior should have updated tests. Untested control flow is a flag.
+- **Diff discipline**: don't substitute commit messages or `git --stat` for reading the code. On a follow-up review after fixes, read `git diff <last-reviewed-sha>..HEAD` in full before claiming an item is "verified" or "fixed". Never put ✅ on items whose diff you haven't read.


### PR DESCRIPTION
## Summary

- Adds a **Diff discipline** bullet to the existing "PR review focus" section of `CLAUDE.md`.
- Closes a real gap surfaced in a recent review session: on a follow-up after fixes, the reviewer leaned on commit messages and `git --stat` summaries, claimed "all fixes verified", and missed two real issues (one bug introduced by the rename commit, one type-annotation inconsistency).
- The new bullet forbids substituting commit messages or `--stat` for the actual diff, and forbids ✅-stamping items whose diff hasn't been read.

## Test plan

- [ ] Skim the rendered `CLAUDE.md` in the PR preview to confirm the bullet sits cleanly in the existing section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)