### PR TITLE
Add SDPA attention implementation

### DIFF
--- a/fast_llm/data/document/block.py
+++ b/fast_llm/data/document/block.py
@@ -124,17 +124,19 @@ class LengthModelInputPreprocessor:
         return cumulative_lengths_q, cumulative_lengths_k
 
     @functools.cached_property
+    def _first_length_k(self) -> int:
+        # First doc's K-side length includes the past KV prefix; remaining docs match q-side.
+        return self.sequence_k_past + self.lengths[0] - self.first_document_begin
+
+    @functools.cached_property
     def max_lengths(self) -> tuple[int, int]:
         max_length_q = max(self.lengths)
-        max_length_k = max(max_length_q, self.sequence_k_past + self.lengths[0] - self.first_document_begin)
-        return max_length_q, max_length_k
+        return max_length_q, max(max_length_q, self._first_length_k)
 
     @functools.cached_property
     def min_lengths(self) -> tuple[int, int]:
         min_length_q = min(self.lengths)
-        # First doc's K-side length includes the past KV prefix; remaining docs match q-side.
-        first_length_k = self.sequence_k_past + self.lengths[0] - self.first_document_begin
-        min_length_k = min(first_length_k, *self.lengths[1:]) if len(self.lengths) > 1 else first_length_k
+        min_length_k = min(self._first_length_k, *self.lengths[1:]) if len(self.lengths) > 1 else self._first_length_k
         return min_length_q, min_length_k
 
     @functools.cached_property

--- a/fast_llm/data/document/block.py
+++ b/fast_llm/data/document/block.py
@@ -31,6 +31,7 @@ class BlockModelInput(ModelInput):
     document_index_q: torch.Tensor | None = None
     document_index_k: torch.Tensor | None = None
     position_index: torch.Tensor | None = None
+    first_document_begin: int = 0
 
     def to_kwargs(self) -> dict[str, typing.Any]:
         return {
@@ -51,6 +52,7 @@ class BlockModelInput(ModelInput):
             AttentionKwargs.document_index_q: self.document_index_q,
             AttentionKwargs.document_index_k: self.document_index_k,
             LanguageModelKwargs.position_ids: self.position_index,
+            AttentionKwargs.first_document_begin: self.first_document_begin,
         }
 
 
@@ -101,6 +103,7 @@ class LengthModelInputPreprocessor:
             # TODO: Support non-causal cropping (needs to know about the future too).
             Assert.eq(model_input.sequence_k_dim.global_size, self.last_document_end)
 
+        model_input.first_document_begin = self.first_document_begin
         if config.return_cumulative_sequence_lengths:
             model_input.cumulative_lengths_q, model_input.cumulative_lengths_k = self.cumulative_lengths
         if config.return_max_sequence_lengths or config.return_document_index:

--- a/fast_llm/data/document/block.py
+++ b/fast_llm/data/document/block.py
@@ -24,8 +24,10 @@ class BlockModelInput(ModelInput):
     lengths: list[int] = None
     cumulative_lengths_q: torch.Tensor | None = None
     cumulative_lengths_k: torch.Tensor | None = None
-    max_length_q: torch.Tensor | None = None
-    max_length_k: torch.Tensor | None = None
+    max_length_q: int | None = None
+    max_length_k: int | None = None
+    min_length_q: int | None = None
+    min_length_k: int | None = None
     document_index_q: torch.Tensor | None = None
     document_index_k: torch.Tensor | None = None
     position_index: torch.Tensor | None = None
@@ -44,6 +46,8 @@ class BlockModelInput(ModelInput):
             AttentionKwargs.cu_seqlens_k: self.cumulative_lengths_k,
             AttentionKwargs.max_seqlen_q: self.max_length_q,
             AttentionKwargs.max_seqlen_k: self.max_length_k,
+            AttentionKwargs.min_seqlen_q: self.min_length_q,
+            AttentionKwargs.min_seqlen_k: self.min_length_k,
             AttentionKwargs.document_index_q: self.document_index_q,
             AttentionKwargs.document_index_k: self.document_index_k,
             LanguageModelKwargs.position_ids: self.position_index,
@@ -101,6 +105,8 @@ class LengthModelInputPreprocessor:
             model_input.cumulative_lengths_q, model_input.cumulative_lengths_k = self.cumulative_lengths
         if config.return_max_sequence_lengths or config.return_document_index:
             model_input.max_length_q, model_input.max_length_k = self.max_lengths
+        if config.return_min_sequence_lengths:
+            model_input.min_length_q, model_input.min_length_k = self.min_lengths
         if config.return_document_index:
             model_input.document_index_q, model_input.document_index_k = self.document_index
         if config.return_position_index:
@@ -118,13 +124,18 @@ class LengthModelInputPreprocessor:
         return cumulative_lengths_q, cumulative_lengths_k
 
     @functools.cached_property
-    def max_lengths(self) -> tuple[torch.Tensor, torch.Tensor]:
+    def max_lengths(self) -> tuple[int, int]:
         max_length_q = max(self.lengths)
         max_length_k = max(max_length_q, self.sequence_k_past + self.lengths[0] - self.first_document_begin)
-        return (
-            torch.full((1,), max_length_q, dtype=torch.int32, device=self.device),
-            torch.full((1,), max_length_k, dtype=torch.int32, device=self.device),
-        )
+        return max_length_q, max_length_k
+
+    @functools.cached_property
+    def min_lengths(self) -> tuple[int, int]:
+        min_length_q = min(self.lengths)
+        # First doc's K-side length includes the past KV prefix; remaining docs match q-side.
+        first_length_k = self.sequence_k_past + self.lengths[0] - self.first_document_begin
+        min_length_k = min(first_length_k, *self.lengths[1:]) if len(self.lengths) > 1 else first_length_k
+        return min_length_q, min_length_k
 
     @functools.cached_property
     def document_index(self) -> tuple[torch.Tensor, torch.Tensor]:

--- a/fast_llm/data/document/config.py
+++ b/fast_llm/data/document/config.py
@@ -25,6 +25,7 @@ class LengthPreprocessingConfig(BatchPreprocessingConfig):
     distributed: DistributedConfig = Field()
     return_cumulative_sequence_lengths: bool = Field(default=False)
     return_max_sequence_lengths: bool = Field(default=False)
+    return_min_sequence_lengths: bool = Field(default=False)
     return_document_index: bool = Field(default=False)
     return_position_index: bool = Field(default=False)
 

--- a/fast_llm/layers/attention/attention.py
+++ b/fast_llm/layers/attention/attention.py
@@ -87,15 +87,8 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
                 and self._config.head_size <= 256
             ):
                 self._implementation = AttentionImplementation.flash
-            elif self._distributed_config.use_cuda and self._config.window_size is None:
-                # SDPA's EFFICIENT backend handles every dtype on CUDA; on CPU the
-                # nested + is_causal path has no viable backend, and SDPA does not
-                # support sliding window so windowed runs need backup either way.
-                self._implementation = AttentionImplementation.sdpa
             else:
-                self._implementation = AttentionImplementation.backup
-        if self._implementation == AttentionImplementation.sdpa:
-            assert self._config.window_size is None, "SDPA implementation does not support sliding window."
+                self._implementation = AttentionImplementation.sdpa
 
         self._parallel_dim = self._distributed_config.get_distributed_dim(DistributedDimNames.tensor)
         self._sequence_data_parallel_dim = self._distributed_config.get_distributed_dim(
@@ -276,30 +269,48 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
         value: torch.Tensor,  # total_k, head_groups, head_size
         kwargs: dict[str, typing.Any],
     ) -> torch.Tensor:  # total_q, heads, head_size
-        # SDPA's EFFICIENT backend (the only one that supports head_size > 256) requires
-        # Q/K/V to have the same num_heads, so we materialize K/V across query heads.
-        # Wrap as nested-jagged to give SDPA the per-document mask via batch elements,
-        # avoiding the pack→pad→gather dance.
+        # SDPA's fused kernels require Q/K/V to share heads, so we expand K/V across query heads.
         if self._local_heads_per_group > 1:
             key = key.repeat_interleave(self._local_heads_per_group, dim=1)
             value = value.repeat_interleave(self._local_heads_per_group, dim=1)
-        cu_seqlens_q = kwargs[AttentionKwargs.cu_seqlens_q].to(torch.int64)
-        cu_seqlens_k = kwargs[AttentionKwargs.cu_seqlens_k].to(torch.int64)
-        query_nested = torch.nested.nested_tensor_from_jagged(query, cu_seqlens_q)
-        key_nested = torch.nested.nested_tensor_from_jagged(key, cu_seqlens_k)
-        value_nested = torch.nested.nested_tensor_from_jagged(value, cu_seqlens_k)
 
