### PR TITLE
Add comment policy to Code Style in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,7 @@ Tests live in `tests/`. The following patterns work well in this codebase.
 
 ## Code Style
 
+- **Comments**: Write no comments by default. Only add one when the WHY is non-obvious — a hidden constraint, a subtle invariant, a workaround for a specific bug, behavior that would surprise a reader. Never restate what the code already says; well-named identifiers do that.
 - **Imports**: Third-party → `import package.module` (keep fully qualified). First-party → `from fast_llm.module import Thing`. No relative imports. Optional/slow imports inside methods or under `if typing.TYPE_CHECKING:`.
 - **Naming**: No abbreviations (use `batch_size` not `bs`). Private members get a single `_` prefix; never use `__`. Keep public interfaces lean.
 - **Types**: Always type-hint public interfaces. Use modern syntax (`X | Y`, `list[T]` not `List[T]`, PEP 695 generics like `class X[T: Bound]:` instead of `typing.TypeVar`).


### PR DESCRIPTION
## Summary

- The PR review checklist already flagged comments that restate obvious code, but the Code Style section had no comment guidance
- Coder sessions read Code Style to guide generation and found no constraint, defaulting to verbose comments; reviewer sessions then flagged them
- Adds an explicit **Comments** entry to Code Style so both sides apply the same rule

## Test plan

- [ ] Verify coder sessions now produce minimal comments in new code
- [ ] Verify reviewer sessions continue to flag excessive comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)