### PR TITLE
Improve review command output: verified line numbers, tighter items

### DIFF
--- a/.claude/commands/review-coarse.md
+++ b/.claude/commands/review-coarse.md
@@ -28,7 +28,7 @@ On a follow-up review after fixes have been pushed, run `git diff <last-reviewed
 
 Each numbered item must stand on its own as a concrete, actionable finding — a specific change to make or a clear problem to fix, phrased so `fix N` is a complete instruction. Prefer a single recommendation; only present alternatives ("either X or Y") when both are genuinely viable and you can't justify picking one. Keep items concise by default; add context (rationale, alternatives considered) only when it's needed for the contributor to act.
 
-When an item refers to specific code, include a path from the repo root and the relevant line number(s), in the form `path/to/file.py:42` or `path/to/file.py:42-58`.
+When an item refers to specific code, include a path from the repo root and the relevant line number(s), in the form `path/to/file.py:42` or `path/to/file.py:42-58`. Verify line numbers by reading the relevant file section with the `Read` tool — diff hunk headers (`@@`) are easy to miscount and must not be used as the sole source.
 
 Format each item as a **standalone paragraph beginning with a bolded number**, e.g. `**1.** <finding>...`, *not* as a Markdown ordered list (`1. ...\n2. ...`) — terminal renderers collapse ordered lists to a tight layout regardless of source blank lines, but standalone paragraphs render with normal vertical spacing. Insert a blank line between items. Don't use unnumbered bullets where ordinals would make items addressable.
 

--- a/.claude/commands/review-coarse.md
+++ b/.claude/commands/review-coarse.md
@@ -26,7 +26,11 @@ On a follow-up review after fixes have been pushed, run `git diff <last-reviewed
 
 ## Output
 
-Each numbered item must stand on its own as a concrete, actionable finding — a specific change to make or a clear problem to fix, phrased so `fix N` is a complete instruction. Prefer a single recommendation; only present alternatives ("either X or Y") when both are genuinely viable and you can't justify picking one. Keep items concise by default; add context (rationale, alternatives considered) only when it's needed for the contributor to act.
+Each numbered item must stand on its own as a concrete, actionable finding — a specific change to make or a clear problem to fix, phrased so `fix N` is a complete instruction. Prefer a single recommendation; only present alternatives ("either X or Y") when both are genuinely viable and you can't justify picking one.
+
+Keep each item's lead to **1–3 sentences**: location, what's wrong, what to do. Trust the reader to read the code — don't explain how the bug would manifest, walk through the data flow, justify why the current code is wrong beyond a brief phrase, or compare fix options inside the lead.
+
+If a finding genuinely needs more — a cross-file invariant the reader couldn't infer locally, a non-obvious failure mode, an alternative worth weighing — add it as a *separate paragraph* below the lead. Use this sparingly; the lead must remain a short, scannable paragraph on its own.
 
 When an item refers to specific code, include a path from the repo root and the relevant line number(s), in the form `path/to/file.py:42` or `path/to/file.py:42-58`. Verify line numbers by reading the relevant file section with the `Read` tool — diff hunk headers (`@@`) are easy to miscount and must not be used as the sole source.
 

--- a/.claude/commands/review-fine.md
+++ b/.claude/commands/review-fine.md
@@ -24,7 +24,7 @@ On a follow-up review after fixes have been pushed, run `git diff <last-reviewed
 
 Each numbered item must stand on its own as a concrete, actionable finding — a specific change to make or a clear problem to fix, phrased so `fix N` is a complete instruction. Prefer a single recommendation; only present alternatives ("either X or Y") when both are genuinely viable and you can't justify picking one. Keep items concise by default; add context (rationale, alternatives considered) only when it's needed for the contributor to act.
 
-When an item refers to specific code, include a path from the repo root and the relevant line number(s), in the form `path/to/file.py:42` or `path/to/file.py:42-58`.
+When an item refers to specific code, include a path from the repo root and the relevant line number(s), in the form `path/to/file.py:42` or `path/to/file.py:42-58`. Verify line numbers by reading the relevant file section with the `Read` tool — diff hunk headers (`@@`) are easy to miscount and must not be used as the sole source.
 
 Format each item as a **standalone paragraph beginning with a bolded number**, e.g. `**1.** <finding>...`, *not* as a Markdown ordered list (`1. ...\n2. ...`) — terminal renderers collapse ordered lists to a tight layout regardless of source blank lines, but standalone paragraphs render with normal vertical spacing. Insert a blank line between items. Don't use unnumbered bullets where ordinals would make items addressable.
 

--- a/.claude/commands/review-fine.md
+++ b/.claude/commands/review-fine.md
@@ -22,7 +22,11 @@ On a follow-up review after fixes have been pushed, run `git diff <last-reviewed
 
 ## Output
 
-Each numbered item must stand on its own as a concrete, actionable finding — a specific change to make or a clear problem to fix, phrased so `fix N` is a complete instruction. Prefer a single recommendation; only present alternatives ("either X or Y") when both are genuinely viable and you can't justify picking one. Keep items concise by default; add context (rationale, alternatives considered) only when it's needed for the contributor to act.
+Each numbered item must stand on its own as a concrete, actionable finding — a specific change to make or a clear problem to fix, phrased so `fix N` is a complete instruction. Prefer a single recommendation; only present alternatives ("either X or Y") when both are genuinely viable and you can't justify picking one.
+
+Keep each item's lead to **1–3 sentences**: location, what's wrong, what to do. Trust the reader to read the code — don't explain how the bug would manifest, walk through the data flow, justify why the current code is wrong beyond a brief phrase, or compare fix options inside the lead.
+
+If a finding genuinely needs more — a cross-file invariant the reader couldn't infer locally, a non-obvious failure mode, an alternative worth weighing — add it as a *separate paragraph* below the lead. Use this sparingly; the lead must remain a short, scannable paragraph on its own.
 
 When an item refers to specific code, include a path from the repo root and the relevant line number(s), in the form `path/to/file.py:42` or `path/to/file.py:42-58`. Verify line numbers by reading the relevant file section with the `Read` tool — diff hunk headers (`@@`) are easy to miscount and must not be used as the sole source.
 


### PR DESCRIPTION
## Summary

Two fixes to `/review-coarse` and `/review-fine` based on observed output quality issues:

- **Line numbers**: items frequently cited nonsense line numbers because models were reading them off diff hunk headers (`@@`), which are easy to miscount. Require verification via the `Read` tool before citing.
- **Conciseness**: items routinely ballooned into multi-paragraph essays with mechanism walkthroughs, fix-option comparisons, and rationale. Cap each item's lead at 1–3 sentences (location, what's wrong, what to do) and allow a separate paragraph below the lead only when extra context is genuinely needed.

## Test plan

- [ ] Run `/review-coarse` and `/review-fine` on a branch with changes; verify line numbers match actual file positions and items stay short