-        with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION):
-            output_nested = torch.nn.functional.scaled_dot_product_attention(
-                query_nested.transpose(1, 2),
-                key_nested.transpose(1, 2),
-                value_nested.transpose(1, 2),
-                is_causal=self._config.causal,
+        if query.is_cuda and self._config.window_size is None:
+            # Most-efficient path: nested-jagged + is_causal lets EFFICIENT skip materializing
+            # the attention mask. Document boundaries are encoded by the per-doc batch elements.
+            cu_seqlens_q = kwargs[AttentionKwargs.cu_seqlens_q].to(torch.int64)
+            cu_seqlens_k = kwargs[AttentionKwargs.cu_seqlens_k].to(torch.int64)
+            query_nested = torch.nested.nested_tensor_from_jagged(query, cu_seqlens_q)
+            key_nested = torch.nested.nested_tensor_from_jagged(key, cu_seqlens_k)
+            value_nested = torch.nested.nested_tensor_from_jagged(value, cu_seqlens_k)
+            with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION):
+                output_nested = torch.nn.functional.scaled_dot_product_attention(
+                    query_nested.transpose(1, 2),
+                    key_nested.transpose(1, 2),
+                    value_nested.transpose(1, 2),
+                    is_causal=self._config.causal,
+                    dropout_p=self._config.dropout if self.training else 0.0,
+                    scale=self._softmax_scale,
+                ).transpose(1, 2)
+            return output_nested.values()
+
+        # CPU MATH rejects nested + is_causal, and the nested path can't express sliding window.
+        # Both fall back on the same dense + attn_mask form, reusing backup's preprocessed mask.
+        # Backup builds it as (1, sq, 1, sk) for its head-grouped layout; SDPA wants (B, H, sq, sk).
+        attention_mask = kwargs[AttentionKwargs.attention_mask]
+        if attention_mask is not None:
+            attention_mask = attention_mask.transpose(1, 2)
+        return (
+            torch.nn.functional.scaled_dot_product_attention(
+                query.unsqueeze(0).transpose(1, 2),
+                key.unsqueeze(0).transpose(1, 2),
+                value.unsqueeze(0).transpose(1, 2),
+                attn_mask=attention_mask,
                 dropout_p=self._config.dropout if self.training else 0.0,
                 scale=self._softmax_scale,
-            ).transpose(1, 2)
-
-        return output_nested.values()
+            )
+            .transpose(1, 2)
+            .squeeze(0)
+        )
 
     def _apply_norm_with_grad_capture(
         self, norm: torch.nn.Module, x: torch.Tensor
@@ -552,16 +563,23 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
                 "return_max_sequence_lengths": True,
                 "causal": self._config.causal,
             }
-        elif self._implementation == AttentionImplementation.sdpa:
+        elif (
+            self._implementation == AttentionImplementation.sdpa
+            and self._distributed_config.use_cuda
+            and self._config.window_size is None
+        ):
             return {"return_cumulative_sequence_lengths": True, "causal": self._config.causal}
-        elif self._implementation == AttentionImplementation.backup:
+        elif self._implementation in (AttentionImplementation.sdpa, AttentionImplementation.backup):
             return {"return_document_index": True, "causal": self._config.causal}
         else:
             raise NotImplementedError(self._implementation)
 
     def preprocess(self, kwargs: dict[str, typing.Any]) -> None:
         self._rotary.preprocess(kwargs)
-        if self._implementation == AttentionImplementation.backup:
+        if self._implementation == AttentionImplementation.backup or (
+            self._implementation == AttentionImplementation.sdpa
+            and (not self._distributed_config.use_cuda or self._config.window_size is not None)
+        ):
             self._preprocess_for_backup_attention(kwargs)
 
     def _preprocess_for_backup_attention(self, kwargs: dict[str, typing.Any]) -> None:

--- a/fast_llm/layers/attention/attention.py
+++ b/fast_llm/layers/attention/attention.py
@@ -292,7 +292,22 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
             "dropout_p": self._config.dropout if self.training else 0.0,
             "scale": self._softmax_scale,
         }
-        if self._implementation == AttentionImplementation.sdpa_nested:
+        # Dispatch on whether the preprocessor materialized an explicit dense mask. The nested
+        # path uses `is_causal=True`, which PyTorch implements as TOP-LEFT (UPPER-LEFT) alignment
+        # and produces wrong results when any document straddles the current micro-sequence's
+        # start (seq_q < seq_k for the straddling doc — that doc needs BOTTOM-RIGHT). When the
+        # preprocessor detects straddling, it builds an explicit BOTTOM-RIGHT mask via
+        # `_preprocess_for_backup_attention`; we then fall back to the dense SDPA path.
+        if AttentionKwargs.attention_mask in kwargs:
+            # Dense + backup's preprocessed causal+document mask. Required on CPU (MATH rejects
+            # nested + is_causal), on CUDA with sliding window (the nested path can't express
+            # it), and on CUDA when any document straddles the current micro-sequence's start.
+            # Backup builds the mask as (1, sq, 1, sk); SDPA wants (B, H, sq, sk).
+            query = query.unsqueeze(0)
+            key = key.unsqueeze(0)
+            value = value.unsqueeze(0)
+            sdpa_args["attn_mask"] = kwargs[AttentionKwargs.attention_mask].transpose(1, 2)
+        else:
             # Wrap each document as its own batch element via nested-jagged so cross-doc masking
             # is structural and EFFICIENT skips materializing the attention mask. The dispatch
             # otherwise reads `max_seqlen`/`min_seqlen` to host on every call; passing them in
@@ -319,14 +334,6 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
                 max_seqlen=kwargs[AttentionKwargs.max_seqlen_k],
             )
             sdpa_args["is_causal"] = self._config.causal
-        else:
-            # Dense + backup's preprocessed causal+document mask. Required on CPU (MATH rejects
-            # nested + is_causal) and on CUDA with sliding window (the nested path can't express
-            # it). Backup builds the mask as (1, sq, 1, sk); SDPA wants (B, H, sq, sk).
-            query = query.unsqueeze(0)
-            key = key.unsqueeze(0)
-            value = value.unsqueeze(0)
-            sdpa_args["attn_mask"] = kwargs[AttentionKwargs.attention_mask].transpose(1, 2)
 
         output = torch.nn.functional.scaled_dot_product_attention(
             query.transpose(1, 2),
@@ -589,10 +596,14 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
                 "causal": self._config.causal,
             }
         elif self._implementation == AttentionImplementation.sdpa_nested:
+            # `document_index` is needed for the dense fallback when a document straddles the
+            # current micro-sequence's start (PyTorch nested SDPA's `is_causal=True` does TOP-LEFT
+            # causal alignment, which is wrong for the straddling doc with `seq_q < seq_k`).
             return {
                 "return_cumulative_sequence_lengths": True,
                 "return_max_sequence_lengths": True,
                 "return_min_sequence_lengths": True,
+                "return_document_index": True,
                 "causal": self._config.causal,
             }
         elif self._implementation in (AttentionImplementation.sdpa_dense, AttentionImplementation.backup):
@@ -604,6 +615,14 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
         self._rotary.preprocess(kwargs)
         if self._implementation in (AttentionImplementation.backup, AttentionImplementation.sdpa_dense):
             self._preprocess_for_backup_attention(kwargs)
+        elif self._implementation == AttentionImplementation.sdpa_nested:
+            # Detect cross-micro-sequence document straddle: PyTorch nested SDPA's `is_causal=True`
+            # does TOP-LEFT causal, but a straddling doc has `seq_q < seq_k` and needs BOTTOM-RIGHT.
+            # Materialize the dense mask in that case so `_attn_sdpa` falls back to dense SDPA.
+            first_document_begin = kwargs.get(AttentionKwargs.first_document_begin, 0)
+            sequence_k_past = kwargs[AttentionKwargs.sequence_k_dim].size - kwargs[AttentionKwargs.token_dim].size
+            if first_document_begin < sequence_k_past:
+                self._preprocess_for_backup_attention(kwargs)
 
     def _preprocess_for_backup_attention(self, kwargs: dict[str, typing.Any]) -> None:
         device = kwargs[AttentionKwargs.device] if AttentionKwargs.device in kwargs else self._distributed.device

--- a/fast_llm/layers/attention/attention.py
+++ b/fast_llm/layers/attention/attention.py
@@ -10,7 +10,12 @@ from fast_llm.engine.config_utils.initialization import init_normal_
 from fast_llm.engine.config_utils.tensor_dim import CompositeTensorDim, ConcatenatedTensorDim, TensorDim
 from fast_llm.engine.distributed.config import DistributedConfig, DistributedDimNames
 from fast_llm.functional.utils import wrap_forward_backward
-from fast_llm.layers.attention.config import AttentionConfig, AttentionImplementation, AttentionKwargs
+from fast_llm.layers.attention.config import (
+    _FLASH_MAX_HEAD_SIZE,
+    AttentionConfig,
+    AttentionImplementation,
+    AttentionKwargs,
+)
 from fast_llm.layers.common.peft.config import PeftConfig
 from fast_llm.layers.decoder.block import BlockWithBias
 from fast_llm.tensor import TensorMeta
@@ -79,12 +84,13 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
             peft=peft,
             return_bias=return_bias,
         )
+        # Two-stage resolution so callers can set `implementation=sdpa` to get the auto-picked SDPA flavor.
         self._implementation = self._config.implementation
         if self._implementation == AttentionImplementation.auto:
             if (
                 _flash_available
                 and self._distributed_config.compute_dtype in (DataType.float16, DataType.bfloat16)
-                and self._config.head_size <= 256
+                and self._config.head_size <= _FLASH_MAX_HEAD_SIZE
             ):
                 self._implementation = AttentionImplementation.flash
             else:
@@ -270,8 +276,8 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
     def _attn_sdpa(
         self,
         query: torch.Tensor,  # total_q, heads, head_size
-        key: torch.Tensor,  # total_k, head_groups, head_size
-        value: torch.Tensor,  # total_k, head_groups, head_size
+        key: torch.Tensor,  # total_k, head_groups, head_size (pre-GQA-expansion)
+        value: torch.Tensor,  # total_k, head_groups, head_size (pre-GQA-expansion)
         kwargs: dict[str, typing.Any],
     ) -> torch.Tensor:  # total_q, heads, head_size
         # SDPA's fused kernels require Q/K/V to share heads, so we expand K/V across query heads.
@@ -291,6 +297,7 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
             # is structural and EFFICIENT skips materializing the attention mask. The dispatch
             # otherwise reads `max_seqlen`/`min_seqlen` to host on every call; passing them in
             # explicitly keeps the path sync-free.
+            # `nested_tensor_from_jagged` requires int64 offsets.
             cu_seqlens_q = kwargs[AttentionKwargs.cu_seqlens_q].to(torch.int64)
             cu_seqlens_k = kwargs[AttentionKwargs.cu_seqlens_k].to(torch.int64)
             query = torch.nested.nested_tensor_from_jagged(

--- a/fast_llm/layers/attention/attention.py
+++ b/fast_llm/layers/attention/attention.py
@@ -280,7 +280,9 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
         }
         if query.is_cuda and self._config.window_size is None:
             # Wrap each document as its own batch element via nested-jagged so cross-doc masking
