### PR TITLE
Expand rotary, attention, and embedding layer tests into parametrized suites

### DIFF
--- a/tests/layers/test_attention.py
+++ b/tests/layers/test_attention.py
@@ -131,7 +131,8 @@ _base_attention_cases = [
 ]
 
 _attention_rotary_cases = [
-    # Rotary: only independent reference check (packing equivalence requires per-doc position reset).
+    # Rotary: packing equivalence is skipped for multi-document inputs (packed rotary uses global
+    # positions; per-sequence reference uses per-doc positions). All three checks run for single-doc inputs.
     ("causal_rotary", {"causal": True, "rotary": True}),
 ]
 
@@ -303,6 +304,7 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
         Assert.rms_close_relative(out_flash, out_ref_bf16, 4e-3, 1e-7)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "lengths",
     [pytest.param(lengths, id=str(lengths)) for lengths in _attention_lengths],

--- a/tests/layers/test_attention.py
+++ b/tests/layers/test_attention.py
@@ -1,64 +1,316 @@
+import contextlib
+import dataclasses
+
 import pytest
 import torch
+import torch.nn.functional
 
 from fast_llm.data.document.config import LanguageModelBatchPreprocessingConfig
 from fast_llm.data.document.language_model import LanguageModelBatch
+from fast_llm.engine.config_utils.data_type import DataType
 from fast_llm.engine.config_utils.tensor_dim import TensorDim
 from fast_llm.engine.distributed.config import DistributedConfig
+from fast_llm.engine.distributed.distributed import Distributed
 from fast_llm.layers.attention.attention import Attention, _flash_available
 from fast_llm.layers.attention.config import AttentionConfig
 from fast_llm.utils import Assert
