### PR TITLE
Per-loss logits_scale_factor

### DIFF
--- a/fast_llm/layers/language_model/loss/config.py
+++ b/fast_llm/layers/language_model/loss/config.py
@@ -41,6 +41,15 @@ class LanguageModelLossConfig(Config):
         desc="Weight for this loss in the total loss computation.",
         valid=check_field(Assert.geq, 0.0),
     )
+    logits_scale_factor: float = Field(
+        default=1.0,
+        hint=FieldHint.feature,
+        desc=(
+            "Extra logits scale factor applied for this loss only, stacked on top of the model's"
+            " `logits_scale_factor`."
+        ),
+        valid=check_field(Assert.gt, 0.0),
+    )
 
     def get_layer(
         self,

--- a/fast_llm/layers/language_model/loss/loss.py
+++ b/fast_llm/layers/language_model/loss/loss.py
@@ -33,7 +33,7 @@ class LanguageModelLoss[ConfigType: LanguageModelLossConfig](Configurable[Config
         self._prediction_heads = prediction_heads
         self._name = name
         self._num_splits = num_splits
-        self._logits_scale_factor = logits_scale_factor
+        self._logits_scale_factor = logits_scale_factor * self._config.logits_scale_factor
         self._weight = weight * self._config.weight
         self._do_register_loss = register_loss
         self._vocab_parallel = distributed_config.tensor_parallel > 1 and vocab_parallel


### PR DESCRIPTION
## Summary

Add a `logits_scale_factor` field to `LanguageModelLossConfig`, applied on top of the head's `logits_scale_factor` for that loss only. Every loss subclass picks it up automatically via `self._logits_scale_factor` — no per-subclass changes.

Primary use case: in RL losses, set to `1 / actor_temperature` so new log-probabilities are computed at the same scale as the actor's stored old log-probabilities (importance ratio at step 0 is no longer offset by the actor's sampling temperature).

Reimplemented from PR #502's `temperature` field on the GRPO config: the field is moved to the base config (so all losses can opt in), renamed to match the existing head field, and given multiplier semantics (extra scale, default `1.0`, stacked on top of the head's scale).

## Test plan

- [ ] Existing loss tests still pass at default `logits_scale_factor=1.0`.
- [ ] Manual: setting `logits_scale_factor=2.0` on a GRPO loss config produces softmax outputs equivalent to doubling the head's `logits_scale_factor`.