-            # is structural and EFFICIENT skips materializing the attention mask.
+            # is structural and EFFICIENT skips materializing the attention mask. SDPA's nested
+            # dispatch reads `max_seqlen`/`min_seqlen` to host (5 cudaMemcpyAsync DtoH per call),
+            # which floors per-call wall at ~6 ms; still much faster than dense+mask in varlen.
             cu_seqlens_q = kwargs[AttentionKwargs.cu_seqlens_q].to(torch.int64)
             cu_seqlens_k = kwargs[AttentionKwargs.cu_seqlens_k].to(torch.int64)
             query = torch.nested.nested_tensor_from_jagged(query, cu_seqlens_q)

--- a/fast_llm/layers/attention/attention.py
+++ b/fast_llm/layers/attention/attention.py
@@ -87,11 +87,13 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
                 and self._config.head_size <= 256
             ):
                 self._implementation = AttentionImplementation.flash
-            elif self._config.window_size is not None:
-                # SDPA path doesn't support sliding window; backup is the only fallback that does.
-                self._implementation = AttentionImplementation.backup
-            else:
+            elif self._distributed_config.use_cuda and self._config.window_size is None:
+                # SDPA's EFFICIENT backend handles every dtype on CUDA; on CPU the
+                # nested + is_causal path has no viable backend, and SDPA does not
+                # support sliding window so windowed runs need backup either way.
                 self._implementation = AttentionImplementation.sdpa
+            else:
+                self._implementation = AttentionImplementation.backup
         if self._implementation == AttentionImplementation.sdpa:
             assert self._config.window_size is None, "SDPA implementation does not support sliding window."
 

--- a/fast_llm/layers/attention/attention.py
+++ b/fast_llm/layers/attention/attention.py
@@ -81,10 +81,19 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
         )
         self._implementation = self._config.implementation
         if self._implementation == AttentionImplementation.auto:
-            if _flash_available and self._distributed_config.compute_dtype in (DataType.float16, DataType.bfloat16):
+            if (
+                _flash_available
+                and self._distributed_config.compute_dtype in (DataType.float16, DataType.bfloat16)
+                and self._config.head_size <= 256
+            ):
                 self._implementation = AttentionImplementation.flash
-            else:
+            elif self._config.window_size is not None:
+                # SDPA path doesn't support sliding window; backup is the only fallback that does.
                 self._implementation = AttentionImplementation.backup
+            else:
+                self._implementation = AttentionImplementation.sdpa
+        if self._implementation == AttentionImplementation.sdpa:
+            assert self._config.window_size is None, "SDPA implementation does not support sliding window."
 
         self._parallel_dim = self._distributed_config.get_distributed_dim(DistributedDimNames.tensor)
         self._sequence_data_parallel_dim = self._distributed_config.get_distributed_dim(
@@ -258,6 +267,38 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
             softmax_scale=self._softmax_scale,
         )
 
+    def _attn_sdpa(
+        self,
+        query: torch.Tensor,  # total_q, heads, head_size
+        key: torch.Tensor,  # total_k, head_groups, head_size
+        value: torch.Tensor,  # total_k, head_groups, head_size
+        kwargs: dict[str, typing.Any],
+    ) -> torch.Tensor:  # total_q, heads, head_size
+        # SDPA's EFFICIENT backend (the only one that supports head_size > 256) requires
+        # Q/K/V to have the same num_heads, so we materialize K/V across query heads.
+        # Wrap as nested-jagged to give SDPA the per-document mask via batch elements,
+        # avoiding the pack→pad→gather dance.
+        if self._local_heads_per_group > 1:
+            key = key.repeat_interleave(self._local_heads_per_group, dim=1)
+            value = value.repeat_interleave(self._local_heads_per_group, dim=1)
+        cu_seqlens_q = kwargs[AttentionKwargs.cu_seqlens_q].to(torch.int64)
+        cu_seqlens_k = kwargs[AttentionKwargs.cu_seqlens_k].to(torch.int64)
+        query_nested = torch.nested.nested_tensor_from_jagged(query, cu_seqlens_q)
+        key_nested = torch.nested.nested_tensor_from_jagged(key, cu_seqlens_k)
+        value_nested = torch.nested.nested_tensor_from_jagged(value, cu_seqlens_k)
+
+        with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION):
+            output_nested = torch.nn.functional.scaled_dot_product_attention(
+                query_nested.transpose(1, 2),
+                key_nested.transpose(1, 2),
+                value_nested.transpose(1, 2),
+                is_causal=self._config.causal,
+                dropout_p=self._config.dropout if self.training else 0.0,
+                scale=self._softmax_scale,
+            ).transpose(1, 2)
+
+        return output_nested.values()
+
     def _apply_norm_with_grad_capture(
         self, norm: torch.nn.Module, x: torch.Tensor
     ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor] | None]:
@@ -420,6 +461,8 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
         with set_generator(self._distributed.tp_generator):
             if self._implementation == AttentionImplementation.flash:
                 input_ = self._attn_flash(query, key, value, kwargs)
+            elif self._implementation == AttentionImplementation.sdpa:
+                input_ = self._attn_sdpa(query, key, value, kwargs)
             elif self._implementation == AttentionImplementation.backup:
                 # TODO: Avoid the flattens.
                 input_ = self._attn_backup(query, key, value, kwargs)
@@ -472,7 +515,10 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
 
         attention_compute = sequence_q * sequence_k * attn_compute_base
 
-        if (not config.hardware) or self._implementation in AttentionImplementation.flash:
+        if (not config.hardware) or self._implementation in (
+            AttentionImplementation.flash,
+            AttentionImplementation.sdpa,
+        ):
             # Remove non-causal part. (TODO: Support non-causal)
             # TODO: Compute is overestimated without cross-document attention.
             attention_compute -= (sequence_q * (sequence_q - 1) * attn_compute_base) // 2
@@ -498,15 +544,18 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
         )
 
     def get_preprocessing_config(self) -> dict[str, typing.Any]:
-        return (
-            {
+        if self._implementation == AttentionImplementation.flash:
+            return {
                 "return_cumulative_sequence_lengths": True,
                 "return_max_sequence_lengths": True,
                 "causal": self._config.causal,
             }
-            if self._implementation == AttentionImplementation.flash
-            else {"return_document_index": True, "causal": self._config.causal}
-        )
+        elif self._implementation == AttentionImplementation.sdpa:
+            return {"return_cumulative_sequence_lengths": True, "causal": self._config.causal}
+        elif self._implementation == AttentionImplementation.backup:
+            return {"return_document_index": True, "causal": self._config.causal}
+        else:
+            raise NotImplementedError(self._implementation)
 
     def preprocess(self, kwargs: dict[str, typing.Any]) -> None:
         self._rotary.preprocess(kwargs)

--- a/fast_llm/layers/attention/attention.py
+++ b/fast_llm/layers/attention/attention.py
@@ -274,43 +274,38 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
             key = key.repeat_interleave(self._local_heads_per_group, dim=1)
             value = value.repeat_interleave(self._local_heads_per_group, dim=1)
 
+        sdpa_args: dict[str, typing.Any] = {
+            "dropout_p": self._config.dropout if self.training else 0.0,
+            "scale": self._softmax_scale,
+        }
         if query.is_cuda and self._config.window_size is None:
-            # Most-efficient path: nested-jagged + is_causal lets EFFICIENT skip materializing
-            # the attention mask. Document boundaries are encoded by the per-doc batch elements.
+            # Wrap each document as its own batch element via nested-jagged so cross-doc masking
+            # is structural and EFFICIENT skips materializing the attention mask.
             cu_seqlens_q = kwargs[AttentionKwargs.cu_seqlens_q].to(torch.int64)
             cu_seqlens_k = kwargs[AttentionKwargs.cu_seqlens_k].to(torch.int64)
-            query_nested = torch.nested.nested_tensor_from_jagged(query, cu_seqlens_q)
-            key_nested = torch.nested.nested_tensor_from_jagged(key, cu_seqlens_k)
-            value_nested = torch.nested.nested_tensor_from_jagged(value, cu_seqlens_k)
-            with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION):
-                output_nested = torch.nn.functional.scaled_dot_product_attention(
-                    query_nested.transpose(1, 2),
-                    key_nested.transpose(1, 2),
-                    value_nested.transpose(1, 2),
-                    is_causal=self._config.causal,
-                    dropout_p=self._config.dropout if self.training else 0.0,
-                    scale=self._softmax_scale,
-                ).transpose(1, 2)
-            return output_nested.values()
+            query = torch.nested.nested_tensor_from_jagged(query, cu_seqlens_q)
+            key = torch.nested.nested_tensor_from_jagged(key, cu_seqlens_k)
+            value = torch.nested.nested_tensor_from_jagged(value, cu_seqlens_k)
+            sdpa_args["is_causal"] = self._config.causal
+        else:
+            # Dense + backup's preprocessed causal+document mask. Required on CPU (MATH rejects
+            # nested + is_causal) and on CUDA with sliding window (the nested path can't express
+            # it). Backup builds the mask as (1, sq, 1, sk); SDPA wants (B, H, sq, sk).
+            attention_mask = kwargs[AttentionKwargs.attention_mask]
+            if attention_mask is not None:
+                attention_mask = attention_mask.transpose(1, 2)
+            query = query.unsqueeze(0)
+            key = key.unsqueeze(0)
+            value = value.unsqueeze(0)
+            sdpa_args["attn_mask"] = attention_mask
 