+from tests.utils.utils import get_stage
+
+_HEADS = 4
+_KV_HEADS = 2
+_HEAD_SIZE = 16
 
 
-@pytest.mark.parametrize(("causal", "window_size"), ((True, None), (True, 50), (False, None)))
-@pytest.mark.parametrize(
-    "lengths",
-    (
-        [20, 32, 10, 11, 9, 18],
-        [100],
-        [2, 8, 22, 7, 6, 5, 1, 10, 4, 11, 3, 8, 4, 9],
-        [5 for _ in range(20)],
-    ),
-)
-@pytest.mark.skipif(not _flash_available, reason="Flash attention not available")
-def test_attention_implementations(causal: bool, window_size: int | None, lengths: list[int]):
-    """
-    Check that the flash and backup attention implementation give the same result.
-    """
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    attention: Attention = AttentionConfig(
-        head_size=32,
-        heads=4,
-        head_groups=2,
-        window_size=window_size,
-        causal=causal,
-    ).get_layer(
-        distributed_config := DistributedConfig(compute_dtype="bfloat16"),
-        TensorDim("hidden_size", 256),
-        lr_scale=None,
-        peft=None,
-    )
+def _compute_rotary_freqs(seq_len: int, head_size: int, theta: float, device: torch.device) -> torch.Tensor:
+    angle_scales = theta ** (-torch.arange(0, 1, 2 / head_size, dtype=torch.float64, device=device))
+    positions = torch.arange(seq_len, dtype=torch.float64, device=device)
+    angles = torch.outer(positions, angle_scales)
+    freqs = torch.cat([torch.cos(angles), torch.sin(angles)], dim=-1).to(torch.float32)
+    return freqs.unsqueeze(1)  # (seq_len, 1, head_size)
+
+
+def _apply_rotary(tensor: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
+    half = tensor.shape[-1] // 2
+    re, im = tensor[..., :half], tensor[..., half:]
+    cos, sin = freqs[..., :half], freqs[..., half:]
+    return torch.cat([re * cos - im * sin, im * cos + re * sin], dim=-1)
+
+
+@dataclasses.dataclass
+class AttentionTestConfig:
+    name: str
+    heads: int = _HEADS
+    kv_heads: int = _KV_HEADS
+    head_size: int = _HEAD_SIZE
+    causal: bool = True
+    window_size: int | None = None
+    rotary: bool = False
+
+    @property
+    def hidden_size(self) -> int:
+        return self.heads * self.head_size
+
+    @property
+    def heads_per_group(self) -> int:
+        return self.heads // self.kv_heads
+
+    def get_attention_config(self, implementation: str = "backup") -> AttentionConfig:
+        config: dict = {
+            "heads": self.heads,
+            "head_groups": self.kv_heads,
+            "head_size": self.head_size,
+            "add_linear_biases": False,
+            "causal": self.causal,
+            "implementation": implementation,
+        }
+        if self.window_size is not None:
+            config["window_size"] = self.window_size
+        if self.rotary:
+            config["rotary"] = {"type": "default"}
+        return AttentionConfig.from_dict(config)
+
+    def expected_output(
+        self,
+        input_: torch.Tensor,
+        attention: Attention,
+        lengths: list[int],
+    ) -> torch.Tensor:
+        """
+        Independent reference: plain F.linear + rotary + per-document einsum attention.
+        No calls to Fast-LLM attention internals.
+        """
+        with torch.no_grad():
+            q = torch.nn.functional.linear(input_, attention.query.weight.detach()).unflatten(
+                1, (self.heads, self.head_size)
+            )
+            kv = torch.nn.functional.linear(input_, attention.key_value.weight.detach()).unflatten(
+                1, (2 * self.kv_heads, self.head_size)
+            )
+
+            if self.rotary:
+                freqs = _compute_rotary_freqs(input_.shape[0], self.head_size, 10000.0, input_.device)
+                q = _apply_rotary(q, freqs)
+                k_rotated = _apply_rotary(kv[:, : self.kv_heads, :], freqs)
+                kv = torch.cat([k_rotated, kv[:, self.kv_heads :, :]], dim=1)
+
+            k, v = kv[:, : self.kv_heads, :], kv[:, self.kv_heads :, :]
+            scale = self.head_size**-0.5
+
+            attn_out = torch.empty_like(q)
+            offset = 0
+            for length in lengths:
+                q_doc = q[offset : offset + length]
+                k_doc = k[offset : offset + length]
+                v_doc = v[offset : offset + length]
+
+                head_outputs = []
+                for head_index in range(self.heads):
+                    group = head_index // self.heads_per_group
+                    scores = (q_doc[:, head_index, :].float() @ k_doc[:, group, :].float().T) * scale
+                    if self.causal:
+                        positions = torch.arange(length, device=input_.device)
+                        # mask[i, j] = True if j <= i (query i can attend to key j)
+                        mask = positions.unsqueeze(1) >= positions.unsqueeze(0)
+                        if self.window_size is not None:
+                            mask = mask & (positions.unsqueeze(1) - positions.unsqueeze(0) < self.window_size)
+                        scores = scores.masked_fill(~mask, float("-inf"))
+                    head_outputs.append((torch.softmax(scores, dim=-1) @ v_doc[:, group, :].float()).to(q.dtype))
+
+                attn_out[offset : offset + length] = torch.stack(head_outputs, dim=1)
+                offset += length
+
+            return torch.nn.functional.linear(attn_out.flatten(1), attention.dense.weight.detach())
+
+
+_base_attention_cases = [
+    ("causal", {"causal": True}),
+    ("noncausal", {"causal": False}),
+    ("window", {"causal": True, "window_size": 4}),
+    # MQA: all query heads share a single KV head
+    ("mqa", {"causal": True, "kv_heads": 1}),
+    # MHA: each query head has its own KV head
+    ("mha", {"causal": True, "kv_heads": _HEADS}),
+]
+
+_attention_rotary_cases = [
+    # Rotary: only independent reference check (packing equivalence requires per-doc position reset)
+    ("causal_rotary", {"causal": True, "rotary": True}),
+]
+
+_attention_test_configs = [
+    AttentionTestConfig(name=base_name, **base_kwargs)
+    for base_name, base_kwargs in _base_attention_cases + _attention_rotary_cases
+]
+
+_attention_lengths = [
+    [15],
+    [6, 9],
+    [4, 1, 10],
+    [20, 32, 10, 11, 9, 18],
+]
+
+
+def _run_per_seq_reference(
+    attention: Attention,
+    stage,
+    distributed_config: DistributedConfig,
+    hidden_states: torch.Tensor,
+    lengths: list[int],
+    device: torch.device,
+) -> torch.Tensor:
+    out_refs = []
+    for length, hidden_slice in zip(lengths, torch.split(hidden_states, lengths, dim=0), strict=True):
+        (model_input,) = LanguageModelBatch(
+            tokens=torch.empty(length, dtype=torch.int64, device=device), lengths=[length]
+        ).get_model_inputs(
+            LanguageModelBatchPreprocessingConfig(
+                distributed=distributed_config,
+                predicted_tokens=0,
+                **attention.get_preprocessing_config(),
+            )
+        )
+        kwargs = model_input.to_kwargs()
+        attention.preprocess(kwargs)
+        out, context = stage.forward(hidden_slice, kwargs)
+        stage.backward(torch.ones_like(out), context)
+        out_refs.append(out.detach())
+    return torch.cat(out_refs, dim=0)
+
+
+@contextlib.contextmanager
+def _no_tf32():
+    prev = torch.backends.cuda.matmul.allow_tf32
+    torch.backends.cuda.matmul.allow_tf32 = False
+    try:
+        yield
+    finally:
+        torch.backends.cuda.matmul.allow_tf32 = prev
+
+
+def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
+    with _no_tf32():
+        _test_attention_impl(config, lengths)
+
+
+def _test_attention_impl(config: AttentionTestConfig, lengths: list[int]) -> None:
     num_tokens = sum(lengths)
+    hidden_dim = TensorDim("hidden", config.hidden_size)
 
-    query = torch.empty(num_tokens, 4, 32, dtype=torch.bfloat16, device=device).normal_()
-    key = torch.empty(num_tokens, 2, 32, dtype=torch.bfloat16, device=device).normal_()
-    value = torch.empty(num_tokens, 2, 32, dtype=torch.bfloat16, device=device).normal_()
+    distributed_config = DistributedConfig(use_cuda=torch.cuda.is_available())
+    distributed = Distributed(distributed_config)
+    device = distributed.device
 
-    (model_input,) = LanguageModelBatch(
+    attention: Attention = config.get_attention_config("backup").get_layer(
+        distributed_config, hidden_dim, lr_scale=None, peft=None, return_bias=False
+    )
+    stage = get_stage([attention], distributed)
+
+    # Independent reference check with TF32 disabled on GPU.
+    # Backup attention uses baddbmm over head groups; the reference uses per-head matmul — a
+    # different summation order. With TF32 enabled these can differ by ~3e-4 on A100/H100;
+    # disabling TF32 reduces the gap to ~1e-7, well within rtol=1e-4.
+    # Running on GPU (not CPU) avoids Triton failing on CPU tensors when key/query norm is enabled.
+    attention.eval()
+    input_for_ref = torch.randn(num_tokens, config.hidden_size, device=device)
+    (model_input_ref,) = LanguageModelBatch(
         tokens=torch.empty(num_tokens, dtype=torch.int64, device=device), lengths=lengths
     ).get_model_inputs(
         LanguageModelBatchPreprocessingConfig(
             distributed=distributed_config,
             predicted_tokens=0,
-            return_cumulative_sequence_lengths=True,
-            return_max_sequence_lengths=True,
-            return_document_index=True,
+            **attention.get_preprocessing_config(),
         )
     )
-    kwargs = model_input.to_kwargs()
-    attention._preprocess_for_backup_attention(kwargs)
+    kwargs_ref = model_input_ref.to_kwargs()
+    attention.preprocess(kwargs_ref)
+    with torch.no_grad():
+        out_fastllm = attention(input_for_ref, kwargs_ref)
+    expected = config.expected_output(input_for_ref, attention, lengths)
+    Assert.rms_close_relative(out_fastllm, expected, 1e-5, 1e-7)
+    attention.train()
 
-    out_backup = attention._attn_backup(query, key, value, kwargs)
-    out_flash = attention._attn_flash(query, key, value, kwargs)
+    # Rotary uses global positions across packed docs; per-sequence uses local positions.
+    # Packing equivalence and flash checks are only valid for single-document inputs with rotary.
+    if config.rotary and len(lengths) > 1:
+        return
 
-    Assert.rms_close(out_backup, out_flash, 2e-3)
+    # Packing equivalence check: packed backup must match per-sequence backup, forward and backward.
+    # TF32 disabled so that linear projections are row-by-row identical regardless of batch size;
+    # different batch sizes can trigger different CUDA tiling strategies, causing ~1e-4 drift with TF32.
+    hidden_states = torch.randn(num_tokens, config.hidden_size, device=device, requires_grad=True)
+
+    out_ref = _run_per_seq_reference(attention, stage, distributed_config, hidden_states, lengths, device)
+    names, params = zip(*list(attention.named_parameters()))
+    grads_ref = [param.grad_buffer.clone() for param in params]
+    stage.reset_gradients()
+
+    (model_input_packed,) = LanguageModelBatch(
+        tokens=torch.empty(num_tokens, dtype=torch.int64, device=device), lengths=lengths
+    ).get_model_inputs(
+        LanguageModelBatchPreprocessingConfig(
+            distributed=distributed_config,
+            predicted_tokens=0,
+            **attention.get_preprocessing_config(),
+        )
+    )
+    kwargs_packed = model_input_packed.to_kwargs()
+    attention.preprocess(kwargs_packed)
+    out_backup, context = stage.forward(hidden_states, kwargs_packed)
+    stage.backward(torch.ones_like(out_backup), context)
+
+    Assert.rms_close_relative(out_backup, out_ref, 1e-5, 1e-7)
+    for name, param, grad_ref in zip(names, params, grads_ref, strict=True):
+        Assert.rms_close_relative(param.grad_buffer, grad_ref, 1e-5, 1e-7, msg=name)
+    stage.reset_gradients()
+
+    # Flash equivalence check: packed flash output must match per-sequence bfloat16 backup reference.
+    if _flash_available:
+        distributed_config_bf16 = DistributedConfig(compute_dtype=DataType.bfloat16, use_cuda=True)
+        distributed_bf16 = Distributed(distributed_config_bf16)
+
+        attention_backup_bf16: Attention = config.get_attention_config("backup").get_layer(
+            distributed_config_bf16, hidden_dim, lr_scale=None, peft=None, return_bias=False
+        )
+        stage_backup_bf16 = get_stage([attention_backup_bf16], distributed_bf16)
+        for param_bf16, param_f32 in zip(attention_backup_bf16.parameters(), attention.parameters(), strict=True):
+            param_bf16.data.copy_(param_f32.data)
+
+        hidden_states_bf16 = hidden_states.detach().to(torch.bfloat16).requires_grad_(True)
+        out_ref_bf16 = _run_per_seq_reference(
+            attention_backup_bf16, stage_backup_bf16, distributed_config_bf16, hidden_states_bf16, lengths, device
+        )
+        stage_backup_bf16.reset_gradients()
+
+        attention_flash: Attention = config.get_attention_config("flash").get_layer(
+            distributed_config_bf16, hidden_dim, lr_scale=None, peft=None, return_bias=False
+        )
+        stage_flash = get_stage([attention_flash], distributed_bf16)
+        for param_flash, param_f32 in zip(attention_flash.parameters(), attention.parameters(), strict=True):
+            param_flash.data.copy_(param_f32.data)
+
+        (model_input_flash,) = LanguageModelBatch(
+            tokens=torch.empty(num_tokens, dtype=torch.int64, device=device), lengths=lengths
+        ).get_model_inputs(
+            LanguageModelBatchPreprocessingConfig(
+                distributed=distributed_config_bf16,
+                predicted_tokens=0,
+                **attention_flash.get_preprocessing_config(),
+            )
+        )
+        kwargs_flash = model_input_flash.to_kwargs()
+        attention_flash.preprocess(kwargs_flash)
+        out_flash, _ = stage_flash.forward(hidden_states_bf16, kwargs_flash)
+
+        Assert.rms_close(out_flash, out_ref_bf16, 4e-3)
+
+
+@pytest.mark.parametrize(
+    "lengths",
+    [pytest.param(lengths, id=str(lengths)) for lengths in _attention_lengths],
+)
+@pytest.mark.parametrize(
+    "config",
+    [pytest.param(config, id=config.name) for config in _attention_test_configs],
+)
+def test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
+    _test_attention(config, lengths)

--- a/tests/layers/test_attention.py
+++ b/tests/layers/test_attention.py
@@ -45,6 +45,7 @@ class AttentionTestConfig:
     causal: bool = True
     window_size: int | None = None
     rotary: bool = False
+    rotary_theta: float = 10000.0
 
     @property
     def hidden_size(self) -> int:
@@ -66,7 +67,7 @@ class AttentionTestConfig:
         if self.window_size is not None:
             config["window_size"] = self.window_size
         if self.rotary:
-            config["rotary"] = {"type": "default"}
+            config["rotary"] = {"type": "default", "theta": self.rotary_theta}
         return AttentionConfig.from_dict(config)
 
     def expected_output(
@@ -88,7 +89,7 @@ class AttentionTestConfig:
             )
 
             if self.rotary:
-                freqs = _compute_rotary_freqs(input_.shape[0], self.head_size, 10000.0, input_.device)
+                freqs = _compute_rotary_freqs(input_.shape[0], self.head_size, self.rotary_theta, input_.device)
                 q = _apply_rotary(q, freqs)
                 k_rotated = _apply_rotary(kv[:, : self.kv_heads, :], freqs)
                 kv = torch.cat([k_rotated, kv[:, self.kv_heads :, :]], dim=1)
@@ -109,7 +110,6 @@ class AttentionTestConfig:
                     scores = (q_doc[:, head_index, :].float() @ k_doc[:, group, :].float().T) * scale
                     if self.causal:
                         positions = torch.arange(length, device=input_.device)
-                        # mask[i, j] = True if j <= i (query i can attend to key j)
                         mask = positions.unsqueeze(1) >= positions.unsqueeze(0)
                         if self.window_size is not None:
                             mask = mask & (positions.unsqueeze(1) - positions.unsqueeze(0) < self.window_size)
@@ -126,14 +126,12 @@ _base_attention_cases = [
     ("causal", {"causal": True}),
     ("noncausal", {"causal": False}),
     ("window", {"causal": True, "window_size": 4}),
-    # MQA: all query heads share a single KV head
     ("mqa", {"causal": True, "kv_heads": 1}),
-    # MHA: each query head has its own KV head
     ("mha", {"causal": True, "kv_heads": _HEADS}),
 ]
 
 _attention_rotary_cases = [
-    # Rotary: only independent reference check (packing equivalence requires per-doc position reset)
+    # Rotary: only independent reference check (packing equivalence requires per-doc position reset).
     ("causal_rotary", {"causal": True, "rotary": True}),
 ]
 
@@ -157,6 +155,7 @@ def _run_per_seq_reference(
     hidden_states: torch.Tensor,
     lengths: list[int],
     device: torch.device,
+    with_backward: bool = True,
 ) -> torch.Tensor:
     out_refs = []
     for length, hidden_slice in zip(lengths, torch.split(hidden_states, lengths, dim=0), strict=True):
@@ -172,7 +171,8 @@ def _run_per_seq_reference(
         kwargs = model_input.to_kwargs()
         attention.preprocess(kwargs)
         out, context = stage.forward(hidden_slice, kwargs)
-        stage.backward(torch.ones_like(out), context)
+        if with_backward:
+            stage.backward(torch.ones_like(out), context)
         out_refs.append(out.detach())
     return torch.cat(out_refs, dim=0)
 
@@ -188,11 +188,6 @@ def _no_tf32():
 
 
 def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
-    with _no_tf32():
-        _test_attention_impl(config, lengths)
-
-
-def _test_attention_impl(config: AttentionTestConfig, lengths: list[int]) -> None:
     num_tokens = sum(lengths)
     hidden_dim = TensorDim("hidden", config.hidden_size)
 
@@ -209,7 +204,6 @@ def _test_attention_impl(config: AttentionTestConfig, lengths: list[int]) -> Non
     # Backup attention uses baddbmm over head groups; the reference uses per-head matmul — a
     # different summation order. With TF32 enabled these can differ by ~3e-4 on A100/H100;
     # disabling TF32 reduces the gap to ~1e-7, well within rtol=1e-4.
-    # Running on GPU (not CPU) avoids Triton failing on CPU tensors when key/query norm is enabled.
     attention.eval()
     input_for_ref = torch.randn(num_tokens, config.hidden_size, device=device)
     (model_input_ref,) = LanguageModelBatch(
@@ -275,11 +269,16 @@ def _test_attention_impl(config: AttentionTestConfig, lengths: list[int]) -> Non
         for param_bf16, param_f32 in zip(attention_backup_bf16.parameters(), attention.parameters(), strict=True):
             param_bf16.data.copy_(param_f32.data)
 
-        hidden_states_bf16 = hidden_states.detach().to(torch.bfloat16).requires_grad_(True)
+        hidden_states_bf16 = hidden_states.detach().to(torch.bfloat16)
         out_ref_bf16 = _run_per_seq_reference(
-            attention_backup_bf16, stage_backup_bf16, distributed_config_bf16, hidden_states_bf16, lengths, device
+            attention_backup_bf16,
+            stage_backup_bf16,
+            distributed_config_bf16,
+            hidden_states_bf16,
+            lengths,
+            device,
+            with_backward=False,
         )
-        stage_backup_bf16.reset_gradients()
 
         attention_flash: Attention = config.get_attention_config("flash").get_layer(
             distributed_config_bf16, hidden_dim, lr_scale=None, peft=None, return_bias=False
@@ -301,7 +300,7 @@ def _test_attention_impl(config: AttentionTestConfig, lengths: list[int]) -> Non
         attention_flash.preprocess(kwargs_flash)
         out_flash, _ = stage_flash.forward(hidden_states_bf16, kwargs_flash)
 
-        Assert.rms_close(out_flash, out_ref_bf16, 4e-3)
+        Assert.rms_close_relative(out_flash, out_ref_bf16, 4e-3, 1e-7)
 
 
 @pytest.mark.parametrize(
@@ -313,4 +312,5 @@ def _test_attention_impl(config: AttentionTestConfig, lengths: list[int]) -> Non
     [pytest.param(config, id=config.name) for config in _attention_test_configs],
 )
 def test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
-    _test_attention(config, lengths)
+    with _no_tf32():
+        _test_attention(config, lengths)

--- a/tests/layers/test_embedding.py
+++ b/tests/layers/test_embedding.py
@@ -95,6 +95,8 @@ _base_cases = [
     ("default", {}),
     ("with_padding", {"with_padding": True}),
     ("with_position_embeddings", {"with_position_embeddings": True}),
+    # Padding + position embeddings: catches bugs where position addition happens before the padding mask.
+    ("with_padding_and_position_embeddings", {"with_padding": True, "with_position_embeddings": True}),
 ]
 
 _variants = [

--- a/tests/layers/test_embedding.py
+++ b/tests/layers/test_embedding.py
@@ -9,6 +9,7 @@ from fast_llm.engine.config_utils.tensor_dim import TensorDim
 from fast_llm.layers.language_model.config import LanguageModelKwargs
 from fast_llm.layers.language_model.embedding import LanguageModelEmbedding
 from fast_llm.models.gpt.config import GPTModelConfig
+from fast_llm.utils import Assert
 from tests.utils.utils import get_base_model, get_stage
 
 NUM_TOKENS = 64
@@ -97,18 +98,14 @@ _base_cases = [
 ]
 
 _variants = [
-    ("", {}),
+    ("float32", {}),
     ("bfloat16", {"compute_dtype": DataType.bfloat16}),
     ("full_precision_residual", {"full_precision_residual": True}),
 ]
 
 
-def _make_name(base_name: str, variant_name: str) -> str:
-    return f"{base_name}_{variant_name}" if variant_name else base_name
-
-
 _embedding_test_configs = [
-    EmbeddingTestConfig(name=_make_name(base_name, variant_name), **base_kwargs, **variant_kwargs)
+    EmbeddingTestConfig(name=f"{base_name}_{variant_name}", **base_kwargs, **variant_kwargs)
     for base_name, base_kwargs in _base_cases
     for variant_name, variant_kwargs in _variants
 ]
@@ -129,4 +126,4 @@ def test_embedding(test_config: EmbeddingTestConfig):
 
     expected = test_config.get_reference_output(layer, kwargs)
     threshold = 1e-5 if test_config.compute_dtype == DataType.float32 else 5e-3
-    torch.testing.assert_close(output, expected, rtol=threshold, atol=threshold)
+    Assert.rms_close_relative(output, expected, threshold, 1e-7)

--- a/tests/layers/test_embedding.py
+++ b/tests/layers/test_embedding.py
@@ -1,0 +1,132 @@
+import dataclasses
+import functools
+
+import pytest
+import torch
+
+from fast_llm.engine.config_utils.data_type import DataType
+from fast_llm.engine.config_utils.tensor_dim import TensorDim
+from fast_llm.layers.language_model.config import LanguageModelKwargs
+from fast_llm.layers.language_model.embedding import LanguageModelEmbedding
+from fast_llm.models.gpt.config import GPTModelConfig
+from tests.utils.utils import get_base_model, get_stage
+
+NUM_TOKENS = 64
+VOCAB_SIZE = 256
+HIDDEN_SIZE = 128
+NUM_POSITION_EMBEDDINGS = 128
+
+
+@dataclasses.dataclass
+class EmbeddingTestConfig:
+    name: str
+    compute_dtype: DataType = DataType.float32
+    full_precision_residual: bool = False
+    with_position_embeddings: bool = False
+    with_padding: bool = False
+
+    @functools.cached_property
+    def residual_dtype(self) -> torch.dtype:
+        return (DataType.float32 if self.full_precision_residual else self.compute_dtype).torch
+
+    def get_config(self) -> GPTModelConfig:
+        embeddings: dict = {
+            "vocab_size": VOCAB_SIZE,
+            "full_precision_residual": self.full_precision_residual,
+        }
+        if self.with_position_embeddings:
+            embeddings["position_embeddings"] = {"enabled": True}
+            embeddings["num_position_embeddings"] = NUM_POSITION_EMBEDDINGS
+        return GPTModelConfig.from_dict(
+            {
+                "base_model": {
+                    "decoder": {"num_blocks": 0},
+                    "embeddings": embeddings,
+                    "head": {"normalization": {"type": "rms_norm"}},
+                    "hidden_size": HIDDEN_SIZE,
+                },
+                "distributed": {
+                    "compute_dtype": self.compute_dtype,
+                    "use_cuda": torch.cuda.is_available(),
+                },
+            }
+        )
+
+    def get_inputs(self, device: torch.device) -> dict:
+        num_real_tokens = NUM_TOKENS // 2 if self.with_padding else NUM_TOKENS
+        token_ids = torch.randint(0, VOCAB_SIZE, (NUM_TOKENS,), device=device)
+        if self.with_padding:
+            token_ids[num_real_tokens:] = -1
+        token_dim = TensorDim("token", NUM_TOKENS)
+        kwargs = {
+            LanguageModelKwargs.token_ids: token_ids,
+            LanguageModelKwargs.token_dim: token_dim,
+            LanguageModelKwargs.hidden_token_dim: token_dim,
+            LanguageModelKwargs.num_tokens: num_real_tokens,
+        }
+        if self.with_position_embeddings:
+            kwargs[LanguageModelKwargs.position_ids] = torch.arange(NUM_TOKENS, device=device)
+        return kwargs
+
+    def get_reference_output(self, layer: LanguageModelEmbedding, kwargs: dict) -> torch.Tensor:
+        token_ids = kwargs[LanguageModelKwargs.token_ids]
+        mask_inputs = kwargs[LanguageModelKwargs.num_tokens] < kwargs[LanguageModelKwargs.token_dim].size
+
+        word_weight = layer.word_embeddings_weight.detach()
+        if mask_inputs:
+            token_mask = token_ids >= 0
+            embeddings = torch.embedding(word_weight, token_ids * token_mask)
+        else:
+            embeddings = torch.embedding(word_weight, token_ids)
+
+        if layer.position_embeddings_weight is not None:
+            embeddings = embeddings + torch.nn.functional.embedding(
+                kwargs[LanguageModelKwargs.position_ids], layer.position_embeddings_weight.detach()
+            )
+
+        if mask_inputs:
+            embeddings = embeddings * token_mask.unsqueeze(-1)
+
+        return embeddings.to(dtype=self.residual_dtype)
+
+
+_base_cases = [
+    ("default", {}),
+    ("with_padding", {"with_padding": True}),
+    ("with_position_embeddings", {"with_position_embeddings": True}),
+]
+
+_variants = [
+    ("", {}),
+    ("bfloat16", {"compute_dtype": DataType.bfloat16}),
+    ("full_precision_residual", {"full_precision_residual": True}),
+]
+
+
+def _make_name(base_name: str, variant_name: str) -> str:
+    return f"{base_name}_{variant_name}" if variant_name else base_name
+
+
+_embedding_test_configs = [
+    EmbeddingTestConfig(name=_make_name(base_name, variant_name), **base_kwargs, **variant_kwargs)
+    for base_name, base_kwargs in _base_cases
+    for variant_name, variant_kwargs in _variants
+]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "test_config",
+    [pytest.param(c, id=c.name) for c in _embedding_test_configs],
+)
+def test_embedding(test_config: EmbeddingTestConfig):
+    model, distributed = get_base_model(test_config.get_config())
+    stage = get_stage([model.embeddings], distributed)
+    layer: LanguageModelEmbedding = stage._layers[0]
+
+    kwargs = test_config.get_inputs(distributed.device)
+    output, _ = stage.forward(torch.empty(0, device=distributed.device), kwargs)
+
+    expected = test_config.get_reference_output(layer, kwargs)
+    threshold = 1e-5 if test_config.compute_dtype == DataType.float32 else 5e-3
+    torch.testing.assert_close(output, expected, rtol=threshold, atol=threshold)

--- a/tests/layers/test_rotary.py
+++ b/tests/layers/test_rotary.py
@@ -1,52 +1,230 @@
+import dataclasses
+import functools
+import math
+
+import pytest
 import torch
-import transformers
 
 from fast_llm.engine.config_utils.tensor_dim import TensorDim
 from fast_llm.layers.attention.config import AttentionKwargs
-from fast_llm.layers.attention.rotary.config import Rotary2DConfig
+from fast_llm.layers.attention.rotary.config import (
+    DefaultRotaryConfig,
+    Llama3RotaryConfig,
+    Rotary2DConfig,
+    RotaryConfig,
+    YarnRotaryConfig,
+)
 from fast_llm.layers.vision.config import VisionKwargs
 from fast_llm.utils import Assert
 
+_NUM_HEADS = 4
+_GRID_WIDTH = 4  # Patch grid column count for 2D tests; _sequence_lengths must be divisible by this.
 
-def test_rotary_2d(testing_device):
+
+def _reference_rotary_1d_forward(
+    tensor: torch.Tensor,
+    angle_scales: torch.Tensor,
+    positions: torch.Tensor,
+    attention_factor: float = 1.0,
+) -> torch.Tensor:
     """
-    Compare Fast-LLM's implementation of 2d rotary embeddings with Pixtral.
+    Independent reference for 1D RoPE in Fast-LLM's split-real layout.
+    Pair k = (re_k, im_k) is rotated by angle positions[n] * angle_scales[k].
+
+    tensor: (num_tokens, num_heads, head_size)
+    angle_scales: (head_size // 2,) float64
+    attention_factor: overall cos/sin scale (non-1 for YarnRotary)
     """
-    head_dim = 16
-    num_heads = 8
+    angle_scales = angle_scales.to(positions.device)
+    angles = torch.outer(positions.to(torch.float64), angle_scales)  # (num_tokens, head_size//2)
+    cos = (attention_factor * torch.cos(angles)).to(tensor.dtype).unsqueeze(1)
+    sin = (attention_factor * torch.sin(angles)).to(tensor.dtype).unsqueeze(1)
+    half = tensor.shape[-1] // 2
+    re, im = tensor[..., :half], tensor[..., half:]
+    return torch.cat([re * cos - im * sin, im * cos + re * sin], dim=-1)
 
-    patch_positions = torch.tensor(
-        [[h, w] for h in range(4) for w in range(4)],
-        dtype=torch.int64,
-        device=testing_device,
-    )
-    query = torch.empty(
-        2, len(patch_positions), num_heads, head_dim, dtype=torch.float32, device=testing_device
-    ).normal_()
-    key = torch.empty_like(query).normal_()
-    value = torch.empty_like(query).normal_()
 
-    pixtral_config = transformers.PixtralVisionConfig(hidden_size=head_dim * num_heads, num_attention_heads=num_heads)
-    pixtral_rotary = transformers.models.pixtral.modeling_pixtral.PixtralRotaryEmbedding(pixtral_config).to(
-        testing_device
-    )
-    # Convert patch positions (h, w) to Pixtral's linear position IDs
-    # Pixtral expects: position_id = h * max_patches_per_side + w
-    position_ids = (
-        patch_positions[None, :, 0] * (pixtral_config.image_size // pixtral_config.patch_size)
-        + patch_positions[None, :, 1]
-    )
-    output_pixtral_query, output_pixtral_key = transformers.models.pixtral.modeling_pixtral.apply_rotary_pos_emb(
-        query, key, *pixtral_rotary(query, position_ids), unsqueeze_dim=2
-    )
+def _reference_rotary_2d_forward(
+    tensor: torch.Tensor,
+    patch_positions: torch.Tensor,
+    theta: float,
+    head_size: int,
+) -> torch.Tensor:
+    """
+    Independent reference for 2D RoPE (Pixtral/Rotary2D style).
+    theta^-arange(0,1,2/H).view(-1,2) gives per-pair [h_scale, w_scale]:
+    column 0 (even-indexed) drives height rotation, column 1 (odd-indexed) drives width.
+    First head_size//4 pairs rotate by h-position, last head_size//4 by w-position.
 
-    fast_llm_rotary = Rotary2DConfig().get_layer(TensorDim("head_dim", head_dim))
-    kwargs = {VisionKwargs.patch_positions: patch_positions, AttentionKwargs.device: testing_device}
-    fast_llm_rotary.preprocess(kwargs)
-    output_fast_llm_query, output_fast_llm_key_value = fast_llm_rotary.forward(
-        query, torch.cat([key, value], dim=-2), kwargs
-    )
-    output_fast_llm_key, output_fast_llm_value_ = output_fast_llm_key_value.chunk(2, dim=-2)
-    Assert.rms_close(output_pixtral_query, output_fast_llm_query, 1e-5)
-    Assert.rms_close(output_pixtral_key, output_fast_llm_key, 1e-5)
-    Assert.all_equal(output_fast_llm_value_, value)
+    tensor: (num_patches, num_heads, head_size)
+    patch_positions: (num_patches, 2) int64 with (h, w) coordinates
+    """
+    arange = torch.arange(0, 1, 2 / head_size, dtype=torch.float64, device=patch_positions.device)
+    freq_matrix = (theta**-arange).view(-1, 2)  # (head_size//4, 2)
+    h_angles = torch.outer(patch_positions[:, 0].to(torch.float64), freq_matrix[:, 0])
+    w_angles = torch.outer(patch_positions[:, 1].to(torch.float64), freq_matrix[:, 1])
+    angles = torch.cat([h_angles, w_angles], dim=-1)  # (num_patches, head_size//2)
+    cos = torch.cos(angles).to(tensor.dtype).unsqueeze(1)  # (num_patches, 1, head_size//2)
+    sin = torch.sin(angles).to(tensor.dtype).unsqueeze(1)
+    half = head_size // 2
+    re, im = tensor[..., :half], tensor[..., half:]
+    return torch.cat([re * cos - im * sin, im * cos + re * sin], dim=-1)
+
+
+@dataclasses.dataclass
+class RotaryTestConfig:
+    name: str
+    head_size: int
+    rotary_type: str = "default"
+    theta: float = 10000.0
+    # llama3 and yarn
+    scale_factor: float = 8.0
+    original_context_length: int = 8192
+    # llama3
+    low_frequency_factor: float = 1.0
+    high_frequency_factor: float = 4.0
+    # yarn
+    beta_fast: float = 32.0
+    beta_slow: float = 1.0
+
+    @property
+    def attention_factor(self) -> float:
+        if self.rotary_type == "yarn":
+            return 0.1 * math.log(self.scale_factor) + 1.0
+        return 1.0
+
+    def get_rotary_config(self) -> RotaryConfig:
+        if self.rotary_type == "default":
+            return DefaultRotaryConfig(theta=self.theta)
+        if self.rotary_type == "llama3":
+            return Llama3RotaryConfig(
+                theta=self.theta,
+                scale_factor=self.scale_factor,
+                low_frequency_factor=self.low_frequency_factor,
+                high_frequency_factor=self.high_frequency_factor,
+                original_context_length=self.original_context_length,
+            )
+        if self.rotary_type == "yarn":
+            return YarnRotaryConfig(
+                theta=self.theta,
+                scale_factor=self.scale_factor,
+                beta_fast=self.beta_fast,
+                beta_slow=self.beta_slow,
+                original_context_length=self.original_context_length,
+            )
+        if self.rotary_type == "2d":
+            return Rotary2DConfig(theta=self.theta)
+        raise ValueError(self.rotary_type)
+
+    @functools.cached_property
+    def reference_angle_scales(self) -> torch.Tensor:
+        base = self.theta ** -torch.arange(0, 1, 2 / self.head_size, dtype=torch.float64)
+        if self.rotary_type in ("default", "2d"):
+            return base
+        if self.rotary_type == "llama3":
+            high_freq_wavelength = self.original_context_length / self.high_frequency_factor
+            low_freq_wavelength = self.original_context_length / self.low_frequency_factor
+            new_scales = []
+            for scale in base.tolist():
+                wavelength = 2 * math.pi / scale
+                if wavelength < high_freq_wavelength:
+                    new_scales.append(scale)
+                elif wavelength > low_freq_wavelength:
+                    new_scales.append(scale / self.scale_factor)
+                else:
+                    smooth = (self.original_context_length / wavelength - self.low_frequency_factor) / (
+                        self.high_frequency_factor - self.low_frequency_factor
+                    )
+                    new_scales.append((1 - smooth) * scale / self.scale_factor + smooth * scale)
+            return torch.tensor(new_scales, dtype=torch.float64)
+        if self.rotary_type == "yarn":
+            low = max(math.floor(self._yarn_correction(self.beta_fast)), 0)
+            high = min(math.ceil(self._yarn_correction(self.beta_slow)), self.head_size - 1)
+            if low == high:
+                high += 0.001
+            extrapolation_factor = torch.clamp(
+                (torch.arange(self.head_size // 2, dtype=torch.float64) - low) / (high - low), 0, 1
+            )
+            return base / self.scale_factor * extrapolation_factor + base * (1 - extrapolation_factor)
+        raise ValueError(self.rotary_type)
+
+    def _yarn_correction(self, beta: float) -> float:
+        return (
+            self.head_size * math.log(self.original_context_length / (beta * 2 * math.pi)) / (2 * math.log(self.theta))
+        )
+
+    def make_preprocess_kwargs(self, num_tokens: int, device: torch.device) -> dict:
+        if self.rotary_type == "2d":
+            patch_positions = torch.tensor(
+                [[i // _GRID_WIDTH, i % _GRID_WIDTH] for i in range(num_tokens)],
+                dtype=torch.int64,
+                device=device,
+            )
+            return {VisionKwargs.patch_positions: patch_positions, AttentionKwargs.device: device}
+        return {
+            AttentionKwargs.sequence_length: num_tokens,
+            AttentionKwargs.sequence_k_dim: TensorDim("sequence_k", num_tokens),
+            AttentionKwargs.token_dim: TensorDim("token", num_tokens),
+            AttentionKwargs.device: device,
+        }
+
+    def reference_output(
+        self, query: torch.Tensor, key: torch.Tensor, preprocess_kwargs: dict
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.rotary_type == "2d":
+            patch_positions = preprocess_kwargs[VisionKwargs.patch_positions]
+            return (
+                _reference_rotary_2d_forward(query, patch_positions, self.theta, self.head_size),
+                _reference_rotary_2d_forward(key, patch_positions, self.theta, self.head_size),
+            )
+        positions = torch.arange(query.shape[0], dtype=torch.int64, device=query.device)
+        return (
+            _reference_rotary_1d_forward(query, self.reference_angle_scales, positions, self.attention_factor),
+            _reference_rotary_1d_forward(key, self.reference_angle_scales, positions, self.attention_factor),
+        )
+
+
+_head_sizes = [16, 32, 64]
+
+_rotary_test_configs: list[RotaryTestConfig] = []
+
+
+def _add_configs(name: str, **kwargs) -> None:
+    for head_size in _head_sizes:
+        _rotary_test_configs.append(RotaryTestConfig(name=f"{name}_h{head_size}", head_size=head_size, **kwargs))
+
+
+_add_configs("default")
+_add_configs("default_big_theta", theta=500000.0)
+_add_configs("llama3", rotary_type="llama3")
+_add_configs("yarn", rotary_type="yarn")
+_add_configs("2d", rotary_type="2d")
+
+_sequence_lengths = [8, 24]
+
+
+@pytest.mark.parametrize(
+    "sequence_length",
+    [pytest.param(seq_len, id=str(seq_len)) for seq_len in _sequence_lengths],
+)
+@pytest.mark.parametrize(
+    "config",
+    [pytest.param(config, id=config.name) for config in _rotary_test_configs],
+)
+def test_rotary(config: RotaryTestConfig, sequence_length: int, testing_device) -> None:
+    query = torch.randn(sequence_length, _NUM_HEADS, config.head_size, device=testing_device)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+
+    rotary = config.get_rotary_config().get_layer(TensorDim("head_size", config.head_size))
+    preprocess_kwargs = config.make_preprocess_kwargs(sequence_length, testing_device)
+    rotary.preprocess(preprocess_kwargs)
+    # Clone before forward: triton_rotary_ modifies the query tensor in-place.
+    query_ref = query.clone()
+    out_query, out_key_value = rotary.forward(query, torch.cat([key, value], dim=-2), preprocess_kwargs)
+    out_key, out_value = out_key_value.chunk(2, dim=-2)
+
+    expected_query, expected_key = config.reference_output(query_ref, key, preprocess_kwargs)
+    Assert.rms_close_relative(out_query, expected_query, 1e-5, 1e-7)
+    Assert.rms_close_relative(out_key, expected_key, 1e-5, 1e-7)
+    Assert.all_equal(out_value, value)

--- a/tests/layers/test_rotary.py
+++ b/tests/layers/test_rotary.py
@@ -186,23 +186,24 @@ class RotaryTestConfig:
 
 _head_sizes = [16, 32, 64]
 
-_rotary_test_configs: list[RotaryTestConfig] = []
+_rotary_type_specs = [
+    ("default", {}),
+    ("default_big_theta", {"theta": 500000.0}),
+    ("llama3", {"rotary_type": "llama3"}),
+    ("yarn", {"rotary_type": "yarn"}),
+    ("2d", {"rotary_type": "2d"}),
+]
 
-
-def _add_configs(name: str, **kwargs) -> None:
-    for head_size in _head_sizes:
-        _rotary_test_configs.append(RotaryTestConfig(name=f"{name}_h{head_size}", head_size=head_size, **kwargs))
-
-
-_add_configs("default")
-_add_configs("default_big_theta", theta=500000.0)
-_add_configs("llama3", rotary_type="llama3")
-_add_configs("yarn", rotary_type="yarn")
-_add_configs("2d", rotary_type="2d")
+_rotary_test_configs = [
+    RotaryTestConfig(name=f"{name}_h{head_size}", head_size=head_size, **kwargs)
+    for name, kwargs in _rotary_type_specs
+    for head_size in _head_sizes
+]
 
 _sequence_lengths = [8, 24]
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "sequence_length",
     [pytest.param(seq_len, id=str(seq_len)) for seq_len in _sequence_lengths],


### PR DESCRIPTION
## Summary

- **`test_rotary.py`**: rewrites the procedural test as a parametrized config-driven suite covering `default`, `llama3`, `yarn`, and `2D` rotary across multiple head sizes and sequence lengths. Independent 1D/2D reference implementations in plain PyTorch (no Fast-LLM kernel calls). Clones `query` before calling forward — `triton_rotary_` writes results in-place and would corrupt the reference otherwise.

- **`test_attention.py`**: replaces sparse per-feature stubs with a single combined test. Each configuration exercises three checks:
  - Independent einsum reference (plain `F.linear` + per-head matmul, no Fast-LLM internals)
  - Packing equivalence: packed output must match per-sequence forward and backward
  - Flash equivalence: packed flash output must match bfloat16 backup reference
  
  Configurations: causal, non-causal, sliding-window, MQA (1 KV head), MHA (head_groups == heads), default-rotary.

- **`test_embedding.py`** (new): parametrized coverage for `LanguageModelEmbedding`. Base cases (default, padding, position embeddings) × variants (float32, bfloat16, full-precision residual). Reference in plain PyTorch, independent of Fast-LLM embedding internals.

## Test plan
- [ ] `pytest -v tests/layers/test_rotary.py tests/layers/test_attention.py tests/layers/test_embedding.py`