### PR TITLE
Add GSPO loss

### DIFF
--- a/fast_llm/data/document/block.py
+++ b/fast_llm/data/document/block.py
@@ -9,6 +9,7 @@ from fast_llm.data.document.config import LengthPreprocessingConfig
 from fast_llm.engine.config_utils.tensor_dim import TensorDim
 from fast_llm.engine.distributed.config import DistributedDimNames
 from fast_llm.layers.attention.config import AttentionKwargs
+from fast_llm.layers.block.config import BlockKwargs
 from fast_llm.layers.language_model.config import LanguageModelKwargs
 from fast_llm.utils import Assert, padded_cumsum
 
@@ -30,6 +31,8 @@ class BlockModelInput(ModelInput):
     min_length_k: int | None = None
     document_index_q: torch.Tensor | None = None
     document_index_k: torch.Tensor | None = None
+    global_document_index_q: torch.Tensor | None = None
+    num_documents_in_sequence: int | None = None
     position_index: torch.Tensor | None = None
     first_document_begin: int = 0
 
@@ -51,6 +54,8 @@ class BlockModelInput(ModelInput):
             AttentionKwargs.min_seqlen_k: self.min_length_k,
             AttentionKwargs.document_index_q: self.document_index_q,
             AttentionKwargs.document_index_k: self.document_index_k,
+            BlockKwargs.global_document_index_q: self.global_document_index_q,
+            BlockKwargs.num_documents_in_sequence: self.num_documents_in_sequence,
             LanguageModelKwargs.position_ids: self.position_index,
             AttentionKwargs.first_document_begin: self.first_document_begin,
         }

--- a/fast_llm/data/document/language_model.py
+++ b/fast_llm/data/document/language_model.py
@@ -139,7 +139,12 @@ class LanguageModelBatch(TokenBatch):
                 input_length,
             )
         ):
-            model_input = self._get_model_input(sequence_k_past, sequence_k_past + local_input_length, config)
+            model_input = self._get_model_input(
+                sequence_k_past,
+                sequence_k_past + local_input_length,
+                config,
+                is_first_for_rank=micro_sequence_index == 0,
+            )
             model_input.phase = config.phase
 
             if config.use_image_patches:

--- a/fast_llm/data/document/token.py
+++ b/fast_llm/data/document/token.py
@@ -10,7 +10,7 @@ from fast_llm.data.document.config import TokenPreprocessingConfig
 from fast_llm.engine.distributed.distributed import Distributed
 from fast_llm.layers.language_model.config import LanguageModelKwargs
 from fast_llm.tensor import TensorMeta
-from fast_llm.utils import Assert
+from fast_llm.utils import Assert, padded_cumsum
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -98,14 +98,35 @@ class TokenBatch(Batch, TokenDocument):
 
         return lengths, first_document_begin, document_end
 
-    def _get_model_input(self, begin: int, end: int, config: TokenPreprocessingConfig):
+    def _get_model_input(self, begin: int, end: int, config: TokenPreprocessingConfig, *, is_first_for_rank: bool):
         model_input = self._model_input_class(tokens=self.tokens[begin:end])
         lengths, first_document_begin, last_document_end = self._get_cropped_lengths(begin, end)
 
         if config.return_document_count:
+            # Set the global whole-batch count on every rank's first microbatch; `share_batch_data`
+            # will sum across DP via `batch_data_group`. (`begin == 0` would only set it on the
+            # SDP rank-0 first microbatch, leaving other SDP ranks with 0 after the DP-only sum.)
             # Exclude the padding "length" from the document count.
             model_input.num_documents = (
-                len(self.lengths) - (1 if self.unpadded_length < len(self.tokens) else 0) if begin == 0 else 0
+                len(self.lengths) - (1 if self.unpadded_length < len(self.tokens) else 0) if is_first_for_rank else 0
+            )
+
+        if config.return_document_index:
+            # Globally-consistent 1-based document index per token, computed from the unsliced
+            # batch's cumulative lengths. Same convention as `LengthModelInputPreprocessor.document_index`
+            # but the IDs match across SDP/SP ranks so GSPO's per-segment all-reduce is well-defined.
+            global_cumulative_lengths = torch.from_numpy(padded_cumsum(self.lengths)).to(
+                dtype=torch.int32, device=self.device
+            )
+            model_input.global_document_index_q = torch.searchsorted(
+                global_cumulative_lengths,
+                torch.arange(begin, end, device=self.device),
+                side="right",
+                out_int32=True,
+            )
+            # Exclude the padding "length" from the count.
+            model_input.num_documents_in_sequence = len(self.lengths) - (
+                1 if self.unpadded_length < len(self.tokens) else 0
             )
 
         LengthModelInputPreprocessor(

--- a/fast_llm/layers/attention/config.py
+++ b/fast_llm/layers/attention/config.py
@@ -21,8 +21,6 @@ class MixerKwargs(BlockKwargs):
     cu_seqlens_k = "cu_seqlens_k"
     max_seqlen_q = "max_seqlen_q"
     max_seqlen_k = "max_seqlen_k"
-    document_index_q = "document_index_q"
-    document_index_k = "document_index_k"
     position_ids = "position_ids"
 
 

--- a/fast_llm/layers/block/config.py
+++ b/fast_llm/layers/block/config.py
@@ -40,6 +40,8 @@ class BlockKwargs:
     # TODO: These are confusing
     sequence_length = "sequence_length"
     lengths = "lengths"
+    document_index_q = "document_index_q"
+    document_index_k = "document_index_k"
     # TODO: Belongs elsewhere?
     grad_output = "grad_output"
     activation_distillation_targets = "activation_distillation_targets"

--- a/fast_llm/layers/block/config.py
+++ b/fast_llm/layers/block/config.py
@@ -42,6 +42,12 @@ class BlockKwargs:
     lengths = "lengths"
     document_index_q = "document_index_q"
     document_index_k = "document_index_k"
+    # Global counterpart of `document_index_q` (1-based, consistent across SDP/SP ranks).
+    # GSPO consumes this so per-segment buffers can be all-reduced across ranks.
+    global_document_index_q = "global_document_index_q"
+    # Number of documents in this DP rank's batch (same on all SDP/SP ranks within a DP rank).
+    # Distinct from `num_documents_in_batch`, which is the global count summed across DP.
+    num_documents_in_sequence = "num_documents_in_sequence"
     # TODO: Belongs elsewhere?
     grad_output = "grad_output"
     activation_distillation_targets = "activation_distillation_targets"

--- a/fast_llm/layers/language_model/loss/config.py
+++ b/fast_llm/layers/language_model/loss/config.py
@@ -9,15 +9,17 @@ from fast_llm.layers.block.config import BlockKwargs
 from fast_llm.utils import Assert
 
 if typing.TYPE_CHECKING:
-    pass
-
     from fast_llm.layers.language_model.loss.dpo import LanguageModelDPOLoss
     from fast_llm.layers.language_model.loss.entropy_loss import (
         LanguageModelDistillationLoss,
         LanguageModelLabelEntropyLoss,
     )
-    from fast_llm.layers.language_model.loss.grpo import LanguageModelGRPOLoss
     from fast_llm.layers.language_model.loss.loss import LanguageModelLoss
+    from fast_llm.layers.language_model.loss.policy_gradient import (
+        LanguageModelGRPOLoss,
+        LanguageModelGSPOLoss,
+        LanguageModelPolicyGradientLoss,
+    )
     from fast_llm.layers.language_model.loss.z_loss import LanguageModelZLoss
 
 
@@ -209,13 +211,26 @@ class GRPOMetricsLevel(enum.StrEnum):
     with_entropy = "with_entropy"
 
 
-@config_class(dynamic_type={LanguageModelLossConfig: "grpo"})
-class LanguageModelGRPOLossConfig(LanguageModelLossConfig):
+@config_class()
+class LanguageModelPolicyGradientLossConfig(LanguageModelLossConfig):
+    """Shared base for policy-gradient losses (GRPO, GSPO)."""
 
-    _abstract: typing.ClassVar[bool] = False
+    _abstract: typing.ClassVar[bool] = True
 
     epsilon_low: float = Field(default=0.2, desc="Lower clip parameter for ratio of log probs")
     epsilon_high: float = Field(default=0.2, desc="Upper clip parameter for ratio of log probs")
+
+    @property
+    def loss_class(self) -> "type[LanguageModelPolicyGradientLoss]":
+        raise NotImplementedError()
+
+
+@config_class(dynamic_type={LanguageModelLossConfig: "grpo"})
+class LanguageModelGRPOLossConfig(LanguageModelPolicyGradientLossConfig):
+    """Group-Relative Policy Optimization: per-token IS-ratio clipping."""
+
+    _abstract: typing.ClassVar[bool] = False
+
     use_triton: bool | None = Field(
         default=None,
         desc="Enable triton implementation. Default: use if available.",
@@ -234,6 +249,19 @@ class LanguageModelGRPOLossConfig(LanguageModelLossConfig):
 
     @property
     def loss_class(self) -> "type[LanguageModelGRPOLoss]":
-        from fast_llm.layers.language_model.loss.grpo import LanguageModelGRPOLoss
+        from fast_llm.layers.language_model.loss.policy_gradient import LanguageModelGRPOLoss
 
         return LanguageModelGRPOLoss
+
+
+@config_class(dynamic_type={LanguageModelLossConfig: "gspo"})
+class LanguageModelGSPOLossConfig(LanguageModelPolicyGradientLossConfig):
+    """Group Sequence Policy Optimization: sequence-level geometric-mean IS-ratio clipping."""
+
+    _abstract: typing.ClassVar[bool] = False
+
+    @property
+    def loss_class(self) -> "type[LanguageModelGSPOLoss]":
+        from fast_llm.layers.language_model.loss.policy_gradient import LanguageModelGSPOLoss
+
+        return LanguageModelGSPOLoss

--- a/fast_llm/layers/language_model/loss/loss.py
+++ b/fast_llm/layers/language_model/loss/loss.py
@@ -39,6 +39,8 @@ class LanguageModelLoss[ConfigType: LanguageModelLossConfig](Configurable[Config
         self._vocab_parallel = distributed_config.tensor_parallel > 1 and vocab_parallel
         self._sequence_parallel = distributed_config.sequence_tensor_parallel and not self._vocab_parallel
         self._parallel_dim = distributed_config.get_distributed_dim(DistributedDimNames.tensor)
+        self._sdp_dim = distributed_config.get_distributed_dim(DistributedDimNames.sequence_data)
+        self._sdp_active = self._sdp_dim.size > 1
 
     def forward_backward(
         self,

--- a/fast_llm/layers/language_model/loss/loss.py
+++ b/fast_llm/layers/language_model/loss/loss.py
@@ -39,8 +39,8 @@ class LanguageModelLoss[ConfigType: LanguageModelLossConfig](Configurable[Config
         self._vocab_parallel = distributed_config.tensor_parallel > 1 and vocab_parallel
         self._sequence_parallel = distributed_config.sequence_tensor_parallel and not self._vocab_parallel
         self._parallel_dim = distributed_config.get_distributed_dim(DistributedDimNames.tensor)
-        self._sdp_dim = distributed_config.get_distributed_dim(DistributedDimNames.sequence_data)
-        self._sdp_active = self._sdp_dim.size > 1
+        self._sequence_data_dim = distributed_config.get_distributed_dim(DistributedDimNames.sequence_data)
+        self._sequence_data_active = self._sequence_data_dim.size > 1
 
     def forward_backward(
         self,

--- a/fast_llm/layers/language_model/loss/policy_gradient.py
+++ b/fast_llm/layers/language_model/loss/policy_gradient.py
@@ -494,8 +494,10 @@ def fused_gspo_loss_forward_backward(
     mean_log_ratio_per_segment = log_ratio.new_zeros(num_segments).index_add_(
         0, flat_document_index, log_ratio.reshape(-1) * token_weight
     )
-    mean_advantage_per_segment = advantages.new_zeros(num_segments).index_add_(
-        0, flat_document_index, (advantages.reshape(-1) * token_weight).to(advantages.dtype)
+    # Accumulate in `log_ratio.dtype` (fp32). Casting the product back to `advantages.dtype`
+    # before summing would round each token's contribution to a possibly-low input dtype.
+    mean_advantage_per_segment = log_ratio.new_zeros(num_segments).index_add_(
+        0, flat_document_index, advantages.reshape(-1).to(log_ratio.dtype) * token_weight
     )
     for reduce_group in (sdp_group, sp_group):
         if reduce_group is not None:

--- a/fast_llm/layers/language_model/loss/policy_gradient.py
+++ b/fast_llm/layers/language_model/loss/policy_gradient.py
@@ -9,11 +9,14 @@ from fast_llm.engine.distributed.config import DistributedConfig
 from fast_llm.functional.config import TritonConfig
 from fast_llm.functional.entropy_loss import fused_predicted_logits_from_labels, fused_softmax_base
 from fast_llm.functional.utils import reduce_losses
+from fast_llm.layers.block.config import BlockKwargs
 from fast_llm.layers.language_model.config import LanguageModelKwargs
 from fast_llm.layers.language_model.loss.config import (
     GRPOMetricsLevel,
     LanguageModelGRPOLossConfig,
+    LanguageModelGSPOLossConfig,
     LanguageModelLossKwargs,
+    LanguageModelPolicyGradientLossConfig,
 )
 from fast_llm.layers.language_model.loss.loss import LanguageModelLoss
 from fast_llm.utils import Assert
@@ -33,7 +36,42 @@ class GRPOMetrics(typing.NamedTuple):
     entropy: torch.Tensor | None
 
 
-class LanguageModelGRPOLoss[ConfigType: LanguageModelGRPOLossConfig](LanguageModelLoss[ConfigType]):
+class LanguageModelPolicyGradientLoss[ConfigType: LanguageModelPolicyGradientLossConfig](
+    LanguageModelLoss[ConfigType]
+):
+    """Shared scaffolding for policy-gradient losses (GRPO, GSPO).
+
+    Subclasses implement `_forward_backward` to call their specific kernel.
+    """
+
+    def _register_new_logprobs(
+        self,
+        new_logprobs_mean: torch.Tensor | None,
+        kwargs: dict[str, typing.Any],
+        losses: dict | None,
+    ) -> None:
+        if new_logprobs_mean is not None:
+            new_logprobs_mean = new_logprobs_mean / kwargs[LanguageModelKwargs.num_documents_in_batch]
+        self._register_loss(
+            self._logprob_metric_name, new_logprobs_mean, losses, reduce_op=torch.distributed.ReduceOp.SUM
+        )
+
+    def get_loss_definitions(self) -> list[LossDef]:
+        defs = super().get_loss_definitions()
+        defs.append(LossDef(self._logprob_metric_name))
+        return defs
+
+    def get_preprocessing_config(self) -> dict[str, typing.Any]:
+        return {"use_grpo_data": True, "return_label_counts": True, "return_document_count": True}
+
+    @functools.cached_property
+    def _logprob_metric_name(self) -> str:
+        return f"{self._name}_new_logprobs"
+
+
+class LanguageModelGRPOLoss[ConfigType: LanguageModelGRPOLossConfig](LanguageModelPolicyGradientLoss[ConfigType]):
+    """GRPO: per-token IS-ratio clipping."""
+
     def __init__(
         self,
         config: ConfigType,
@@ -99,11 +137,7 @@ class LanguageModelGRPOLoss[ConfigType: LanguageModelGRPOLossConfig](LanguageMod
             divisor=self._get_label_count(kwargs),
         )
 
-        if new_logprobs_mean is not None:
-            new_logprobs_mean = new_logprobs_mean / kwargs[LanguageModelKwargs.num_documents_in_batch]
-        self._register_loss(
-            self._logprob_metric_name, new_logprobs_mean, losses, reduce_op=torch.distributed.ReduceOp.SUM
-        )
+        self._register_new_logprobs(new_logprobs_mean, kwargs, losses)
 
         # Skip the extra softmax pass when there is nothing to register.
         if losses is not None and self._config.metrics != GRPOMetricsLevel.none:
@@ -167,7 +201,6 @@ class LanguageModelGRPOLoss[ConfigType: LanguageModelGRPOLossConfig](LanguageMod
 
     def get_loss_definitions(self) -> list[LossDef]:
         defs = super().get_loss_definitions()
-        defs.append(LossDef(self._logprob_metric_name))
         if self._config.metrics != GRPOMetricsLevel.none:
             defs.extend(
                 [
@@ -187,14 +220,59 @@ class LanguageModelGRPOLoss[ConfigType: LanguageModelGRPOLossConfig](LanguageMod
                 defs.append(LossDef(f"{self._name}_entropy"))
         return defs
 
-    def get_preprocessing_config(
-        self,
-    ) -> dict[str, typing.Any]:
-        return {"use_grpo_data": True, "return_label_counts": True, "return_document_count": True}
 
-    @functools.cached_property
-    def _logprob_metric_name(self) -> str:
-        return f"{self._name}_new_logprobs"
+class LanguageModelGSPOLoss[ConfigType: LanguageModelGSPOLossConfig](LanguageModelPolicyGradientLoss[ConfigType]):
+    """GSPO: sequence-level geometric-mean IS-ratio clipping."""
+
+    def _forward_backward(
+        self,
+        logits: "torch.Tensor",
+        kwargs: dict[str, typing.Any],
+        losses: dict | None = None,
+        split_index: int = 0,
+        grad_logits: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        document_index = self._prepare_target(
+            kwargs[BlockKwargs.document_index_q], split_index, split_by_distance=False
+        )
+        # `document_index_q` is 1-based per the data preprocessor convention; shift to 0-based.
+        document_index = document_index.long() - 1
+        # Buffer size must agree across SDP ranks (sharing the sequence) for the per-segment
+        # all-reduce inside the kernel; MAX-reduce the local max here.
+        local_max = int(document_index.max().item()) if document_index.numel() > 0 else -1
+        if self._sdp_active:
+            max_buffer = document_index.new_tensor(local_max)
+            torch.distributed.all_reduce(max_buffer, op=torch.distributed.ReduceOp.MAX, group=self._sdp_dim.group)
+            local_max = int(max_buffer.item())
+        num_segments = local_max + 1
+
+        loss, grad, new_logprobs_mean = fused_gspo_loss_forward_backward(
+            logits,
+            self._get_labels(kwargs, split_index),
+            self._prepare_target(kwargs[LanguageModelLossKwargs.advantages], split_index),
+            self._prepare_target(kwargs[LanguageModelLossKwargs.old_log_probabilities], split_index),
+            document_index,
+            num_segments,
+            grad_logits=grad_logits,
+            grad_output=self._get_grad_output(kwargs),
+            group=self._parallel_dim.group if self._vocab_parallel else None,
+            sdp_group=self._sdp_dim.group if self._sdp_active else None,
+            epsilon_low=self._config.epsilon_low,
+            epsilon_high=self._config.epsilon_high,
+            logits_scale_factor=self._logits_scale_factor,
+            num_labels_in_seq=(
+                None
+                if losses is None
+                else self._prepare_target(kwargs[LanguageModelLossKwargs.label_counts], split_index)
+            ),
+            divisor=kwargs[LanguageModelKwargs.num_documents_in_batch],
+        )
+
+        self._register_new_logprobs(new_logprobs_mean, kwargs, losses)
+        return loss, grad
+
+    def get_preprocessing_config(self) -> dict[str, typing.Any]:
+        return super().get_preprocessing_config() | {"return_document_index": True}
 
 
 @torch.compile
@@ -320,6 +398,111 @@ def fused_grpo_loss_forward_backward(
         )
         grad = grad.to(logits.dtype)
 
+        if grad_logits is None:
+            grad_logits = grad
+        else:
+            grad_logits.add_(grad)
+
+    return loss, grad_logits, new_logprobs_mean
+
+
+def fused_gspo_loss_forward_backward(
+    logits: torch.Tensor,  # (*batch, vocab)
+    target: torch.Tensor,  # (*batch,)
+    advantages: torch.Tensor,  # (*batch,)
+    old_log_probabilities: torch.Tensor,  # (*batch,)
+    document_index: torch.Tensor,  # (*batch,) int — 0-based segment ID per token
+    num_segments: int,  # buffer size, ≥ document_index.max() + 1
+    grad_logits: torch.Tensor | None = None,
+    grad_output: float | None = None,
+    group: torch.distributed.ProcessGroup | None = None,  # TP vocab group
+    sdp_group: torch.distributed.ProcessGroup | None = None,  # SDP group for cross-rank segment aggregation
+    epsilon_low: float = 0.2,
+    epsilon_high: float = 0.2,
+    logits_scale_factor: float = 1.0,
+    num_labels_in_seq: torch.Tensor | None = None,
+    divisor: float | None = None,  # default: num_segments
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    """GSPO loss: sequence-level geometric-mean IS-ratio clipping.
+
+    Per-segment ratio R_s = exp(mean_t(log p_new_t / p_old_t)), clipped per segment.
+    Per-segment loss = -min(R_s * A_s, clip(R_s) * A_s), summed over segments and divided by `divisor`.
+
+    Computed as an equivalent per-token sum: each token contributes `(1 / token_count_s) * -min(...)`,
+    making the gradient chain (softmax → log_prob → log_ratio → R_s) identical in structure to GRPO,
+    only with the per-token IS ratio replaced by the segment-broadcast R_s, the per-token advantage
+    by the segment-mean A_s, and the loss mask scaled by 1 / token_count_s.
+
+    With `sdp_group`, segment sums are all-reduced so each rank computes the same global R_s/A_s.
+    Token-level contributions remain per-rank, so summing the kernel loss across SDP via SUM reduction
+    matches the canonical single-rank result without further correction.
+    """
+    if divisor is None:
+        divisor = float(num_segments) if num_segments > 0 else 1.0
+    grad_output_scaled = None if grad_output is None else grad_output / divisor * logits_scale_factor
+    loss_mask = target >= 0
+
+    # === Setup phase (identical to GRPO) ===
+    logits_norm, exp_logits, sum_exp_logits, _ = fused_softmax_base(logits, logits_scale_factor, group)
+    predicted_logits, target_masked, target_mask = fused_predicted_logits_from_labels(
+        logits_norm, target, loss_mask, group
+    )
+    new_log_probs = predicted_logits - sum_exp_logits.log()
+    log_ratio = new_log_probs - old_log_probabilities
+
+    # === Segment aggregation ===
+    flat_doc = document_index.reshape(-1).long()
+    flat_mask = loss_mask.reshape(-1).to(log_ratio.dtype)
+    log_ratio_sum = log_ratio.new_zeros(num_segments).index_add_(
+        0, flat_doc, (log_ratio.reshape(-1) * flat_mask).to(log_ratio.dtype)
+    )
+    advantage_sum = advantages.new_zeros(num_segments).index_add_(
+        0, flat_doc, (advantages.reshape(-1) * flat_mask).to(advantages.dtype)
+    )
+    token_count = log_ratio.new_zeros(num_segments).index_add_(0, flat_doc, flat_mask)
+    if sdp_group is not None:
+        torch.distributed.all_reduce(log_ratio_sum, op=torch.distributed.ReduceOp.SUM, group=sdp_group)
+        torch.distributed.all_reduce(advantage_sum, op=torch.distributed.ReduceOp.SUM, group=sdp_group)
+        torch.distributed.all_reduce(token_count, op=torch.distributed.ReduceOp.SUM, group=sdp_group)
+
+    safe_count = token_count.clamp(min=1)
+    segment_ratio = (log_ratio_sum / safe_count).exp()  # (num_segments,) — geometric-mean IS ratio
+    segment_advantage = (advantage_sum / safe_count).detach()  # (num_segments,) — no grad through A
+    inv_token_count = torch.where(token_count > 0, 1.0 / safe_count, token_count.new_zeros(()))
+
+    # Broadcast back to per-token
+    probability_ratio = segment_ratio[flat_doc].reshape(log_ratio.shape)
+    seg_advantage = segment_advantage[flat_doc].reshape(log_ratio.shape)
+    # Per-token weight 1/token_count_s so each segment contributes once to the sum.
+    token_weight = flat_mask.reshape(log_ratio.shape) * inv_token_count[flat_doc].reshape(log_ratio.shape)
+
+    # === Per-token loss (mirrors GRPO; mask folded into token_weight) ===
+    losses = -torch.min(
+        probability_ratio * seg_advantage,
+        torch.clamp(probability_ratio, 1 - epsilon_low, 1 + epsilon_high) * seg_advantage,
+    )
+    loss = (losses * token_weight).sum() / divisor
+
+    new_logprobs_mean = (
+        None if num_labels_in_seq is None else (new_log_probs * loss_mask / num_labels_in_seq.clamp(min=1)).sum()
+    )
+
+    if grad_output_scaled is not None:
+        probability_ratio_grad = (
+            grad_output_scaled
+            * (
+                torch.clamp_min(seg_advantage, 0) * (probability_ratio <= 1 + epsilon_high)
+                + torch.clamp_max(seg_advantage, 0) * (probability_ratio >= 1 - epsilon_low)
+            )
+            * token_weight
+        )
+        predicted_probabilities = exp_logits / sum_exp_logits.unsqueeze_(-1)
+        grad = (probability_ratio_grad * probability_ratio).unsqueeze(-1) * predicted_probabilities.scatter_add(
+            -1,
+            target_masked.unsqueeze(-1),
+            -(loss_mask if target_mask is None else target_mask).unsqueeze(-1).to(torch.float32),
+        )
+        grad = grad.to(logits.dtype)
         if grad_logits is None:
             grad_logits = grad
         else:

--- a/fast_llm/layers/language_model/loss/policy_gradient.py
+++ b/fast_llm/layers/language_model/loss/policy_gradient.py
@@ -221,6 +221,36 @@ class LanguageModelGRPOLoss[ConfigType: LanguageModelGRPOLossConfig](LanguageMod
 class LanguageModelGSPOLoss[ConfigType: LanguageModelGSPOLossConfig](LanguageModelPolicyGradientLoss[ConfigType]):
     """GSPO: sequence-level geometric-mean IS-ratio clipping."""
 
+    def __init__(
+        self,
+        config: ConfigType,
+        distributed_config: DistributedConfig,
+        *,
+        name: str,
+        prediction_distance: int = 1,
+        prediction_heads: int = 1,
+        vocab_parallel: bool = False,
+        num_splits: int = 1,
+        logits_scale_factor: float = 1.0,
+        weight: float = 1.0,
+        register_loss: bool = False,
+    ):
+        super().__init__(
+            config,
+            distributed_config,
+            name=name,
+            prediction_distance=prediction_distance,
+            prediction_heads=prediction_heads,
+            vocab_parallel=vocab_parallel,
+            num_splits=num_splits,
+            logits_scale_factor=logits_scale_factor,
+            weight=weight,
+            register_loss=register_loss,
+        )
+        # `cross_entropy_splits` chunks the sequence across forward calls; per-segment
+        # aggregation can't recombine across chunks since each call only sees a slice.
+        Assert.eq(self._num_splits, 1)
+
     def _forward_backward(
         self,
         logits: "torch.Tensor",

--- a/fast_llm/layers/language_model/loss/policy_gradient.py
+++ b/fast_llm/layers/language_model/loss/policy_gradient.py
@@ -426,7 +426,10 @@ def fused_grpo_loss_forward_backward(
     return loss, grad_logits, new_logprobs_mean
 
 
-@torch.compile
+# Not @torch.compile: dynamo lifts the Python-int `divisor` and `num_segments` args to symbolic
+# ints with no concrete hint, then trips on `grad_output / divisor` during trace evaluation
+# (`ZeroDivisionError` with hint=0). The Triton kernel is the actual GPU perf path; the eager
+# PyTorch fallback doesn't need to be compiled.
 def fused_gspo_loss_forward_backward(
     logits: torch.Tensor,  # (*batch, vocab)
     target: torch.Tensor,  # (*batch,)

--- a/fast_llm/layers/language_model/loss/policy_gradient.py
+++ b/fast_llm/layers/language_model/loss/policy_gradient.py
@@ -237,14 +237,9 @@ class LanguageModelGSPOLoss[ConfigType: LanguageModelGSPOLossConfig](LanguageMod
         )
         # `document_index_q` is 1-based per the data preprocessor convention; shift to 0-based.
         document_index = document_index.long() - 1
-        # Buffer size must agree across SDP ranks (sharing the sequence) for the per-segment
-        # all-reduce inside the kernel; MAX-reduce the local max here.
-        local_max = int(document_index.max().item()) if document_index.numel() > 0 else -1
-        if self._sdp_active:
-            max_buffer = document_index.new_tensor(local_max)
-            torch.distributed.all_reduce(max_buffer, op=torch.distributed.ReduceOp.MAX, group=self._sdp_dim.group)
-            local_max = int(max_buffer.item())
-        num_segments = local_max + 1
+        # `lengths` is the CPU-side per-microbatch document list, identical across SDP ranks,
+        # so the buffer size is known host-side and matches the global segment count.
+        num_segments = len(kwargs[BlockKwargs.lengths])
 
         loss, grad, new_logprobs_mean = fused_gspo_loss_forward_backward(
             logits,
@@ -406,6 +401,7 @@ def fused_grpo_loss_forward_backward(
     return loss, grad_logits, new_logprobs_mean
 
 
+@torch.compile
 def fused_gspo_loss_forward_backward(
     logits: torch.Tensor,  # (*batch, vocab)
     target: torch.Tensor,  # (*batch,)
@@ -413,6 +409,7 @@ def fused_gspo_loss_forward_backward(
     old_log_probabilities: torch.Tensor,  # (*batch,)
     document_index: torch.Tensor,  # (*batch,) int — 0-based segment ID per token
     num_segments: int,  # buffer size, ≥ document_index.max() + 1
+    divisor: float,
     grad_logits: torch.Tensor | None = None,
     grad_output: float | None = None,
     group: torch.distributed.ProcessGroup | None = None,  # TP vocab group
@@ -421,7 +418,6 @@ def fused_gspo_loss_forward_backward(
     epsilon_high: float = 0.2,
     logits_scale_factor: float = 1.0,
     num_labels_in_seq: torch.Tensor | None = None,
-    divisor: float | None = None,  # default: num_segments
 ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
     """GSPO loss: sequence-level geometric-mean IS-ratio clipping.
 
@@ -437,8 +433,6 @@ def fused_gspo_loss_forward_backward(
     Token-level contributions remain per-rank, so summing the kernel loss across SDP via SUM reduction
     matches the canonical single-rank result without further correction.
     """
-    if divisor is None:
-        divisor = float(num_segments) if num_segments > 0 else 1.0
     grad_output_scaled = None if grad_output is None else grad_output / divisor * logits_scale_factor
     loss_mask = target >= 0
 

--- a/fast_llm/layers/language_model/loss/policy_gradient.py
+++ b/fast_llm/layers/language_model/loss/policy_gradient.py
@@ -259,13 +259,12 @@ class LanguageModelGSPOLoss[ConfigType: LanguageModelGSPOLossConfig](LanguageMod
         split_index: int = 0,
         grad_logits: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        document_index = self._prepare_target(
-            kwargs[BlockKwargs.document_index_q], split_index, split_by_distance=False
+        document_index_zero_based = (
+            self._prepare_target(kwargs[BlockKwargs.document_index_q], split_index, split_by_distance=False).long() - 1
         )
-        # `document_index_q` is 1-based per the data preprocessor convention; shift to 0-based.
-        document_index = document_index.long() - 1
         # `lengths` is the CPU-side per-microbatch document list, identical across SDP ranks,
         # so the buffer size is known host-side and matches the global segment count.
+        # `document_index_q` is 1-based per the data preprocessor convention; the kernel takes 0-based.
         num_segments = len(kwargs[BlockKwargs.lengths])
 
         loss, grad, new_logprobs_mean = fused_gspo_loss_forward_backward(
@@ -273,7 +272,7 @@ class LanguageModelGSPOLoss[ConfigType: LanguageModelGSPOLossConfig](LanguageMod
             self._get_labels(kwargs, split_index),
             self._prepare_target(kwargs[LanguageModelLossKwargs.advantages], split_index),
             self._prepare_target(kwargs[LanguageModelLossKwargs.old_log_probabilities], split_index),
-            document_index,
+            document_index_zero_based,
             num_segments,
             grad_logits=grad_logits,
             grad_output=self._get_grad_output(kwargs),
@@ -433,7 +432,7 @@ def fused_gspo_loss_forward_backward(
     target: torch.Tensor,  # (*batch,)
     advantages: torch.Tensor,  # (*batch,)
     old_log_probabilities: torch.Tensor,  # (*batch,)
-    document_index: torch.Tensor,  # (*batch,) int — 0-based segment ID per token
+    document_index_zero_based: torch.Tensor,  # (*batch,) int — segment ID per token, 0-based
     num_segments: int,  # buffer size, ≥ document_index.max() + 1
     divisor: float,
     num_labels_in_seq: torch.Tensor,  # (*batch,) — per-document labeled-token count broadcast per token
@@ -477,7 +476,7 @@ def fused_gspo_loss_forward_backward(
     new_log_probs = predicted_logits - sum_exp_logits.log()
     log_ratio = new_log_probs - old_log_probabilities
 
-    flat_document_index = document_index.reshape(-1).long()
+    flat_document_index = document_index_zero_based.reshape(-1).long()
     flat_mask = loss_mask.reshape(-1).to(log_ratio.dtype)
     # Per-token weight: mask / per-document label count, from the preprocessor.
     # Each labeled token contributes `1 / N_d` so all of doc d's tokens sum to 1 (across

--- a/fast_llm/layers/language_model/loss/policy_gradient.py
+++ b/fast_llm/layers/language_model/loss/policy_gradient.py
@@ -260,12 +260,15 @@ class LanguageModelGSPOLoss[ConfigType: LanguageModelGSPOLossConfig](LanguageMod
         grad_logits: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         document_index_zero_based = (
-            self._prepare_target(kwargs[BlockKwargs.document_index_q], split_index, split_by_distance=False).long() - 1
+            self._prepare_target(
+                kwargs[BlockKwargs.global_document_index_q], split_index, split_by_distance=False
+            ).long()
+            - 1
         )
-        # `lengths` is the CPU-side per-microbatch document list, identical across SDP ranks,
-        # so the buffer size is known host-side and matches the global segment count.
-        # `document_index_q` is 1-based per the data preprocessor convention; the kernel takes 0-based.
-        num_segments = len(kwargs[BlockKwargs.lengths])
+        # `global_document_index_q` is 1-based per the data preprocessor convention; the kernel takes 0-based.
+        # `num_documents_in_sequence` is the doc count for this DP rank's batch — identical across
+        # SDP/SP ranks within a DP rank, so per-segment buffers are sized consistently for all-reduce.
+        num_segments = kwargs[BlockKwargs.num_documents_in_sequence]
 
         loss, grad, new_logprobs_mean = fused_gspo_loss_forward_backward(
             logits,

--- a/fast_llm/layers/language_model/loss/policy_gradient.py
+++ b/fast_llm/layers/language_model/loss/policy_gradient.py
@@ -285,11 +285,7 @@ class LanguageModelGSPOLoss[ConfigType: LanguageModelGSPOLossConfig](LanguageMod
             epsilon_low=self._config.epsilon_low,
             epsilon_high=self._config.epsilon_high,
             logits_scale_factor=self._logits_scale_factor,
-            num_labels_in_seq=(
-                None
-                if losses is None
-                else self._prepare_target(kwargs[LanguageModelLossKwargs.label_counts], split_index)
-            ),
+            num_labels_in_seq=self._prepare_target(kwargs[LanguageModelLossKwargs.label_counts], split_index),
             divisor=kwargs[LanguageModelKwargs.num_documents_in_batch],
         )
 
@@ -440,6 +436,7 @@ def fused_gspo_loss_forward_backward(
     document_index: torch.Tensor,  # (*batch,) int — 0-based segment ID per token
     num_segments: int,  # buffer size, ≥ document_index.max() + 1
     divisor: float,
+    num_labels_in_seq: torch.Tensor,  # (*batch,) — per-document labeled-token count broadcast per token
     grad_logits: torch.Tensor | None = None,
     grad_output: float | None = None,
     group: torch.distributed.ProcessGroup | None = None,  # TP vocab group
@@ -448,13 +445,23 @@ def fused_gspo_loss_forward_backward(
     epsilon_low: float = 0.2,
     epsilon_high: float = 0.2,
     logits_scale_factor: float = 1.0,
-    num_labels_in_seq: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
     """GSPO loss: sequence-level geometric-mean IS-ratio clipping.
 
     Per-segment ratio R_s = exp(mean_t(log p_new_t / p_old_t)), clipped per segment.
     Per-segment loss = -min(R_s * A_s, clip(R_s) * A_s), summed over segments and divided by `divisor`.
     Computed as an equivalent per-token sum so the gradient chain mirrors GRPO.
+
+    `num_labels_in_seq[t]` is the labeled-token count for the document containing token `t`
+    (broadcast per token by the data preprocessor); it doubles as the geometric-mean denominator
+    and the per-token weight. Using it directly — rather than aggregating token counts inside the
+    kernel — is what makes the loss correct when a document spans SDP/SP ranks (numerator
+    `log_ratio_sum` is all-reduced; denominator is constant and available locally).
+
+    Constraint: each document must be visible to a single kernel call (modulo SDP/SP, where
+    the kernel all-reduces). Splitting a document across separate kernel calls (e.g.
+    `schedule.micro_batch_splits > 1`) produces partial per-fragment geometric means that
+    cannot be combined linearly into the whole-document `exp(mean)`.
 
     With `sdp_group` and/or `sp_group`, segment sums are all-reduced over those groups so each rank
     computes the same global R_s/A_s. Token-level contributions remain per-rank, so summing the
@@ -472,30 +479,34 @@ def fused_gspo_loss_forward_backward(
 
     flat_document_index = document_index.reshape(-1).long()
     flat_mask = loss_mask.reshape(-1).to(log_ratio.dtype)
-    log_ratio_sum = log_ratio.new_zeros(num_segments).index_add_(
-        0, flat_document_index, log_ratio.reshape(-1) * flat_mask
+    # Per-token weight: mask / per-document label count, from the preprocessor.
+    # Each labeled token contributes `1 / N_d` so all of doc d's tokens sum to 1 (across
+    # SDP/SP ranks too), regardless of how the doc is sharded.
+    token_weight = flat_mask / num_labels_in_seq.reshape(-1).to(log_ratio.dtype).clamp(min=1)
+    # Pre-divide the per-token contributions by the per-doc label count, then sum per segment.
+    # All tokens in a segment share the same N_d, so this is mathematically equivalent to
+    # `log_ratio_sum / N_d` but avoids any per-segment denominator extraction.
+    mean_log_ratio_per_segment = log_ratio.new_zeros(num_segments).index_add_(
+        0, flat_document_index, log_ratio.reshape(-1) * token_weight
     )
-    advantage_sum = advantages.new_zeros(num_segments).index_add_(
-        0, flat_document_index, (advantages.reshape(-1) * flat_mask).to(advantages.dtype)
+    mean_advantage_per_segment = advantages.new_zeros(num_segments).index_add_(
+        0, flat_document_index, (advantages.reshape(-1) * token_weight).to(advantages.dtype)
     )
-    token_count = log_ratio.new_zeros(num_segments).index_add_(0, flat_document_index, flat_mask)
     for reduce_group in (sdp_group, sp_group):
         if reduce_group is not None:
-            torch.distributed.all_reduce(log_ratio_sum, op=torch.distributed.ReduceOp.SUM, group=reduce_group)
-            torch.distributed.all_reduce(advantage_sum, op=torch.distributed.ReduceOp.SUM, group=reduce_group)
-            torch.distributed.all_reduce(token_count, op=torch.distributed.ReduceOp.SUM, group=reduce_group)
+            torch.distributed.all_reduce(
+                mean_log_ratio_per_segment, op=torch.distributed.ReduceOp.SUM, group=reduce_group
+            )
+            torch.distributed.all_reduce(
+                mean_advantage_per_segment, op=torch.distributed.ReduceOp.SUM, group=reduce_group
+            )
 
-    safe_count = token_count.clamp(min=1)
-    segment_ratio = (log_ratio_sum / safe_count).exp()  # (num_segments,) — geometric-mean IS ratio
-    segment_advantage = (advantage_sum / safe_count).detach()  # (num_segments,) — no grad through A
-    inverse_token_count = torch.where(token_count > 0, 1.0 / safe_count, token_count.new_zeros(()))
+    segment_ratio = mean_log_ratio_per_segment.exp()  # (num_segments,) — geometric-mean IS ratio
+    segment_advantage = mean_advantage_per_segment.detach()  # (num_segments,) — no grad through A
 
     probability_ratio = segment_ratio[flat_document_index].reshape(log_ratio.shape)
     advantage_per_token = segment_advantage[flat_document_index].reshape(log_ratio.shape)
-    # Per-token weight 1/token_count_s so each segment contributes once to the sum.
-    token_weight = flat_mask.reshape(log_ratio.shape) * inverse_token_count[flat_document_index].reshape(
-        log_ratio.shape
-    )
+    token_weight = token_weight.reshape(log_ratio.shape)
 
     losses = -torch.min(
         probability_ratio * advantage_per_token,
@@ -503,9 +514,7 @@ def fused_gspo_loss_forward_backward(
     )
     loss = (losses * token_weight).sum() / divisor
 
-    new_logprobs_mean = (
-        None if num_labels_in_seq is None else (new_log_probs * loss_mask / num_labels_in_seq.clamp(min=1)).sum()
-    )
+    new_logprobs_mean = (new_log_probs * loss_mask / num_labels_in_seq.clamp(min=1)).sum()
 
     if grad_output_scaled is not None:
         probability_ratio_grad = (

--- a/fast_llm/layers/language_model/loss/policy_gradient.py
+++ b/fast_llm/layers/language_model/loss/policy_gradient.py
@@ -252,6 +252,9 @@ class LanguageModelGSPOLoss[ConfigType: LanguageModelGSPOLossConfig](LanguageMod
             grad_output=self._get_grad_output(kwargs),
             group=self._parallel_dim.group if self._vocab_parallel else None,
             sdp_group=self._sdp_dim.group if self._sdp_active else None,
+            # Sequence-parallel shards the sequence across the TP group, so per-segment
+            # buffers are partial on each rank and must be reduced over TP as well.
+            sp_group=self._parallel_dim.group if self._sequence_parallel else None,
             epsilon_low=self._config.epsilon_low,
             epsilon_high=self._config.epsilon_high,
             logits_scale_factor=self._logits_scale_factor,
@@ -414,6 +417,7 @@ def fused_gspo_loss_forward_backward(
     grad_output: float | None = None,
     group: torch.distributed.ProcessGroup | None = None,  # TP vocab group
     sdp_group: torch.distributed.ProcessGroup | None = None,  # SDP group for cross-rank segment aggregation
+    sp_group: torch.distributed.ProcessGroup | None = None,  # TP group when SP is sharding the sequence
     epsilon_low: float = 0.2,
     epsilon_high: float = 0.2,
     logits_scale_factor: float = 1.0,
@@ -429,9 +433,9 @@ def fused_gspo_loss_forward_backward(
     only with the per-token IS ratio replaced by the segment-broadcast R_s, the per-token advantage
     by the segment-mean A_s, and the loss mask scaled by 1 / token_count_s.
 
-    With `sdp_group`, segment sums are all-reduced so each rank computes the same global R_s/A_s.
-    Token-level contributions remain per-rank, so summing the kernel loss across SDP via SUM reduction
-    matches the canonical single-rank result without further correction.
+    With `sdp_group` and/or `sp_group`, segment sums are all-reduced over those groups so each rank
+    computes the same global R_s/A_s. Token-level contributions remain per-rank, so summing the
+    kernel loss across SDP/SP via SUM reduction matches the canonical single-rank result.
     """
     grad_output_scaled = None if grad_output is None else grad_output / divisor * logits_scale_factor
     loss_mask = target >= 0
@@ -454,10 +458,11 @@ def fused_gspo_loss_forward_backward(
         0, flat_doc, (advantages.reshape(-1) * flat_mask).to(advantages.dtype)
     )
     token_count = log_ratio.new_zeros(num_segments).index_add_(0, flat_doc, flat_mask)
-    if sdp_group is not None:
-        torch.distributed.all_reduce(log_ratio_sum, op=torch.distributed.ReduceOp.SUM, group=sdp_group)
-        torch.distributed.all_reduce(advantage_sum, op=torch.distributed.ReduceOp.SUM, group=sdp_group)
-        torch.distributed.all_reduce(token_count, op=torch.distributed.ReduceOp.SUM, group=sdp_group)
+    for reduce_group in (sdp_group, sp_group):
+        if reduce_group is not None:
+            torch.distributed.all_reduce(log_ratio_sum, op=torch.distributed.ReduceOp.SUM, group=reduce_group)
+            torch.distributed.all_reduce(advantage_sum, op=torch.distributed.ReduceOp.SUM, group=reduce_group)
+            torch.distributed.all_reduce(token_count, op=torch.distributed.ReduceOp.SUM, group=reduce_group)
 
     safe_count = token_count.clamp(min=1)
     segment_ratio = (log_ratio_sum / safe_count).exp()  # (num_segments,) — geometric-mean IS ratio

--- a/fast_llm/layers/language_model/loss/policy_gradient.py
+++ b/fast_llm/layers/language_model/loss/policy_gradient.py
@@ -39,10 +39,7 @@ class GRPOMetrics(typing.NamedTuple):
 class LanguageModelPolicyGradientLoss[ConfigType: LanguageModelPolicyGradientLossConfig](
     LanguageModelLoss[ConfigType]
 ):
-    """Shared scaffolding for policy-gradient losses (GRPO, GSPO).
-
-    Subclasses implement `_forward_backward` to call their specific kernel.
-    """
+    """Shared scaffolding for policy-gradient losses (GRPO, GSPO)."""
 
     def _register_new_logprobs(
         self,
@@ -251,7 +248,7 @@ class LanguageModelGSPOLoss[ConfigType: LanguageModelGSPOLossConfig](LanguageMod
             grad_logits=grad_logits,
             grad_output=self._get_grad_output(kwargs),
             group=self._parallel_dim.group if self._vocab_parallel else None,
-            sdp_group=self._sdp_dim.group if self._sdp_active else None,
+            sdp_group=self._sequence_data_dim.group if self._sequence_data_active else None,
             # Sequence-parallel shards the sequence across the TP group, so per-segment
             # buffers are partial on each rank and must be reduced over TP as well.
             sp_group=self._parallel_dim.group if self._sequence_parallel else None,
@@ -427,11 +424,7 @@ def fused_gspo_loss_forward_backward(
 
     Per-segment ratio R_s = exp(mean_t(log p_new_t / p_old_t)), clipped per segment.
     Per-segment loss = -min(R_s * A_s, clip(R_s) * A_s), summed over segments and divided by `divisor`.
-
-    Computed as an equivalent per-token sum: each token contributes `(1 / token_count_s) * -min(...)`,
-    making the gradient chain (softmax → log_prob → log_ratio → R_s) identical in structure to GRPO,
-    only with the per-token IS ratio replaced by the segment-broadcast R_s, the per-token advantage
-    by the segment-mean A_s, and the loss mask scaled by 1 / token_count_s.
+    Computed as an equivalent per-token sum so the gradient chain mirrors GRPO.
 
     With `sdp_group` and/or `sp_group`, segment sums are all-reduced over those groups so each rank
     computes the same global R_s/A_s. Token-level contributions remain per-rank, so summing the
@@ -440,7 +433,6 @@ def fused_gspo_loss_forward_backward(
     grad_output_scaled = None if grad_output is None else grad_output / divisor * logits_scale_factor
     loss_mask = target >= 0
 
-    # === Setup phase (identical to GRPO) ===
     logits_norm, exp_logits, sum_exp_logits, _ = fused_softmax_base(logits, logits_scale_factor, group)
     predicted_logits, target_masked, target_mask = fused_predicted_logits_from_labels(
         logits_norm, target, loss_mask, group
@@ -448,16 +440,15 @@ def fused_gspo_loss_forward_backward(
     new_log_probs = predicted_logits - sum_exp_logits.log()
     log_ratio = new_log_probs - old_log_probabilities
 
-    # === Segment aggregation ===
-    flat_doc = document_index.reshape(-1).long()
+    flat_document_index = document_index.reshape(-1).long()
     flat_mask = loss_mask.reshape(-1).to(log_ratio.dtype)
     log_ratio_sum = log_ratio.new_zeros(num_segments).index_add_(
-        0, flat_doc, (log_ratio.reshape(-1) * flat_mask).to(log_ratio.dtype)
+        0, flat_document_index, log_ratio.reshape(-1) * flat_mask
     )
     advantage_sum = advantages.new_zeros(num_segments).index_add_(
-        0, flat_doc, (advantages.reshape(-1) * flat_mask).to(advantages.dtype)
+        0, flat_document_index, (advantages.reshape(-1) * flat_mask).to(advantages.dtype)
     )
-    token_count = log_ratio.new_zeros(num_segments).index_add_(0, flat_doc, flat_mask)
+    token_count = log_ratio.new_zeros(num_segments).index_add_(0, flat_document_index, flat_mask)
     for reduce_group in (sdp_group, sp_group):
         if reduce_group is not None:
             torch.distributed.all_reduce(log_ratio_sum, op=torch.distributed.ReduceOp.SUM, group=reduce_group)
@@ -467,18 +458,18 @@ def fused_gspo_loss_forward_backward(
     safe_count = token_count.clamp(min=1)
     segment_ratio = (log_ratio_sum / safe_count).exp()  # (num_segments,) — geometric-mean IS ratio
     segment_advantage = (advantage_sum / safe_count).detach()  # (num_segments,) — no grad through A
-    inv_token_count = torch.where(token_count > 0, 1.0 / safe_count, token_count.new_zeros(()))
+    inverse_token_count = torch.where(token_count > 0, 1.0 / safe_count, token_count.new_zeros(()))
 
-    # Broadcast back to per-token
-    probability_ratio = segment_ratio[flat_doc].reshape(log_ratio.shape)
-    seg_advantage = segment_advantage[flat_doc].reshape(log_ratio.shape)
+    probability_ratio = segment_ratio[flat_document_index].reshape(log_ratio.shape)
+    advantage_per_token = segment_advantage[flat_document_index].reshape(log_ratio.shape)
     # Per-token weight 1/token_count_s so each segment contributes once to the sum.
-    token_weight = flat_mask.reshape(log_ratio.shape) * inv_token_count[flat_doc].reshape(log_ratio.shape)
+    token_weight = flat_mask.reshape(log_ratio.shape) * inverse_token_count[flat_document_index].reshape(
+        log_ratio.shape
+    )
 
-    # === Per-token loss (mirrors GRPO; mask folded into token_weight) ===
     losses = -torch.min(
-        probability_ratio * seg_advantage,
-        torch.clamp(probability_ratio, 1 - epsilon_low, 1 + epsilon_high) * seg_advantage,
+        probability_ratio * advantage_per_token,
+        torch.clamp(probability_ratio, 1 - epsilon_low, 1 + epsilon_high) * advantage_per_token,
     )
     loss = (losses * token_weight).sum() / divisor
 
@@ -490,8 +481,8 @@ def fused_gspo_loss_forward_backward(
         probability_ratio_grad = (
             grad_output_scaled
             * (
-                torch.clamp_min(seg_advantage, 0) * (probability_ratio <= 1 + epsilon_high)
-                + torch.clamp_max(seg_advantage, 0) * (probability_ratio >= 1 - epsilon_low)
+                torch.clamp_min(advantage_per_token, 0) * (probability_ratio <= 1 + epsilon_high)
+                + torch.clamp_max(advantage_per_token, 0) * (probability_ratio >= 1 - epsilon_low)
             )
             * token_weight
         )

--- a/tests/layers/test_lm_head.py
+++ b/tests/layers/test_lm_head.py
@@ -163,9 +163,10 @@ class LMHeadTestConfig:
             )
         if self.gspo_loss is not False:
             document_length = NUM_TOKENS // GSPO_NUM_DOCUMENTS
-            kwargs[BlockKwargs.document_index_q] = torch.repeat_interleave(
+            kwargs[BlockKwargs.global_document_index_q] = torch.repeat_interleave(
                 torch.arange(1, GSPO_NUM_DOCUMENTS + 1, dtype=torch.int32, device=device), document_length
             )
+            kwargs[BlockKwargs.num_documents_in_sequence] = GSPO_NUM_DOCUMENTS
             kwargs[BlockKwargs.lengths] = [document_length] * GSPO_NUM_DOCUMENTS
             # Override label_counts: per-token broadcast of the containing document's masked-label count
             # (the kernel's per-document `new_logprobs` aggregation depends on this).
@@ -251,9 +252,9 @@ class LMHeadTestConfig:
                 labels,
                 kwargs[LanguageModelLossKwargs.advantages][head._prediction_distance - 1],
                 kwargs[LanguageModelLossKwargs.old_log_probabilities][head._prediction_distance - 1],
-                # `document_index_q` is 1-based per the data preprocessor convention; the reference takes 0-based.
-                kwargs[BlockKwargs.document_index_q].long() - 1,
-                len(kwargs[BlockKwargs.lengths]),
+                # `global_document_index_q` is 1-based per the data preprocessor convention; the reference takes 0-based.
+                kwargs[BlockKwargs.global_document_index_q].long() - 1,
+                kwargs[BlockKwargs.num_documents_in_sequence],
             )
             # Average over documents of per-document mean log-prob — matches the kernel's
             # `sum_t logprob_t * mask_t / label_count_t` divided by `num_documents_in_batch`.

--- a/tests/layers/test_lm_head.py
+++ b/tests/layers/test_lm_head.py
@@ -7,17 +7,19 @@ import torch
 
 from fast_llm.engine.config_utils.data_type import DataType
 from fast_llm.layers.attention.config import AttentionKwargs
+from fast_llm.layers.block.config import BlockKwargs
 from fast_llm.layers.language_model.config import LM_HEAD_LOSS_NAME, LanguageModelKwargs
 from fast_llm.layers.language_model.head import LanguageModelHead
 from fast_llm.layers.language_model.loss.config import LanguageModelLossKwargs
 from fast_llm.models.gpt.config import GPTModelConfig
 from fast_llm.utils import Assert
-from tests.layers.test_lm_losses import reference_grpo_loss
+from tests.layers.test_lm_losses import reference_grpo_loss, reference_gspo_loss
 from tests.utils.utils import get_base_model, get_stage
 
 NUM_TOKENS = 200
 HIDDEN_SIZE = 256
 VOCAB_SIZE = 500
+GSPO_NUM_DOCUMENTS = 4
 
 
 @dataclasses.dataclass
@@ -27,6 +29,7 @@ class LMHeadTestConfig:
     distillation_loss: bool | float = False
     z_loss: bool | float = False
     grpo_loss: bool | float = False
+    gspo_loss: bool | float = False
     logits_scale_factor: float = 1.0
     final_logit_softcap: float | None = None
     compute_dtype: DataType = DataType.float32
@@ -44,6 +47,7 @@ class LMHeadTestConfig:
             and self.distillation_loss is False
             and self.z_loss is False
             and self.grpo_loss is False
+            and self.gspo_loss is False
             else self.label_loss
         )
 
@@ -73,6 +77,10 @@ class LMHeadTestConfig:
             losses["grpo_loss"] = {"type": "grpo"}
             if isinstance(self.grpo_loss, float):
                 losses["grpo_loss"]["weight"] = self.grpo_loss
+        if self.gspo_loss is not False:
+            losses["gspo_loss"] = {"type": "gspo"}
+            if isinstance(self.gspo_loss, float):
+                losses["gspo_loss"]["weight"] = self.gspo_loss
         if losses:
             head_config["losses"] = losses
 
@@ -110,7 +118,7 @@ class LMHeadTestConfig:
             ]
         else:
             kwargs[LanguageModelKwargs.num_labels_in_batch] = [NUM_TOKENS for _ in range(self.prediction_heads)]
-        if self.actual_label_loss is not False or self.grpo_loss is not False:
+        if self.actual_label_loss is not False or self.grpo_loss is not False or self.gspo_loss is not False:
             labels = [
                 torch.randint(
                     0,
@@ -137,7 +145,7 @@ class LMHeadTestConfig:
                     device=device,
                 )
             }
-        if self.grpo_loss is not False:
+        if self.grpo_loss is not False or self.gspo_loss is not False:
             kwargs[LanguageModelLossKwargs.advantages] = [
                 torch.randn(input_.shape[:-1], dtype=torch.float32, device=device)
                 for _ in range(self.prediction_heads)
@@ -150,7 +158,25 @@ class LMHeadTestConfig:
                 torch.full(input_.shape[:-1], float((labels_ >= 0).sum()), dtype=torch.float32, device=device)
                 for labels_ in kwargs[LanguageModelKwargs.labels]
             ]
-            kwargs[LanguageModelKwargs.num_documents_in_batch] = 1
+            kwargs[LanguageModelKwargs.num_documents_in_batch] = (
+                GSPO_NUM_DOCUMENTS if self.gspo_loss is not False else 1
+            )
+        if self.gspo_loss is not False:
+            document_length = NUM_TOKENS // GSPO_NUM_DOCUMENTS
+            kwargs[BlockKwargs.document_index_q] = torch.repeat_interleave(
+                torch.arange(1, GSPO_NUM_DOCUMENTS + 1, dtype=torch.int32, device=device), document_length
+            )
+            kwargs[BlockKwargs.lengths] = [document_length] * GSPO_NUM_DOCUMENTS
+            # Override label_counts: per-token broadcast of the containing document's masked-label count
+            # (the kernel's per-document `new_logprobs` aggregation depends on this).
+            kwargs[LanguageModelLossKwargs.label_counts] = [
+                (labels_ >= 0)
+                .view(GSPO_NUM_DOCUMENTS, document_length)
+                .sum(-1)
+                .to(torch.float32)
+                .repeat_interleave(document_length)
+                for labels_ in kwargs[LanguageModelKwargs.labels]
+            ]
         return input_, kwargs
 
     def get_reference_outputs(
@@ -185,7 +211,7 @@ class LMHeadTestConfig:
             else None
         )
 
-        if self.actual_label_loss is not False or self.grpo_loss is not False:
+        if self.actual_label_loss is not False or self.grpo_loss is not False or self.gspo_loss is not False:
             labels = kwargs[LanguageModelKwargs.labels][head._prediction_distance - 1]
 
         if self.actual_label_loss is not False:
@@ -218,6 +244,33 @@ class LMHeadTestConfig:
             )
             names_losses_weights.append(("grpo_loss", grpo_loss, float(self.grpo_loss)))
             names_losses_weights.append(("grpo_loss_new_logprobs", new_logprobs, 0.0))
+
+        if self.gspo_loss is not False:
+            gspo_loss, _ = reference_gspo_loss(
+                logits,
+                labels,
+                kwargs[LanguageModelLossKwargs.advantages][head._prediction_distance - 1],
+                kwargs[LanguageModelLossKwargs.old_log_probabilities][head._prediction_distance - 1],
+                # `document_index_q` is 1-based per the data preprocessor convention; the reference takes 0-based.
+                kwargs[BlockKwargs.document_index_q].long() - 1,
+                len(kwargs[BlockKwargs.lengths]),
+            )
+            # Average over documents of per-document mean log-prob — matches the kernel's
+            # `sum_t logprob_t * mask_t / label_count_t` divided by `num_documents_in_batch`.
+            document_length = NUM_TOKENS // GSPO_NUM_DOCUMENTS
+            target_log_probabilities = (
+                torch.nn.functional.log_softmax(logits, -1)
+                .gather(-1, (labels * (labels >= 0)).unsqueeze(-1))
+                .squeeze(-1)
+            )
+            label_mask = (labels >= 0).to(target_log_probabilities.dtype)
+            logprob_sums_per_document = (
+                (target_log_probabilities * label_mask).view(GSPO_NUM_DOCUMENTS, document_length).sum(-1)
+            )
+            label_counts_per_document = label_mask.view(GSPO_NUM_DOCUMENTS, document_length).sum(-1).clamp(min=1)
+            new_logprobs = (logprob_sums_per_document / label_counts_per_document).mean()
+            names_losses_weights.append(("gspo_loss", gspo_loss, float(self.gspo_loss)))
+            names_losses_weights.append(("gspo_loss_new_logprobs", new_logprobs, 0.0))
 
         actual_losses = [loss * weight for _, loss, weight in names_losses_weights if weight != 0.0]
         total_loss = sum(actual_losses)
@@ -264,6 +317,15 @@ _add_configs("label_loss", label_loss=True)
 _add_configs("distillation_loss", distillation_loss=True)
 _add_configs("z_loss", z_loss=True)
 _add_configs("grpo_loss", grpo_loss=True)
+# GSPO can't be split: per-segment aggregation can't recombine across cross_entropy_splits chunks.
+for loss_masking in (False, True):
+    _lm_head_test_configs.append(
+        LMHeadTestConfig(
+            f"gspo_loss{'_masked' if loss_masking else ''}",
+            gspo_loss=True,
+            loss_masking=loss_masking,
+        )
+    )
 _add_configs("label_and_distillation_loss", label_loss=True, distillation_loss=True)
 _add_configs("label_and_z_loss_weighted", label_loss=True, z_loss=0.5)
 _add_configs("label_and_distillation_loss_zero_weight", label_loss=True, distillation_loss=0.0)

--- a/tests/layers/test_lm_losses.py
+++ b/tests/layers/test_lm_losses.py
@@ -435,6 +435,7 @@ def _test_gspo_loss(
         old_log_probabilities,
         document_index,
         num_segments,
+        divisor=max(num_segments, 1),
         grad_logits=local_previous_grad.clone() if accumulate else None,
         grad_output=grad_output,
         group=group,
@@ -617,7 +618,19 @@ _GSPO_PARAMETERS = (
     (500, 4.0, 1.0, False, DataType.float32, 4, False),  # Grad scaling
     (500, 1.0, 1.0, True, DataType.float32, 4, False),  # Loss masking
     (500, 1.0, 1.0, False, DataType.float16, 4, False),  # Fp16
-    (500, 1.0, 1.0, False, DataType.float32, 1, False),  # One segment
+    pytest.param(
+        500,
+        1.0,
+        1.0,
+        False,
+        DataType.float32,
+        1,
+        False,
+        marks=pytest.mark.skipif(
+            not torch.cuda.is_available(),
+            reason="torch._inductor CPU codegen fails on index_add_ into a size-1 buffer",
+        ),
+    ),  # One segment
     (500, 1.0, 1.0, True, DataType.float32, 16, True),  # Many segments + masking + accumulate
 )
 

--- a/tests/layers/test_lm_losses.py
+++ b/tests/layers/test_lm_losses.py
@@ -638,19 +638,7 @@ _GSPO_PARAMETERS = (
     (500, 4.0, 1.0, False, DataType.float32, 4, False),  # Grad scaling
     (500, 1.0, 1.0, True, DataType.float32, 4, False),  # Loss masking
     (500, 1.0, 1.0, False, DataType.float16, 4, False),  # Fp16
-    pytest.param(
-        500,
-        1.0,
-        1.0,
-        False,
-        DataType.float32,
-        1,
-        False,
-        marks=pytest.mark.skipif(
-            not torch.cuda.is_available(),
-            reason="torch._inductor CPU codegen fails on index_add_ into a size-1 buffer",
-        ),
-    ),  # One segment
+    (500, 1.0, 1.0, False, DataType.float32, 1, False),  # One segment
     (500, 1.0, 1.0, True, DataType.float32, 16, True),  # Many segments + masking + accumulate
 )
 

--- a/tests/layers/test_lm_losses.py
+++ b/tests/layers/test_lm_losses.py
@@ -204,10 +204,9 @@ def reference_gspo_loss(
         advantage = (flat_advantages[in_segment].sum() / count.float()).detach()
         clipped_ratio = ratio.clamp(1 - epsilon_low, 1 + epsilon_high)
         total = total + -torch.minimum(ratio * advantage, clipped_ratio * advantage)
-    total = total / max(num_segments, 1)
+    total = total / num_segments
 
-    log_probs = torch.nn.functional.log_softmax(logits_, -1).gather(-1, labels_safe.unsqueeze(-1)).squeeze(-1)
-    new_logprobs = (log_probs * loss_mask).sum() / max(float(loss_mask.sum()), 1.0)
+    new_logprobs = (target_log_probabilities * loss_mask).sum() / max(float(loss_mask.sum()), 1.0)
     return total, new_logprobs
 
 
@@ -413,6 +412,21 @@ def _test_gspo_loss(
     span = max(seq_len // num_segments, 1)
     base = torch.arange(seq_len, device=target.device) // span
     document_index = base.clamp(max=num_segments - 1).expand(batch_shape).contiguous()
+    num_labels = int((target >= 0).sum().item())
+    num_labels_in_seq = torch.where(
+        target >= 0,
+        torch.full(batch_shape, num_labels, dtype=torch.int32, device=target.device),
+        torch.zeros(batch_shape, dtype=torch.int32, device=target.device),
+    )
+    _, ref_new_logprobs = reference_gspo_loss(
+        logits,
+        target,
+        advantages,
+        old_log_probabilities,
+        document_index,
+        num_segments,
+        logits_scale_factor=logits_scale_factor,
+    )
     out_ref, grad_ref = loss_forward_backward(
         grad_output,
         lambda *args, **kwargs: reference_gspo_loss(*args, **kwargs)[0],
@@ -435,13 +449,15 @@ def _test_gspo_loss(
         old_log_probabilities,
         document_index,
         num_segments,
-        divisor=max(num_segments, 1),
+        divisor=num_segments,
         grad_logits=local_previous_grad.clone() if accumulate else None,
         grad_output=grad_output,
         group=group,
         logits_scale_factor=logits_scale_factor,
+        num_labels_in_seq=num_labels_in_seq,
     )
     _compare_losses_and_grads(out_fused, out_ref, grad_output is not None, grad_fused, grad_ref, group=group)
+    Assert.rms_close_relative(new_logprobs_fused, ref_new_logprobs, 1e-5, 1e-6)
 
 
 def _check_grpo_metrics(ref: GRPOMetrics, got: GRPOMetrics, threshold: float) -> None:

--- a/tests/layers/test_lm_losses.py
+++ b/tests/layers/test_lm_losses.py
@@ -195,18 +195,20 @@ def reference_gspo_loss(
     flat_advantages = advantages.reshape(-1)
 
     total = log_ratio.new_zeros(())
+    new_logprobs = log_ratio.new_zeros(())
     for segment in range(num_segments):
         in_segment = (flat_doc == segment) & flat_mask
         count = in_segment.sum()
         if int(count) == 0:
             continue
-        ratio = (flat_log_ratio[in_segment].sum() / count.float()).exp()
-        advantage = (flat_advantages[in_segment].sum() / count.float()).detach()
+        count_float = count.float()
+        ratio = (flat_log_ratio[in_segment].sum() / count_float).exp()
+        advantage = (flat_advantages[in_segment].sum() / count_float).detach()
         clipped_ratio = ratio.clamp(1 - epsilon_low, 1 + epsilon_high)
         total = total + -torch.minimum(ratio * advantage, clipped_ratio * advantage)
+        # Matches the kernel's `sum_t logprob_t * mask_t / N_d` — sum of per-document mean logprobs.
+        new_logprobs = new_logprobs + target_log_probabilities.reshape(-1)[in_segment].sum() / count_float
     total = total / num_segments
-
-    new_logprobs = (target_log_probabilities * loss_mask).sum() / max(float(loss_mask.sum()), 1.0)
     return total, new_logprobs
 
 
@@ -412,12 +414,14 @@ def _test_gspo_loss(
     span = max(seq_len // num_segments, 1)
     base = torch.arange(seq_len, device=target.device) // span
     document_index = base.clamp(max=num_segments - 1).expand(batch_shape).contiguous()
-    num_labels = int((target >= 0).sum().item())
-    num_labels_in_seq = torch.where(
-        target >= 0,
-        torch.full(batch_shape, num_labels, dtype=torch.int32, device=target.device),
-        torch.zeros(batch_shape, dtype=torch.int32, device=target.device),
+    # Per-document labeled-token count broadcast per token, matching what the data
+    # preprocessor produces.
+    flat_doc = document_index.reshape(-1).long()
+    flat_target = target.reshape(-1)
+    labels_per_document = torch.zeros(num_segments, dtype=torch.int32, device=target.device).scatter_add(
+        0, flat_doc, (flat_target >= 0).to(torch.int32)
     )
+    num_labels_in_seq = labels_per_document[flat_doc].reshape(target.shape)
     _, ref_new_logprobs = reference_gspo_loss(
         logits,
         target,

--- a/tests/layers/test_lm_losses.py
+++ b/tests/layers/test_lm_losses.py
@@ -16,12 +16,13 @@ from fast_llm.functional.triton.entropy_loss import triton_entropy_loss_forward_
 from fast_llm.functional.triton.grpo_loss import triton_grpo_loss_forward_backward
 from fast_llm.functional.triton.z_loss import triton_z_loss_forward_backward
 from fast_llm.layers.language_model.loss.dpo import dpo_loss
-from fast_llm.layers.language_model.loss.grpo import (
+from fast_llm.layers.language_model.loss.loss import loss_forward_backward
+from fast_llm.layers.language_model.loss.policy_gradient import (
     GRPOMetrics,
     compute_grpo_metrics,
     fused_grpo_loss_forward_backward,
+    fused_gspo_loss_forward_backward,
 )
-from fast_llm.layers.language_model.loss.loss import loss_forward_backward
 from fast_llm.layers.language_model.loss.z_loss import fused_z_loss_forward_backward, z_loss
 from fast_llm.utils import Assert
 from tests.utils.dataset import get_random_spans
@@ -165,6 +166,49 @@ def reference_grpo_metrics(
         num_tokens=mask.sum(),
         entropy=entropy,
     )
+
+
+def reference_gspo_loss(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    advantages: torch.Tensor,
+    old_log_probabilities: torch.Tensor,
+    document_index: torch.Tensor,
+    num_segments: int,
+    epsilon_low: float = 0.2,
+    epsilon_high: float = 0.2,
+    logits_scale_factor: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    logits_ = logits.float()
+    loss_mask = labels >= 0
+    labels_safe = labels * loss_mask
+    target_log_probabilities = (
+        torch.nn.functional.log_softmax(logits_ * logits_scale_factor, dim=-1)
+        .gather(dim=-1, index=labels_safe.unsqueeze(-1))
+        .squeeze(-1)
+    )
+    log_ratio = target_log_probabilities - old_log_probabilities
+
+    flat_doc = document_index.reshape(-1)
+    flat_mask = loss_mask.reshape(-1)
+    flat_log_ratio = log_ratio.reshape(-1)
+    flat_advantages = advantages.reshape(-1)
+
+    total = log_ratio.new_zeros(())
+    for segment in range(num_segments):
+        in_segment = (flat_doc == segment) & flat_mask
+        count = in_segment.sum()
+        if int(count) == 0:
+            continue
+        ratio = (flat_log_ratio[in_segment].sum() / count.float()).exp()
+        advantage = (flat_advantages[in_segment].sum() / count.float()).detach()
+        clipped_ratio = ratio.clamp(1 - epsilon_low, 1 + epsilon_high)
+        total = total + -torch.minimum(ratio * advantage, clipped_ratio * advantage)
+    total = total / max(num_segments, 1)
+
+    log_probs = torch.nn.functional.log_softmax(logits_, -1).gather(-1, labels_safe.unsqueeze(-1)).squeeze(-1)
+    new_logprobs = (log_probs * loss_mask).sum() / max(float(loss_mask.sum()), 1.0)
+    return total, new_logprobs
 
 
 def reference_grpo_loss(
@@ -350,6 +394,55 @@ def _test_grpo_loss(
     Assert.rms_close_relative(new_logprobs_triton, new_logprobs_fused, 1e-5, 1e-6)
 
 
+def _test_gspo_loss(
+    batch_shape,
+    num_columns,
+    grad_output,
+    logits_scale_factor,
+    loss_masking,
+    dtype,
+    num_segments,
+    accumulate,
+    group=None,
+):
+    logits, target, advantages, old_log_probabilities = _get_grpo_loss_inputs(
+        num_columns, loss_masking, batch_shape, dtype
+    )
+    # Build per-token segment IDs by partitioning each batch row into `num_segments` contiguous spans.
+    seq_len = batch_shape[-1] if len(batch_shape) > 1 else batch_shape[0]
+    span = max(seq_len // num_segments, 1)
+    base = torch.arange(seq_len, device=target.device) // span
+    document_index = base.clamp(max=num_segments - 1).expand(batch_shape).contiguous()
+    out_ref, grad_ref = loss_forward_backward(
+        grad_output,
+        lambda *args, **kwargs: reference_gspo_loss(*args, **kwargs)[0],
+        logits,
+        target,
+        advantages,
+        old_log_probabilities,
+        document_index,
+        num_segments,
+        logits_scale_factor=logits_scale_factor,
+    )
+    if accumulate:
+        previous_grad = torch.randn_like(grad_ref)
+        grad_ref = grad_ref + previous_grad
+        local_previous_grad = split_op(previous_grad, group, -1).contiguous()
+    out_fused, grad_fused, new_logprobs_fused = fused_gspo_loss_forward_backward(
+        split_op(logits, group, -1),
+        target,
+        advantages,
+        old_log_probabilities,
+        document_index,
+        num_segments,
+        grad_logits=local_previous_grad.clone() if accumulate else None,
+        grad_output=grad_output,
+        group=group,
+        logits_scale_factor=logits_scale_factor,
+    )
+    _compare_losses_and_grads(out_fused, out_ref, grad_output is not None, grad_fused, grad_ref, group=group)
+
+
 def _check_grpo_metrics(ref: GRPOMetrics, got: GRPOMetrics, threshold: float) -> None:
     for name in GRPOMetrics._fields:
         ref_value = getattr(ref, name)
@@ -511,6 +604,35 @@ def test_grpo_loss(
 ):
     _test_grpo_loss(
         batch_shape, num_columns, grad_output, logits_scale_factor, loss_masking, dtype, block_size, accumulate
+    )
+
+
+_GSPO_PARAMETERS = (
+    # (num_columns, grad_output, logits_scale_factor, loss_masking, dtype, num_segments, accumulate)
+    (500, 1.0, 1.0, False, DataType.float32, 4, False),  # Simple
+    (256, 1.0, 1.0, False, DataType.float32, 4, False),  # Power of 2
+    (500, None, 1.0, False, DataType.float32, 4, False),  # No grad
+    (500, 1.0, 1.0, False, DataType.float32, 4, True),  # Accumulate
+    (500, 1.0, 4.0, False, DataType.float32, 4, False),  # Loss scaling
+    (500, 4.0, 1.0, False, DataType.float32, 4, False),  # Grad scaling
+    (500, 1.0, 1.0, True, DataType.float32, 4, False),  # Loss masking
+    (500, 1.0, 1.0, False, DataType.float16, 4, False),  # Fp16
+    (500, 1.0, 1.0, False, DataType.float32, 1, False),  # One segment
+    (500, 1.0, 1.0, True, DataType.float32, 16, True),  # Many segments + masking + accumulate
+)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("batch_shape", _BATCH_SHAPES)
+@pytest.mark.parametrize(
+    ("num_columns", "grad_output", "logits_scale_factor", "loss_masking", "dtype", "num_segments", "accumulate"),
+    _GSPO_PARAMETERS,
+)
+def test_gspo_loss(
+    batch_shape, num_columns, grad_output, logits_scale_factor, loss_masking, dtype, num_segments, accumulate
+):
+    _test_gspo_loss(
+        batch_shape, num_columns, grad_output, logits_scale_factor, loss_masking, dtype, num_segments, accumulate
     )
 
 

--- a/tests/utils/model_configs.py
+++ b/tests/utils/model_configs.py
@@ -720,10 +720,7 @@ update_and_add_testing_config(
     # `ms*` (micro_batch_splits>1) and `ce*` (cross_entropy_splits>1) both produce
     # multiple kernel calls per micro-batch; GSPO's per-document geometric mean can't be
     # reconstructed from per-fragment `exp(mean)` values, so we skip these variants.
-    # `bf16` exceeds the default tolerance against the fp32 baseline because GSPO's
-    # `exp(mean log_ratio)` amplifies bf16 noise on the small log-ratio values seen
-    # at initialization (fp16 with its larger mantissa still passes).
-    skip_tests=("ms", "ce", "bf16"),
+    skip_tests=("ms", "ce"),
     groups={
         ModelTestingGroup.basic: ModelTestingGroupAction.normal,
         ModelTestingGroup.checkpoint: ModelTestingGroupAction.not_implemented,

--- a/tests/utils/model_configs.py
+++ b/tests/utils/model_configs.py
@@ -714,6 +714,22 @@ update_and_add_testing_config(
 
 
 update_and_add_testing_config(
+    "llama",
+    "llama_gspo",
+    updates={("model", "base_model", "head", "losses"): {"gspo": {"type": "gspo"}}},
+    groups={
+        ModelTestingGroup.basic: ModelTestingGroupAction.normal,
+        ModelTestingGroup.checkpoint: ModelTestingGroupAction.not_implemented,
+        ModelTestingGroup.convert: ModelTestingGroupAction.not_implemented,
+        ModelTestingGroup.generate: ModelTestingGroupAction.not_implemented,
+        ModelTestingGroup.megatron: ModelTestingGroupAction.not_implemented,
+        ModelTestingGroup.distributed: ModelTestingGroupAction.normal,
+        ModelTestingGroup.streaming: ModelTestingGroupAction.normal,
+    },
+)
+
+
+update_and_add_testing_config(
     # Tests apriel 2 basic conversion.
     "llama",
     "apriel2_attn",

--- a/tests/utils/model_configs.py
+++ b/tests/utils/model_configs.py
@@ -717,11 +717,13 @@ update_and_add_testing_config(
     "llama",
     "llama_gspo",
     updates={("model", "base_model", "head", "losses"): {"gspo": {"type": "gspo"}}},
-    # GSPO's per-document geometric mean can't be reconstructed from per-fragment
-    # `exp(mean)` values, so documents must not be split across separate kernel calls.
-    # `micro_batch_splits > 1` (the `ms*` variants) is the only mechanism that splits documents
-    # outside of a single kernel call's SDP/SP all-reduce.
-    skip_tests=("ms",),
+    # `ms*` (micro_batch_splits>1) and `ce*` (cross_entropy_splits>1) both produce
+    # multiple kernel calls per micro-batch; GSPO's per-document geometric mean can't be
+    # reconstructed from per-fragment `exp(mean)` values, so we skip these variants.
+    # `bf16` exceeds the default tolerance against the fp32 baseline because GSPO's
+    # `exp(mean log_ratio)` amplifies bf16 noise on the small log-ratio values seen
+    # at initialization (fp16 with its larger mantissa still passes).
+    skip_tests=("ms", "ce", "bf16"),
     groups={
         ModelTestingGroup.basic: ModelTestingGroupAction.normal,
         ModelTestingGroup.checkpoint: ModelTestingGroupAction.not_implemented,

--- a/tests/utils/model_configs.py
+++ b/tests/utils/model_configs.py
@@ -717,6 +717,11 @@ update_and_add_testing_config(
     "llama",
     "llama_gspo",
     updates={("model", "base_model", "head", "losses"): {"gspo": {"type": "gspo"}}},
+    # GSPO's per-document geometric mean can't be reconstructed from per-fragment
+    # `exp(mean)` values, so documents must not be split across separate kernel calls.
+    # `micro_batch_splits > 1` (the `ms*` variants) is the only mechanism that splits documents
+    # outside of a single kernel call's SDP/SP all-reduce.
+    skip_tests=("ms",),
     groups={
         ModelTestingGroup.basic: ModelTestingGroupAction.normal,
         ModelTestingGroup.checkpoint: ModelTestingGroupAction.not_implemented,


### PR DESCRIPTION
## Summary

- Adds Group Sequence Policy Optimization (per-segment geometric-mean IS-ratio clipping) as a sibling to GRPO. Sequence-level surrogate, computed as a per-token sum so the softmax-chain backward and SDP partitioning fall out identically to GRPO.
- Extracts shared abstract bases (`LanguageModelPolicyGradientLossConfig` / `LanguageModelPolicyGradientLoss`) for the common scaffolding (epsilon_low/high, new_logprobs metric, preprocessing flags) and refactors GRPO to inherit from them.
- Lifts `document_index_q`/`document_index_k` from `MixerKwargs` up to `BlockKwargs` so the LM head can read them without depending on attention-namespaced keys.
- Renames `fast_llm/layers/language_model/loss/grpo.py` to `policy_gradient.py` (now contains both losses + shared base).

## Design notes

The GSPO kernel structurally parallels `fused_grpo_loss_forward_backward`:
1. Same softmax → predicted_logits → new_log_probs setup.
2. New mid-kernel block: scatter-add per-token `log_ratio`, `advantages`, and counts into per-segment buffers; optional SDP all-reduce of the three buffers; compute `R_s = exp(lrn_sum / token_count)` and `A_s = adv_sum / token_count` (detached).
3. Broadcast `R_s`, `A_s` back to per-token; per-token loss weight is `mask / token_count_s` so each segment contributes once to the sum.
4. Downstream loss and the softmax-chain backward are line-for-line identical to GRPO with `probability_ratio = R_{s(t)}` and per-token advantages replaced by `A_{s(t)}`.

The per-token decomposition gets SDP correctness "for free": each rank only sums contributions from its own tokens, so SUM-reducing at the `LossDef` level reproduces the canonical single-rank result with no `/sdp_size` correction.

No Triton variant yet — comes in a follow-up.

## Test plan

- [x] `pytest tests/layers/test_lm_losses.py::test_gspo_loss` — 20 cases (10 param sets × 2 batch shapes)
- [x] `pytest tests/layers/test_lm_losses.py::test_grpo_loss` — 20 cases pass after refactor
- [x] `pytest tests/layers/test_lm_losses.py::test_grpo_metrics` — 40 cases pass after rename
- [ ] End-to-end RL training run (not exercised by this PR)