-        # CPU MATH rejects nested + is_causal, and the nested path can't express sliding window.
-        # Both fall back on the same dense + attn_mask form, reusing backup's preprocessed mask.
-        # Backup builds it as (1, sq, 1, sk) for its head-grouped layout; SDPA wants (B, H, sq, sk).
-        attention_mask = kwargs[AttentionKwargs.attention_mask]
-        if attention_mask is not None:
-            attention_mask = attention_mask.transpose(1, 2)
-        return (
-            torch.nn.functional.scaled_dot_product_attention(
-                query.unsqueeze(0).transpose(1, 2),
-                key.unsqueeze(0).transpose(1, 2),
-                value.unsqueeze(0).transpose(1, 2),
-                attn_mask=attention_mask,
-                dropout_p=self._config.dropout if self.training else 0.0,
-                scale=self._softmax_scale,
-            )
-            .transpose(1, 2)
-            .squeeze(0)
-        )
+        output = torch.nn.functional.scaled_dot_product_attention(
+            query.transpose(1, 2),
+            key.transpose(1, 2),
+            value.transpose(1, 2),
+            **sdpa_args,
+        ).transpose(1, 2)
+        return output.values() if output.is_nested else output.squeeze(0)
 
     def _apply_norm_with_grad_capture(
         self, norm: torch.nn.Module, x: torch.Tensor

--- a/fast_llm/layers/attention/attention.py
+++ b/fast_llm/layers/attention/attention.py
@@ -87,8 +87,10 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
                 and self._config.head_size <= 256
             ):
                 self._implementation = AttentionImplementation.flash
+            elif self._distributed_config.use_cuda and self._config.window_size is None:
+                self._implementation = AttentionImplementation.sdpa_nested
             else:
-                self._implementation = AttentionImplementation.sdpa
+                self._implementation = AttentionImplementation.sdpa_dense
 
         self._parallel_dim = self._distributed_config.get_distributed_dim(DistributedDimNames.tensor)
         self._sequence_data_parallel_dim = self._distributed_config.get_distributed_dim(
@@ -278,7 +280,7 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
             "dropout_p": self._config.dropout if self.training else 0.0,
             "scale": self._softmax_scale,
         }
-        if query.is_cuda and self._config.window_size is None:
+        if self._implementation == AttentionImplementation.sdpa_nested:
             # Wrap each document as its own batch element via nested-jagged so cross-doc masking
             # is structural and EFFICIENT skips materializing the attention mask. The dispatch
             # otherwise reads `max_seqlen`/`min_seqlen` to host on every call; passing them in
@@ -486,7 +488,7 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
         with set_generator(self._distributed.tp_generator):
             if self._implementation == AttentionImplementation.flash:
                 input_ = self._attn_flash(query, key, value, kwargs)
-            elif self._implementation == AttentionImplementation.sdpa:
+            elif self._implementation in (AttentionImplementation.sdpa_nested, AttentionImplementation.sdpa_dense):
                 input_ = self._attn_sdpa(query, key, value, kwargs)
             elif self._implementation == AttentionImplementation.backup:
                 # TODO: Avoid the flattens.
@@ -542,7 +544,8 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
 
         if (not config.hardware) or self._implementation in (
             AttentionImplementation.flash,
-            AttentionImplementation.sdpa,
+            AttentionImplementation.sdpa_nested,
+            AttentionImplementation.sdpa_dense,
         ):
             # Remove non-causal part. (TODO: Support non-causal)
             # TODO: Compute is overestimated without cross-document attention.
@@ -575,28 +578,21 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
                 "return_max_sequence_lengths": True,
                 "causal": self._config.causal,
             }
-        elif (
-            self._implementation == AttentionImplementation.sdpa
-            and self._distributed_config.use_cuda
-            and self._config.window_size is None
-        ):
+        elif self._implementation == AttentionImplementation.sdpa_nested:
             return {
                 "return_cumulative_sequence_lengths": True,
                 "return_max_sequence_lengths": True,
                 "return_min_sequence_lengths": True,
                 "causal": self._config.causal,
             }
-        elif self._implementation in (AttentionImplementation.sdpa, AttentionImplementation.backup):
+        elif self._implementation in (AttentionImplementation.sdpa_dense, AttentionImplementation.backup):
             return {"return_document_index": True, "causal": self._config.causal}
         else:
             raise NotImplementedError(self._implementation)
 
     def preprocess(self, kwargs: dict[str, typing.Any]) -> None:
         self._rotary.preprocess(kwargs)
-        if self._implementation == AttentionImplementation.backup or (
-            self._implementation == AttentionImplementation.sdpa
-            and (not self._distributed_config.use_cuda or self._config.window_size is not None)
-        ):
+        if self._implementation in (AttentionImplementation.backup, AttentionImplementation.sdpa_dense):
             self._preprocess_for_backup_attention(kwargs)
 
     def _preprocess_for_backup_attention(self, kwargs: dict[str, typing.Any]) -> None:

--- a/fast_llm/layers/attention/attention.py
+++ b/fast_llm/layers/attention/attention.py
@@ -280,14 +280,29 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
         }
         if query.is_cuda and self._config.window_size is None:
             # Wrap each document as its own batch element via nested-jagged so cross-doc masking
-            # is structural and EFFICIENT skips materializing the attention mask. SDPA's nested
-            # dispatch reads `max_seqlen`/`min_seqlen` to host (5 cudaMemcpyAsync DtoH per call),
-            # which floors per-call wall at ~6 ms; still much faster than dense+mask in varlen.
+            # is structural and EFFICIENT skips materializing the attention mask. The dispatch
+            # otherwise reads `max_seqlen`/`min_seqlen` to host on every call; passing them in
+            # explicitly keeps the path sync-free.
             cu_seqlens_q = kwargs[AttentionKwargs.cu_seqlens_q].to(torch.int64)
             cu_seqlens_k = kwargs[AttentionKwargs.cu_seqlens_k].to(torch.int64)
-            query = torch.nested.nested_tensor_from_jagged(query, cu_seqlens_q)
-            key = torch.nested.nested_tensor_from_jagged(key, cu_seqlens_k)
-            value = torch.nested.nested_tensor_from_jagged(value, cu_seqlens_k)
+            query = torch.nested.nested_tensor_from_jagged(
+                query,
+                cu_seqlens_q,
+                min_seqlen=kwargs[AttentionKwargs.min_seqlen_q],
+                max_seqlen=kwargs[AttentionKwargs.max_seqlen_q],
+            )
+            key = torch.nested.nested_tensor_from_jagged(
+                key,
+                cu_seqlens_k,
+                min_seqlen=kwargs[AttentionKwargs.min_seqlen_k],
+                max_seqlen=kwargs[AttentionKwargs.max_seqlen_k],
+            )
+            value = torch.nested.nested_tensor_from_jagged(
+                value,
+                cu_seqlens_k,
+                min_seqlen=kwargs[AttentionKwargs.min_seqlen_k],
+                max_seqlen=kwargs[AttentionKwargs.max_seqlen_k],
+            )
             sdpa_args["is_causal"] = self._config.causal
         else:
             # Dense + backup's preprocessed causal+document mask. Required on CPU (MATH rejects
@@ -565,7 +580,12 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
             and self._distributed_config.use_cuda
             and self._config.window_size is None
         ):
-            return {"return_cumulative_sequence_lengths": True, "causal": self._config.causal}
+            return {
+                "return_cumulative_sequence_lengths": True,
+                "return_max_sequence_lengths": True,
+                "return_min_sequence_lengths": True,
+                "causal": self._config.causal,
+            }
         elif self._implementation in (AttentionImplementation.sdpa, AttentionImplementation.backup):
             return {"return_document_index": True, "causal": self._config.causal}
         else:

--- a/fast_llm/layers/attention/attention.py
+++ b/fast_llm/layers/attention/attention.py
@@ -87,7 +87,10 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
                 and self._config.head_size <= 256
             ):
                 self._implementation = AttentionImplementation.flash
-            elif self._distributed_config.use_cuda and self._config.window_size is None:
+            else:
+                self._implementation = AttentionImplementation.sdpa
+        if self._implementation == AttentionImplementation.sdpa:
+            if self._distributed_config.use_cuda and self._config.window_size is None:
                 self._implementation = AttentionImplementation.sdpa_nested
             else:
                 self._implementation = AttentionImplementation.sdpa_dense
@@ -272,6 +275,9 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
         kwargs: dict[str, typing.Any],
     ) -> torch.Tensor:  # total_q, heads, head_size
         # SDPA's fused kernels require Q/K/V to share heads, so we expand K/V across query heads.
+        # `enable_gqa=True` would handle this internally, but it forces a fallback to the MATH
+        # backend (which materializes the O(S^2) attention matrix) and is unsupported by the
+        # nested-jagged path entirely; manual `repeat_interleave` keeps EFFICIENT in play.
         if self._local_heads_per_group > 1:
             key = key.repeat_interleave(self._local_heads_per_group, dim=1)
             value = value.repeat_interleave(self._local_heads_per_group, dim=1)
@@ -310,13 +316,10 @@ class Attention[ConfigType: AttentionConfig](BlockWithBias[ConfigType]):
             # Dense + backup's preprocessed causal+document mask. Required on CPU (MATH rejects
             # nested + is_causal) and on CUDA with sliding window (the nested path can't express
             # it). Backup builds the mask as (1, sq, 1, sk); SDPA wants (B, H, sq, sk).
-            attention_mask = kwargs[AttentionKwargs.attention_mask]
-            if attention_mask is not None:
-                attention_mask = attention_mask.transpose(1, 2)
             query = query.unsqueeze(0)
             key = key.unsqueeze(0)
             value = value.unsqueeze(0)
-            sdpa_args["attn_mask"] = attention_mask
+            sdpa_args["attn_mask"] = kwargs[AttentionKwargs.attention_mask].transpose(1, 2)
 
         output = torch.nn.functional.scaled_dot_product_attention(
             query.transpose(1, 2),

--- a/fast_llm/layers/attention/config.py
+++ b/fast_llm/layers/attention/config.py
@@ -163,6 +163,11 @@ class AttentionConfig(MixerConfig):
         if self.implementation == AttentionImplementation.flash:
             Assert.leq(self.head_size, 256)
 
+        if self.implementation == AttentionImplementation.sdpa_nested:
+            assert (
+                self.window_size is None
+            ), "`sdpa_nested` does not support sliding window; use `sdpa` or `sdpa_dense`."
+
     @property
     def layer_class(self) -> "type[Attention]":
         from fast_llm.layers.attention.attention import Attention

--- a/fast_llm/layers/attention/config.py
+++ b/fast_llm/layers/attention/config.py
@@ -40,6 +40,7 @@ class AttentionKwargs(MixerKwargs):
 class AttentionImplementation(enum.StrEnum):
     auto = "auto"
     flash = "flash"
+    sdpa = "sdpa"
     sdpa_nested = "sdpa_nested"
     sdpa_dense = "sdpa_dense"
     backup = "backup"
@@ -124,7 +125,10 @@ class AttentionConfig(MixerConfig):
     )
     implementation: AttentionImplementation = Field(
         default=AttentionImplementation.auto,
-        desc="The implementation to use for the attention layer. Default: `flash` if supported, otherwise `backup`.",
+        desc="The implementation to use for the attention layer."
+        " `auto` picks `flash` when available (bf16/fp16, head_size <= 256, flash-attn installed), otherwise `sdpa`."
+        " `sdpa` further resolves to `sdpa_nested` on CUDA without sliding window, and to `sdpa_dense` otherwise."
+        " `sdpa_nested` and `sdpa_dense` are explicit overrides; `backup` is a slow pure-PyTorch fallback.",
         hint=FieldHint.feature,
     )
     query_norm: NormalizationConfig | None = Field(
@@ -155,6 +159,9 @@ class AttentionConfig(MixerConfig):
 
         if not self.causal:
             assert self.window_size is None, "Non-causal windowed attention is not supported."
+
+        if self.implementation == AttentionImplementation.flash:
+            Assert.leq(self.head_size, 256)
 
     @property
     def layer_class(self) -> "type[Attention]":

--- a/fast_llm/layers/attention/config.py
+++ b/fast_llm/layers/attention/config.py
@@ -37,6 +37,9 @@ class AttentionKwargs(MixerKwargs):
     past_key_values = "past_key_values"
 
 
+_FLASH_MAX_HEAD_SIZE = 256
+
+
 class AttentionImplementation(enum.StrEnum):
     auto = "auto"
     flash = "flash"
@@ -161,7 +164,7 @@ class AttentionConfig(MixerConfig):
             assert self.window_size is None, "Non-causal windowed attention is not supported."
 
         if self.implementation == AttentionImplementation.flash:
-            Assert.leq(self.head_size, 256)
+            Assert.leq(self.head_size, _FLASH_MAX_HEAD_SIZE)
 
         if self.implementation == AttentionImplementation.sdpa_nested:
             assert (

--- a/fast_llm/layers/attention/config.py
+++ b/fast_llm/layers/attention/config.py
@@ -21,6 +21,8 @@ class MixerKwargs(BlockKwargs):
     cu_seqlens_k = "cu_seqlens_k"
     max_seqlen_q = "max_seqlen_q"
     max_seqlen_k = "max_seqlen_k"
+    min_seqlen_q = "min_seqlen_q"
+    min_seqlen_k = "min_seqlen_k"
     document_index_q = "document_index_q"
     document_index_k = "document_index_k"
     position_ids = "position_ids"

--- a/fast_llm/layers/attention/config.py
+++ b/fast_llm/layers/attention/config.py
@@ -26,6 +26,7 @@ class MixerKwargs(BlockKwargs):
     document_index_q = "document_index_q"
     document_index_k = "document_index_k"
     position_ids = "position_ids"
+    first_document_begin = "first_document_begin"
 
 
 class AttentionKwargs(MixerKwargs):

--- a/fast_llm/layers/attention/config.py
+++ b/fast_llm/layers/attention/config.py
@@ -40,7 +40,8 @@ class AttentionKwargs(MixerKwargs):
 class AttentionImplementation(enum.StrEnum):
     auto = "auto"
     flash = "flash"
-    sdpa = "sdpa"
+    sdpa_nested = "sdpa_nested"
+    sdpa_dense = "sdpa_dense"
     backup = "backup"
 
 

--- a/fast_llm/layers/attention/config.py
+++ b/fast_llm/layers/attention/config.py
@@ -38,6 +38,7 @@ class AttentionKwargs(MixerKwargs):
 class AttentionImplementation(enum.StrEnum):
     auto = "auto"
     flash = "flash"
+    sdpa = "sdpa"
     backup = "backup"
 
 

--- a/tests/layers/test_attention.py
+++ b/tests/layers/test_attention.py
@@ -174,78 +174,101 @@ class AttentionTestConfig:
             return torch.nn.functional.linear(attn_out.flatten(1), attention.dense.weight.detach())
 
 
-_base_attention_cases = [
+_LENGTHS_FULL = [[15], [6, 9], [4, 1, 10], [20, 32, 10, 11, 9, 18]]
+_LENGTHS_SHORT = [[15], [4, 1, 10]]
+_LENGTHS_SINGLE = [[15]]
+
+_attention_test_cases: list[tuple[AttentionTestConfig, list[int]]] = []
+
+# Mask, group, and window base cases — no norms, swept over all length sets.
+for name, kwargs in (
     ("causal", {"causal": True}),
     ("noncausal", {"causal": False}),
     ("window", {"causal": True, "window_size": 4}),
     ("mqa", {"causal": True, "kv_heads": 1}),
     ("mha", {"causal": True, "kv_heads": _HEADS}),
-]
+):
+    for lengths in _LENGTHS_FULL:
+        _attention_test_cases.append((AttentionTestConfig(name=f"{name}_no_norm", **kwargs), lengths))
 
-_attention_rotary_cases = [
-    # Rotary: packing equivalence is skipped for multi-document inputs (packed rotary uses global
-    # positions; per-sequence reference uses per-doc positions). All three checks run for single-doc inputs.
-    ("causal_rotary", {"causal": True, "rotary": True}),
-]
-
-_attention_norm_variants = [
-    ("no_norm", {}),
-    ("query_norm", {"query_norm": True}),
-    ("key_norm", {"key_norm": True}),
-    ("value_norm", {"value_norm": True}),
-    ("both_norms", {"query_norm": True, "key_norm": True}),
-    ("all_norms", {"query_norm": True, "key_norm": True, "value_norm": True}),
-]
-
-_attention_shared_key_value_cases = [
-    ("shared_key_value", {"shared_key_value": True}),
-    ("shared_key_value_rotary", {"shared_key_value": True, "rotary": True}),
-    # Gemma 4's full-attention layer combines shared_key_value with ProportionalRotary.
+# Per-head norm variants on causal and shared key/value bases. Rotary bases use single-doc
+# inputs because the packed and per-sequence rotary references diverge across boundaries.
+for base_name, base_kwargs, variants, length_set in (
+    (
+        "causal",
+        {"causal": True},
+        (
+            ("query_norm", {"query_norm": True}),
+            ("key_norm", {"key_norm": True}),
+            ("value_norm", {"value_norm": True}),
+            ("both_norms", {"query_norm": True, "key_norm": True}),
+            ("all_norms", {"query_norm": True, "key_norm": True, "value_norm": True}),
+        ),
+        _LENGTHS_SHORT,
+    ),
+    (
+        "causal_rotary",
+        {"causal": True, "rotary": True},
+        (
+            ("no_norm", {}),
+            ("query_norm", {"query_norm": True}),
+            ("key_norm", {"key_norm": True}),
+            ("value_norm", {"value_norm": True}),
+            ("both_norms", {"query_norm": True, "key_norm": True}),
+            ("all_norms", {"query_norm": True, "key_norm": True, "value_norm": True}),
+        ),
+        _LENGTHS_SINGLE,
+    ),
+    (
+        "shared_key_value",
+        {"shared_key_value": True},
+        (
+            ("no_norm", {}),
+            ("key_norm", {"key_norm": True}),
+            ("value_norm", {"value_norm": True}),
+            ("all_norms", {"query_norm": True, "key_norm": True, "value_norm": True}),
+        ),
+        _LENGTHS_SHORT,
+    ),
+    (
+        "shared_key_value_rotary",
+        {"shared_key_value": True, "rotary": True},
+        (
+            ("no_norm", {}),
+            ("key_norm", {"key_norm": True}),
+            ("value_norm", {"value_norm": True}),
+            ("all_norms", {"query_norm": True, "key_norm": True, "value_norm": True}),
+        ),
+        _LENGTHS_SINGLE,
+    ),
     (
         "shared_key_value_proportional_rotary",
         {"shared_key_value": True, "rotary": True, "rotary_partial_rotary_factor": 0.5},
+        (
+            ("no_norm", {}),
+            ("key_norm", {"key_norm": True}),
+            ("value_norm", {"value_norm": True}),
+            ("all_norms", {"query_norm": True, "key_norm": True, "value_norm": True}),
+        ),
+        _LENGTHS_SINGLE,
     ),
-]
+):
+    for variant_name, variant_kwargs in variants:
+        for lengths in length_set:
+            _attention_test_cases.append(
+                (
+                    AttentionTestConfig(name=f"{base_name}_{variant_name}", **base_kwargs, **variant_kwargs),
+                    lengths,
+                )
+            )
 
-_attention_shared_key_value_norm_variants = [
-    ("no_norm", {}),
-    ("key_norm", {"key_norm": True}),
-    ("value_norm", {"value_norm": True}),
-    ("all_norms", {"query_norm": True, "key_norm": True, "value_norm": True}),
-]
-
-# Norms apply per-head and don't interact with mask/group structure, so we test all norm
-# variants on a single base (causal) instead of crossing every norm with every base.
-# Lengths matter for packing/flash equivalence checks, so we sweep all lengths on the
-# base × no_norm cases (where seq layout interacts most with attention math).
-_LENGTHS_FULL = [[15], [6, 9], [4, 1, 10], [20, 32, 10, 11, 9, 18]]
-_LENGTHS_SHORT = [[15], [4, 1, 10]]
-_LENGTHS_SINGLE = [[15]]
-
-
-def _build_test_cases() -> list[tuple[AttentionTestConfig, list[int]]]:
-    cases: list[tuple[AttentionTestConfig, list[int]]] = []
-    for base_name, base_kwargs in _base_attention_cases:
-        config = AttentionTestConfig(name=f"{base_name}_no_norm", **base_kwargs)
-        cases.extend((config, lengths) for lengths in _LENGTHS_FULL)
-    for variant_name, variant_kwargs in _attention_norm_variants:
-        if variant_name == "no_norm":
-            continue
-        config = AttentionTestConfig(name=f"causal_{variant_name}", causal=True, **variant_kwargs)
-        cases.extend((config, lengths) for lengths in _LENGTHS_SHORT)
-    for base_name, base_kwargs in _attention_rotary_cases:
-        for variant_name, variant_kwargs in _attention_norm_variants:
-            config = AttentionTestConfig(name=f"{base_name}_{variant_name}", **base_kwargs, **variant_kwargs)
-            cases.extend((config, lengths) for lengths in _LENGTHS_SINGLE)
-    for base_name, base_kwargs in _attention_shared_key_value_cases:
-        lengths_set = _LENGTHS_SINGLE if base_kwargs.get("rotary") else _LENGTHS_SHORT
-        for variant_name, variant_kwargs in _attention_shared_key_value_norm_variants:
-            config = AttentionTestConfig(name=f"{base_name}_{variant_name}", **base_kwargs, **variant_kwargs)
-            cases.extend((config, lengths) for lengths in lengths_set)
-    return cases
-
-
-_attention_test_cases = _build_test_cases()
+# head_size > 256 — exercises the SDPA-only regime (flash caps at 256).
+for name, kwargs in (
+    ("large_head_causal", {"causal": True, "head_size": 320}),
+    ("large_head_mqa", {"causal": True, "head_size": 320, "kv_heads": 1}),
+):
+    for lengths in _LENGTHS_SHORT:
+        _attention_test_cases.append((AttentionTestConfig(name=name, **kwargs), lengths))
 
 
 def _run_per_seq_reference(
@@ -357,50 +380,57 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
         Assert.rms_close_relative(param.grad_buffer, grad_ref, 1e-5, 1e-7, msg=name)
     stage.reset_gradients()
 
-    # Flash equivalence check: packed flash output must match per-sequence bfloat16 backup reference.
-    if _flash_available:
-        distributed_config_bf16 = DistributedConfig(compute_dtype=DataType.bfloat16, use_cuda=True)
-        distributed_bf16 = Distributed(distributed_config_bf16)
+    # Flash and SDPA equivalence checks: each implementation's packed bfloat16 output must
+    # match a per-sequence bfloat16 backup reference.
+    if not torch.cuda.is_available():
+        return
 
-        attention_backup_bf16: Attention = config.get_attention_config("backup").get_layer(
+    distributed_config_bf16 = DistributedConfig(compute_dtype=DataType.bfloat16, use_cuda=True)
+    distributed_bf16 = Distributed(distributed_config_bf16)
+
+    attention_backup_bf16: Attention = config.get_attention_config("backup").get_layer(
+        distributed_config_bf16, hidden_dim, lr_scale=None, peft=None, return_bias=False
+    )
+    stage_backup_bf16 = get_stage([attention_backup_bf16], distributed_bf16)
+    for param_bf16, param_f32 in zip(attention_backup_bf16.parameters(), attention.parameters(), strict=True):
+        param_bf16.data.copy_(param_f32.data)
+
+    hidden_states_bf16 = hidden_states.detach().to(torch.bfloat16)
+    out_ref_bf16 = _run_per_seq_reference(
+        attention_backup_bf16,
+        stage_backup_bf16,
+        distributed_config_bf16,
+        hidden_states_bf16,
+        lengths,
+        device,
+        with_backward=False,
+    )
+
+    def _check_packed(implementation: str) -> None:
+        attention_impl: Attention = config.get_attention_config(implementation).get_layer(
             distributed_config_bf16, hidden_dim, lr_scale=None, peft=None, return_bias=False
         )
-        stage_backup_bf16 = get_stage([attention_backup_bf16], distributed_bf16)
-        for param_bf16, param_f32 in zip(attention_backup_bf16.parameters(), attention.parameters(), strict=True):
-            param_bf16.data.copy_(param_f32.data)
-
-        hidden_states_bf16 = hidden_states.detach().to(torch.bfloat16)
-        out_ref_bf16 = _run_per_seq_reference(
-            attention_backup_bf16,
-            stage_backup_bf16,
-            distributed_config_bf16,
-            hidden_states_bf16,
-            lengths,
-            device,
-            with_backward=False,
-        )
-
-        attention_flash: Attention = config.get_attention_config("flash").get_layer(
-            distributed_config_bf16, hidden_dim, lr_scale=None, peft=None, return_bias=False
-        )
-        stage_flash = get_stage([attention_flash], distributed_bf16)
-        for param_flash, param_f32 in zip(attention_flash.parameters(), attention.parameters(), strict=True):
-            param_flash.data.copy_(param_f32.data)
-
-        (model_input_flash,) = LanguageModelBatch(
+        stage_impl = get_stage([attention_impl], distributed_bf16)
+        for param_impl, param_f32 in zip(attention_impl.parameters(), attention.parameters(), strict=True):
+            param_impl.data.copy_(param_f32.data)
+        (model_input,) = LanguageModelBatch(
             tokens=torch.empty(num_tokens, dtype=torch.int64, device=device), lengths=lengths
         ).get_model_inputs(
             LanguageModelBatchPreprocessingConfig(
                 distributed=distributed_config_bf16,
                 predicted_tokens=0,
-                **attention_flash.get_preprocessing_config(),
+                **attention_impl.get_preprocessing_config(),
             )
         )
-        kwargs_flash = model_input_flash.to_kwargs()
-        attention_flash.preprocess(kwargs_flash)
-        out_flash, _ = stage_flash.forward(hidden_states_bf16, kwargs_flash)
+        kwargs_impl = model_input.to_kwargs()
+        attention_impl.preprocess(kwargs_impl)
+        out_impl, _ = stage_impl.forward(hidden_states_bf16, kwargs_impl)
+        Assert.rms_close_relative(out_impl, out_ref_bf16, 5e-3, 1e-7)
 
-        Assert.rms_close_relative(out_flash, out_ref_bf16, 5e-3, 1e-7)
+    if _flash_available and config.head_size <= 256:
+        _check_packed("flash")
+    if config.window_size is None:
+        _check_packed("sdpa")
 
 
 @pytest.mark.slow

--- a/tests/layers/test_attention.py
+++ b/tests/layers/test_attention.py
@@ -380,7 +380,40 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
         Assert.rms_close_relative(param.grad_buffer, grad_ref, 1e-5, 1e-7, msg=name)
     stage.reset_gradients()
 
-    # Flash and SDPA equivalence checks: each implementation's packed bfloat16 output must
+    def _check_packed(
+        implementation: str,
+        distributed_config_check: DistributedConfig,
+        distributed_check: Distributed,
+        hidden_states_check: torch.Tensor,
+        out_ref_check: torch.Tensor,
+        rtol: float,
+    ) -> None:
+        attention_impl: Attention = config.get_attention_config(implementation).get_layer(
+            distributed_config_check, hidden_dim, lr_scale=None, peft=None, return_bias=False
+        )
+        stage_impl = get_stage([attention_impl], distributed_check)
+        for param_impl, param_f32 in zip(attention_impl.parameters(), attention.parameters(), strict=True):
+            param_impl.data.copy_(param_f32.data)
+        (model_input,) = LanguageModelBatch(
+            tokens=torch.empty(num_tokens, dtype=torch.int64, device=device), lengths=lengths
+        ).get_model_inputs(
+            LanguageModelBatchPreprocessingConfig(
+                distributed=distributed_config_check,
+                predicted_tokens=0,
+                **attention_impl.get_preprocessing_config(),
+            )
+        )
+        kwargs_impl = model_input.to_kwargs()
+        attention_impl.preprocess(kwargs_impl)
+        out_impl, _ = stage_impl.forward(hidden_states_check, kwargs_impl)
+        Assert.rms_close_relative(out_impl, out_ref_check, rtol, 1e-7)
+
+    # SDPA-dense equivalence check: sdpa_dense reuses backup's mask, so its packed fp32 output
+    # must match the per-sequence backup reference. This is the only SDPA branch that runs on CPU
+    # (sdpa_nested needs CUDA), so the check is unconditional rather than CUDA-gated.
+    _check_packed("sdpa_dense", distributed_config, distributed, hidden_states.detach(), out_ref, 1e-5)
+
+    # Flash and SDPA-nested equivalence checks: each implementation's packed bfloat16 output must
     # match a per-sequence bfloat16 backup reference.
     if not torch.cuda.is_available():
         return
@@ -406,30 +439,9 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
         with_backward=False,
     )
 
-    def _check_packed(implementation: str) -> None:
-        attention_impl: Attention = config.get_attention_config(implementation).get_layer(
-            distributed_config_bf16, hidden_dim, lr_scale=None, peft=None, return_bias=False
-        )
-        stage_impl = get_stage([attention_impl], distributed_bf16)
-        for param_impl, param_f32 in zip(attention_impl.parameters(), attention.parameters(), strict=True):
-            param_impl.data.copy_(param_f32.data)
-        (model_input,) = LanguageModelBatch(
-            tokens=torch.empty(num_tokens, dtype=torch.int64, device=device), lengths=lengths
-        ).get_model_inputs(
-            LanguageModelBatchPreprocessingConfig(
-                distributed=distributed_config_bf16,
-                predicted_tokens=0,
-                **attention_impl.get_preprocessing_config(),
-            )
-        )
-        kwargs_impl = model_input.to_kwargs()
-        attention_impl.preprocess(kwargs_impl)
-        out_impl, _ = stage_impl.forward(hidden_states_bf16, kwargs_impl)
-        Assert.rms_close_relative(out_impl, out_ref_bf16, 5e-3, 1e-7)
-
     if _flash_available and config.head_size <= 256:
-        _check_packed("flash")
-    _check_packed("sdpa")
+        _check_packed("flash", distributed_config_bf16, distributed_bf16, hidden_states_bf16, out_ref_bf16, 5e-3)
+    _check_packed("sdpa_nested", distributed_config_bf16, distributed_bf16, hidden_states_bf16, out_ref_bf16, 5e-3)
 
 
 @pytest.mark.slow

--- a/tests/layers/test_attention.py
+++ b/tests/layers/test_attention.py
@@ -386,6 +386,7 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
         distributed_check: Distributed,
         hidden_states_check: torch.Tensor,
         out_ref_check: torch.Tensor,
+        grads_ref_check: list[torch.Tensor],
         rtol: float,
     ) -> None:
         attention_impl: Attention = config.get_attention_config(implementation).get_layer(
@@ -405,16 +406,19 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
         )
         kwargs_impl = model_input.to_kwargs()
         attention_impl.preprocess(kwargs_impl)
-        out_impl, _ = stage_impl.forward(hidden_states_check, kwargs_impl)
+        out_impl, context = stage_impl.forward(hidden_states_check, kwargs_impl)
+        stage_impl.backward(torch.ones_like(out_impl), context)
         Assert.rms_close_relative(out_impl, out_ref_check, rtol, 1e-7)
+        for param_impl, grad_ref in zip(attention_impl.parameters(), grads_ref_check, strict=True):
+            Assert.rms_close_relative(param_impl.grad_buffer, grad_ref, rtol, 1e-7, msg=implementation)
 
     # SDPA-dense equivalence check: sdpa_dense reuses backup's mask, so its packed fp32 output
-    # must match the per-sequence backup reference. This is the only SDPA branch that runs on CPU
-    # (sdpa_nested needs CUDA), so the check is unconditional rather than CUDA-gated.
-    _check_packed("sdpa_dense", distributed_config, distributed, hidden_states.detach(), out_ref, 1e-5)
+    # and parameter gradients must match the per-sequence backup reference. This is the only SDPA
+    # branch that runs on CPU (sdpa_nested needs CUDA), so the check is unconditional.
+    _check_packed("sdpa_dense", distributed_config, distributed, hidden_states, out_ref, grads_ref, 1e-5)
 
-    # Flash and SDPA-nested equivalence checks: each implementation's packed bfloat16 output must
-    # match a per-sequence bfloat16 backup reference.
+    # Flash and SDPA-nested equivalence checks: each implementation's packed bfloat16 output and
+    # parameter gradients must match a per-sequence bfloat16 backup reference.
     if not torch.cuda.is_available():
         return
 
@@ -430,18 +434,23 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
 
     hidden_states_bf16 = hidden_states.detach().to(torch.bfloat16)
     out_ref_bf16 = _run_per_seq_reference(
-        attention_backup_bf16,
-        stage_backup_bf16,
-        distributed_config_bf16,
-        hidden_states_bf16,
-        lengths,
-        device,
-        with_backward=False,
+        attention_backup_bf16, stage_backup_bf16, distributed_config_bf16, hidden_states_bf16, lengths, device
     )
+    grads_ref_bf16 = [param.grad_buffer.clone() for param in attention_backup_bf16.parameters()]
 
     if _flash_available and config.head_size <= 256:
-        _check_packed("flash", distributed_config_bf16, distributed_bf16, hidden_states_bf16, out_ref_bf16, 5e-3)
-    _check_packed("sdpa_nested", distributed_config_bf16, distributed_bf16, hidden_states_bf16, out_ref_bf16, 5e-3)
+        _check_packed(
+            "flash", distributed_config_bf16, distributed_bf16, hidden_states_bf16, out_ref_bf16, grads_ref_bf16, 5e-3
+        )
+    _check_packed(
+        "sdpa_nested",
+        distributed_config_bf16,
+        distributed_bf16,
+        hidden_states_bf16,
+        out_ref_bf16,
+        grads_ref_bf16,
+        5e-3,
+    )
 
 
 @pytest.mark.slow

--- a/tests/layers/test_attention.py
+++ b/tests/layers/test_attention.py
@@ -429,8 +429,7 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
 
     if _flash_available and config.head_size <= 256:
         _check_packed("flash")
-    if config.window_size is None:
-        _check_packed("sdpa")
+    _check_packed("sdpa")
 
 
 @pytest.mark.slow

--- a/tests/layers/test_attention.py
+++ b/tests/layers/test_attention.py
@@ -387,7 +387,8 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
         hidden_states_check: torch.Tensor,
         out_ref_check: torch.Tensor,
         grads_ref_check: list[torch.Tensor],
-        rtol: float,
+        out_rtol: float,
+        grad_rtol: float,
     ) -> None:
         attention_impl: Attention = config.get_attention_config(implementation).get_layer(
             distributed_config_check, hidden_dim, lr_scale=None, peft=None, return_bias=False
@@ -408,17 +409,19 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
         attention_impl.preprocess(kwargs_impl)
         out_impl, context = stage_impl.forward(hidden_states_check, kwargs_impl)
         stage_impl.backward(torch.ones_like(out_impl), context)
-        Assert.rms_close_relative(out_impl, out_ref_check, rtol, 1e-7)
+        Assert.rms_close_relative(out_impl, out_ref_check, out_rtol, 1e-7)
         for param_impl, grad_ref in zip(attention_impl.parameters(), grads_ref_check, strict=True):
-            Assert.rms_close_relative(param_impl.grad_buffer, grad_ref, rtol, 1e-7, msg=implementation)
+            Assert.rms_close_relative(param_impl.grad_buffer, grad_ref, grad_rtol, 1e-7, msg=implementation)
 
     # SDPA-dense equivalence check: sdpa_dense reuses backup's mask, so its packed fp32 output
     # and parameter gradients must match the per-sequence backup reference. This is the only SDPA
     # branch that runs on CPU (sdpa_nested needs CUDA), so the check is unconditional.
-    _check_packed("sdpa_dense", distributed_config, distributed, hidden_states, out_ref, grads_ref, 1e-5)
+    _check_packed("sdpa_dense", distributed_config, distributed, hidden_states, out_ref, grads_ref, 1e-5, 1e-5)
 
-    # Flash and SDPA-nested equivalence checks: each implementation's packed bfloat16 output and
-    # parameter gradients must match a per-sequence bfloat16 backup reference.
+    # Flash and SDPA equivalence checks: each implementation's packed bfloat16 output and parameter
+    # gradients must match a per-sequence bfloat16 backup reference. Backward grad tolerance is
+    # looser than forward — bf16 reduction-order noise compounds through the backward pass, and
+    # the same-kernel sdpa_dense path itself diverges from per-seq backup by ~7e-3 at bf16.
     if not torch.cuda.is_available():
         return
 
@@ -432,25 +435,44 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
     for param_bf16, param_f32 in zip(attention_backup_bf16.parameters(), attention.parameters(), strict=True):
         param_bf16.data.copy_(param_f32.data)
 
-    hidden_states_bf16 = hidden_states.detach().to(torch.bfloat16)
+    hidden_states_bf16 = hidden_states.detach().to(torch.bfloat16).requires_grad_()
     out_ref_bf16 = _run_per_seq_reference(
         attention_backup_bf16, stage_backup_bf16, distributed_config_bf16, hidden_states_bf16, lengths, device
     )
     grads_ref_bf16 = [param.grad_buffer.clone() for param in attention_backup_bf16.parameters()]
 
-    if _flash_available and config.head_size <= 256:
-        _check_packed(
-            "flash", distributed_config_bf16, distributed_bf16, hidden_states_bf16, out_ref_bf16, grads_ref_bf16, 5e-3
-        )
     _check_packed(
-        "sdpa_nested",
+        "sdpa_dense",
         distributed_config_bf16,
         distributed_bf16,
         hidden_states_bf16,
         out_ref_bf16,
         grads_ref_bf16,
         5e-3,
+        1.5e-2,
     )
+    if _flash_available and config.head_size <= 256:
+        _check_packed(
+            "flash",
+            distributed_config_bf16,
+            distributed_bf16,
+            hidden_states_bf16,
+            out_ref_bf16,
+            grads_ref_bf16,
+            5e-3,
+            1.5e-2,
+        )
+    if config.window_size is None:
+        _check_packed(
+            "sdpa_nested",
+            distributed_config_bf16,
+            distributed_bf16,
+            hidden_states_bf16,
+            out_ref_bf16,
+            grads_ref_bf16,
+            5e-3,
+            1.5e-2,
+        )
 
 
 @pytest.mark.slow

--- a/tests/layers/test_attention.py
+++ b/tests/layers/test_attention.py
@@ -264,8 +264,8 @@ for base_name, base_kwargs, variants, length_set in (
 
 # head_size > 256 — exercises the SDPA-only regime (flash caps at 256).
 for name, kwargs in (
-    ("large_head_causal", {"causal": True, "head_size": 320}),
-    ("large_head_mqa", {"causal": True, "head_size": 320, "kv_heads": 1}),
+    ("large_head_causal_no_norm", {"causal": True, "head_size": 320}),
+    ("large_head_mqa_no_norm", {"causal": True, "head_size": 320, "kv_heads": 1}),
 ):
     for lengths in _LENGTHS_SHORT:
         _attention_test_cases.append((AttentionTestConfig(name=name, **kwargs), lengths))
@@ -278,7 +278,6 @@ def _run_per_seq_reference(
     hidden_states: torch.Tensor,
     lengths: list[int],
     device: torch.device,
-    with_backward: bool = True,
 ) -> torch.Tensor:
     out_refs = []
     for length, hidden_slice in zip(lengths, torch.split(hidden_states, lengths, dim=0), strict=True):
@@ -294,8 +293,7 @@ def _run_per_seq_reference(
         kwargs = model_input.to_kwargs()
         attention.preprocess(kwargs)
         out, context = stage.forward(hidden_slice, kwargs)
-        if with_backward:
-            stage.backward(torch.ones_like(out), context)
+        stage.backward(torch.ones_like(out), context)
         out_refs.append(out.detach())
     return torch.cat(out_refs, dim=0)
 
@@ -420,8 +418,8 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
 
     # Flash and SDPA equivalence checks: each implementation's packed bfloat16 output and parameter
     # gradients must match a per-sequence bfloat16 backup reference. Backward grad tolerance is
-    # looser than forward — bf16 reduction-order noise compounds through the backward pass, and
-    # the same-kernel sdpa_dense path itself diverges from per-seq backup by ~7e-3 at bf16.
+    # looser than forward — bf16 reduction-order noise compounds through the backward pass, with
+    # even the sdpa_dense path diverging from the per-seq backup reference by ~7e-3 at bf16.
     if not torch.cuda.is_available():
         return
 

--- a/tests/layers/test_attention.py
+++ b/tests/layers/test_attention.py
@@ -271,6 +271,44 @@ for name, kwargs in (
         _attention_test_cases.append((AttentionTestConfig(name=name, **kwargs), lengths))
 
 
+def _check_packed(
+    implementation: str,
+    config: AttentionTestConfig,
+    hidden_dim: TensorDim,
+    lengths: list[int],
+    attention_f32: Attention,
+    distributed_config: DistributedConfig,
+    distributed: Distributed,
+    hidden_states: torch.Tensor,
+    out_ref: torch.Tensor,
+    grads_ref: list[torch.Tensor],
+    out_rtol: float,
+    grad_rtol: float,
+) -> None:
+    attention_impl: Attention = config.get_attention_config(implementation).get_layer(
+        distributed_config, hidden_dim, lr_scale=None, peft=None, return_bias=False
+    )
+    stage_impl = get_stage([attention_impl], distributed)
+    for param_impl, param_f32 in zip(attention_impl.parameters(), attention_f32.parameters(), strict=True):
+        param_impl.data.copy_(param_f32.data)
+    (model_input,) = LanguageModelBatch(
+        tokens=torch.empty(sum(lengths), dtype=torch.int64, device=hidden_states.device), lengths=lengths
+    ).get_model_inputs(
+        LanguageModelBatchPreprocessingConfig(
+            distributed=distributed_config,
+            predicted_tokens=0,
+            **attention_impl.get_preprocessing_config(),
+        )
+    )
+    kwargs_impl = model_input.to_kwargs()
+    attention_impl.preprocess(kwargs_impl)
+    out_impl, context = stage_impl.forward(hidden_states, kwargs_impl)
+    stage_impl.backward(torch.ones_like(out_impl), context)
+    Assert.rms_close_relative(out_impl, out_ref, out_rtol, 1e-7)
+    for param_impl, grad_ref in zip(attention_impl.parameters(), grads_ref, strict=True):
+        Assert.rms_close_relative(param_impl.grad_buffer, grad_ref, grad_rtol, 1e-7, msg=implementation)
+
+
 def _run_per_seq_reference(
     attention: Attention,
     stage,
@@ -378,48 +416,21 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
         Assert.rms_close_relative(param.grad_buffer, grad_ref, 1e-5, 1e-7, msg=name)
     stage.reset_gradients()
 
-    def _check_packed(
-        implementation: str,
-        distributed_config_check: DistributedConfig,
-        distributed_check: Distributed,
-        hidden_states_check: torch.Tensor,
-        out_ref_check: torch.Tensor,
-        grads_ref_check: list[torch.Tensor],
-        out_rtol: float,
-        grad_rtol: float,
-    ) -> None:
-        attention_impl: Attention = config.get_attention_config(implementation).get_layer(
-            distributed_config_check, hidden_dim, lr_scale=None, peft=None, return_bias=False
-        )
-        stage_impl = get_stage([attention_impl], distributed_check)
-        for param_impl, param_f32 in zip(attention_impl.parameters(), attention.parameters(), strict=True):
-            param_impl.data.copy_(param_f32.data)
-        (model_input,) = LanguageModelBatch(
-            tokens=torch.empty(num_tokens, dtype=torch.int64, device=device), lengths=lengths
-        ).get_model_inputs(
-            LanguageModelBatchPreprocessingConfig(
-                distributed=distributed_config_check,
-                predicted_tokens=0,
-                **attention_impl.get_preprocessing_config(),
-            )
-        )
-        kwargs_impl = model_input.to_kwargs()
-        attention_impl.preprocess(kwargs_impl)
-        out_impl, context = stage_impl.forward(hidden_states_check, kwargs_impl)
-        stage_impl.backward(torch.ones_like(out_impl), context)
-        Assert.rms_close_relative(out_impl, out_ref_check, out_rtol, 1e-7)
-        for param_impl, grad_ref in zip(attention_impl.parameters(), grads_ref_check, strict=True):
-            Assert.rms_close_relative(param_impl.grad_buffer, grad_ref, grad_rtol, 1e-7, msg=implementation)
+    _check_packed(
+        "sdpa_dense",
+        config,
+        hidden_dim,
+        lengths,
+        attention,
+        distributed_config,
+        distributed,
+        hidden_states,
+        out_ref,
+        grads_ref,
+        1e-5,
+        1e-5,
+    )
 
-    # SDPA-dense equivalence check: sdpa_dense reuses backup's mask, so its packed fp32 output
-    # and parameter gradients must match the per-sequence backup reference. This is the only SDPA
-    # branch that runs on CPU (sdpa_nested needs CUDA), so the check is unconditional.
-    _check_packed("sdpa_dense", distributed_config, distributed, hidden_states, out_ref, grads_ref, 1e-5, 1e-5)
-
-    # Flash and SDPA equivalence checks: each implementation's packed bfloat16 output and parameter
-    # gradients must match a per-sequence bfloat16 backup reference. Backward grad tolerance is
-    # looser than forward — bf16 reduction-order noise compounds through the backward pass, with
-    # even the sdpa_dense path diverging from the per-seq backup reference by ~7e-3 at bf16.
     if not torch.cuda.is_available():
         return
 
@@ -439,30 +450,18 @@ def _test_attention(config: AttentionTestConfig, lengths: list[int]) -> None:
     )
     grads_ref_bf16 = [param.grad_buffer.clone() for param in attention_backup_bf16.parameters()]
 
-    _check_packed(
-        "sdpa_dense",
-        distributed_config_bf16,
-        distributed_bf16,
-        hidden_states_bf16,
-        out_ref_bf16,
-        grads_ref_bf16,
-        5e-3,
-        1.5e-2,
-    )
-    if _flash_available and config.head_size <= 256:
+    # bf16 grad rtol is looser than forward: reduction-order noise compounds through backward.
+    for implementation in ("sdpa_dense", "flash", "sdpa_nested"):
+        if implementation == "flash" and (not _flash_available or config.head_size > 256):
+            continue
+        if implementation == "sdpa_nested" and config.window_size is not None:
+            continue
         _check_packed(
-            "flash",
-            distributed_config_bf16,
-            distributed_bf16,
-            hidden_states_bf16,
-            out_ref_bf16,
-            grads_ref_bf16,
-            5e-3,
-            1.5e-2,
-        )
-    if config.window_size is None:
-        _check_packed(
-            "sdpa_nested",
+            implementation,
+            config,
+            hidden_dim,
+            lengths,
+            attention,
             distributed_config_bf16,
             distributed_bf16,
             hidden_states_bf16,


### PR DESCRIPTION
## Summary

Flash-attn caps at `head_size = 256`, so `head_size = 512` models (Gemma 4 full-attention) hit the `backup` path and OOM above ~8K context. Add `AttentionImplementation.sdpa` with two CUDA-aware paths:

- **Nested** (CUDA, no window, no straddle): `torch.nested.nested_tensor_from_jagged` + `is_causal=True` on EFFICIENT. Cross-doc masking is structural (each doc = its own batch element), no O(S²) materialization. Pre-computed `min/max_seqlen` keep dispatch sync-free.
- **Dense** (CPU, sliding window, *or* cross-microseq straddle): `(1, H, total, D)` + explicit `attn_mask` reusing backup's preprocessed causal+document mask. MATH rejects nested+`is_causal`; nested can't express sliding window; and PyTorch's nested `is_causal=True` applies TOP-LEFT alignment, which silently corrupts the straddling doc (`seq_q < seq_k` needs BOTTOM-RIGHT). `Attention.preprocess` detects `first_document_begin < sequence_k_past` and materializes the dense mask; `_attn_sdpa` dispatches on `attention_mask` presence.

K/V are manually `repeat_interleave`d across query heads because SDPA's fused kernels reject broadcasted GQA. Auto-fallback: `flash` for `bf16/fp16` + `head_size ≤ 256`, else `sdpa`; `backup` no longer auto-selected.

Preprocessor side: `max_lengths` is a Python `int` (flash accepts; sails through `Document.to_device_` since it's not a `Tensor`), `min_lengths` added symmetrically, `first_document_begin` plumbed as `AttentionKwargs` int so dispatch is CPU-side (no per-step GPU→CPU sync to inspect `cu_seqlens_k[0]`).

## Benchmark — H100 bf16, Llama-7B / Gemma-4 shapes

Multi-doc varlen at 16K, 4×4K docs (the typical training case): nested 18.6 ms / 88 ms vs dense-mask 50 / 616 ms — 2.6×–7× win from structural masking. Backup OOMs above ~8K at these widths. Single-doc at 16K: ~17% nested overhead vs dense, acceptable to keep one code path. Nested SDPA call is sync-free (was 5 host barriers without pre-computed seqlens — would have killed host-GPU overlap in training).

## Test plan

- [x] Local `pytest -v -n 4 tests/layers/test_attention.py` (CPU): 56 passed
- [x] Cluster `pytest -v -n 8 tests/layers/test_attention.py` (CUDA): 56 passed
- [x] Cluster `pytest -v -n 8 --models gpt_2 tests/models/test_model.py`: resolves `gpt_2-{ms4,sdp2,sdp2_stp2,sdp2_stp2_bf4}` (4 of 5 prior straddle failures). `gpt_2-stp2_pp2s1_bf4` still failing — unrelated cause, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)