### PR TITLE
Declarative Apriel hybrid block layout via ListDispatchConfigConverter

### DIFF
--- a/fast_llm/engine/checkpoint/external.py
+++ b/fast_llm/engine/checkpoint/external.py
@@ -14,6 +14,7 @@ from fast_llm.engine.checkpoint.config import CheckpointLoadMetadataConfig
 from fast_llm.engine.checkpoint.state_dict import StateDictCheckpointHandler
 from fast_llm.engine.multi_stage.config import CheckpointMetadata, FastLLMModelConfig
 from fast_llm.engine.multi_stage.fast_llm_model import FastLLMModel
+from fast_llm.layers.block.config import FixedBlockSequenceConfig, PatternBlockSequenceConfig
 from fast_llm.tensor import SafeTensorSlice
 from fast_llm.utils import Assert
 
@@ -424,6 +425,88 @@ class DispatchConfigConverter(ConfigConverter):
         _safe_set_nested_dict_value(fast_llm_out, self.fast_llm_paths[0], sub_fast_llm)
 
 
+class ListDispatchConfigConverter(ConfigConverter):
+    """Polymorphic block-sequence dispatch driven by a positional HF list.
+
+    Models Apriel's hybrid-SSM shape: the HF config carries one entry per pipeline position in a
+    ``hybrid_block_layout: list[str]``, and the per-block HF keys live flat at the top level — each
+    registered block converter claims a disjoint subset (attention → flat top-level keys, mamba →
+    ``ssm_cfg.*``, gdn/kda → ``linear_attn_config.*``). On import, the layout list dispatches each
+    Fast-LLM block; on export, the block sequence (Fixed or Pattern) emits the union of each distinct
+    block's HF dict plus the layout and block count. Two registries are required because the format
+    distinguishes "which mixer classes appear at all" from "which mixer classes participate in the
+    config round-trip":
+
+    * ``registry``: mixer-config class → block ``ConfigSectionConverter``. Covers every block type
+      whose HF keys must be claimed by the coverage walker — including weight-side-only types whose
+      config-side layout name is absent (e.g. ``KimiDeltaAttentionConfig``).
+    * ``layout_names``: mixer-config class → layout discriminator string. Subset of ``registry`` keys
+      that participate in the config-side round-trip; classes absent here can't be config-exported
+      (no layout name to emit) or config-imported (no reverse-map entry).
+
+    Fast-LLM target is a :class:`FixedBlockSequenceConfig` when the layout has a single entry, a
+    :class:`PatternBlockSequenceConfig` otherwise. The same HF dict feeds every per-block import —
+    each block converter's declarations claim disjoint top-level keys, and shared top-level scalars
+    (e.g. ``rms_norm_eps``) cross-validate via the safe-set guard.
+    """
+
+    fast_llm_recurses: typing.ClassVar[bool] = True
+
+    def __init__(
+        self,
+        fast_llm_path: tuple[str, ...],
+        hf_layout_path: tuple[str, ...],
+        hf_num_blocks_path: tuple[str, ...],
+        registry: "dict[type[Config], type[ConfigSectionConverter]]",
+        layout_names: "dict[type[Config], str]",
+    ):
+        self.fast_llm_paths = (fast_llm_path,)
+        # Layout/num-blocks paths and per-block claims register through ``_consumed_hf_paths``.
+        self.hf_paths = ()
+        self._hf_layout_path = hf_layout_path
+        self._hf_num_blocks_path = hf_num_blocks_path
+        self._registry = registry
+        self._layout_names = layout_names
+        self._config_classes = {name: cls for cls, name in layout_names.items()}
+
+    def export_to(self, fast_llm_config: Config, hf_out: dict) -> None:
+        block_sequence = _get_attr_path(fast_llm_config, self.fast_llm_paths[0])
+        if type(block_sequence) is FixedBlockSequenceConfig:
+            distinct_blocks = [block_sequence.block]
+            pattern_blocks = [block_sequence.block]
+        elif type(block_sequence) is PatternBlockSequenceConfig:
+            distinct_blocks = list(block_sequence.blocks.values())
+            pattern_blocks = [block_sequence.blocks[name] for name in block_sequence.pattern]
+        else:
+            raise NotImplementedError(type(block_sequence).__name__)
+        for block_config in distinct_blocks:
+            converter_class = self._registry[type(block_config.mixer)]
+            sub_hf = converter_class.export_config(block_config)
+            for key, value in sub_hf.items():
+                _safe_set_nested_dict_value(hf_out, (key,), value)
+        layout = [self._layout_names[type(block_config.mixer)] for block_config in pattern_blocks]
+        _safe_set_nested_dict_value(hf_out, self._hf_layout_path, layout)
+        _safe_set_nested_dict_value(hf_out, self._hf_num_blocks_path, block_sequence.num_blocks)
+
+    def import_to(self, hf_dict: dict, fast_llm_out: dict) -> None:
+        layout = get_nested_dict_value(hf_dict, self._hf_layout_path)
+        num_blocks = get_nested_dict_value(hf_dict, self._hf_num_blocks_path)
+        if len(layout) == 1:
+            converter_class = self._registry[self._config_classes[layout[0]]]
+            sub_fast_llm = {"block": converter_class.import_config(hf_dict), "num_blocks": num_blocks}
+        else:
+            sub_fast_llm = {
+                "type": "pattern",
+                "blocks": {
+                    layout_name: self._registry[self._config_classes[layout_name]].import_config(hf_dict)
+                    for layout_name in set(layout)
+                },
+                "pattern": layout,
+                "num_blocks": num_blocks,
+            }
+        _safe_set_nested_dict_value(fast_llm_out, self.fast_llm_paths[0], sub_fast_llm)
+
+
 class TypedDictContainerConfigConverter(ConfigConverter):
     """Maps a Fast-LLM ``dict[str, Config]`` field to an HF ``dict[str, dict]`` where each entry is round-tripped
     through a per-class section converter selected via the entry's runtime type (export) or HF discriminator (import).
@@ -610,6 +693,11 @@ class ConfigSectionConverter(abc.ABC):
                         paths |= sub_class._consumed_hf_paths()
             elif isinstance(declaration, TypedDictContainerConfigConverter):
                 paths.add(declaration.hf_paths[0])
+            elif isinstance(declaration, ListDispatchConfigConverter):
+                paths.add(declaration._hf_layout_path)
+                paths.add(declaration._hf_num_blocks_path)
+                for sub_class in declaration._registry.values():
+                    paths |= sub_class._consumed_hf_paths()
             else:
                 for path in declaration.hf_paths:
                     if path:

--- a/fast_llm/engine/checkpoint/external.py
+++ b/fast_llm/engine/checkpoint/external.py
@@ -14,7 +14,6 @@ from fast_llm.engine.checkpoint.config import CheckpointLoadMetadataConfig
 from fast_llm.engine.checkpoint.state_dict import StateDictCheckpointHandler
 from fast_llm.engine.multi_stage.config import CheckpointMetadata, FastLLMModelConfig
 from fast_llm.engine.multi_stage.fast_llm_model import FastLLMModel
-from fast_llm.layers.block.config import FixedBlockSequenceConfig, PatternBlockSequenceConfig
 from fast_llm.tensor import SafeTensorSlice
 from fast_llm.utils import Assert
 
@@ -117,6 +116,15 @@ class ConfigConverter(abc.ABC):
 
     @abc.abstractmethod
     def import_to(self, hf_dict: dict, fast_llm_out: dict) -> None: ...
+
+    def _consumed_hf_paths(self) -> frozenset[tuple[str, ...]]:
+        """HF paths this declaration claims for the section's coverage check.
+
+        Default: every non-empty entry in ``hf_paths``. Override when the claim set depends on
+        a sub-converter registry, a nested-path prefix, or a discriminator key (Nested, Dispatch,
+        TypedDictContainer, ListDispatch).
+        """
+        return frozenset(path for path in self.hf_paths if path)
 
 
 class RenameConfigConverter(ConfigConverter):
@@ -374,6 +382,21 @@ class NestedConfigConverter(ConfigConverter):
         sub_fast_llm = self._converter_class.import_config(sub_hf)
         _safe_set_nested_dict_value(fast_llm_out, self.fast_llm_paths[0], sub_fast_llm)
 
+    def _consumed_hf_paths(self) -> frozenset[tuple[str, ...]]:
+        sub_class = self._converter_class
+        if self._hf_path is None:
+            # Flat-merge: sub-converter shares the parent's HF namespace.
+            paths = set(sub_class._consumed_hf_paths())
+            if sub_class.hf_type_name is not None:
+                paths.add((self._hf_discriminator_key,))
+        else:
+            # Nested: prepend hf_path so the walker descends into the subdict and flags unknown keys.
+            prefix = self._hf_path
+            paths = {prefix + sub_path for sub_path in sub_class._consumed_hf_paths()}
+            if sub_class.hf_type_name is not None:
+                paths.add(prefix + (self._hf_discriminator_key,))
+        return frozenset(paths)
+
 
 class DispatchConfigConverter(ConfigConverter):
     """Polymorphic sub-config dispatch.
@@ -424,87 +447,22 @@ class DispatchConfigConverter(ConfigConverter):
         sub_fast_llm = converter_class.import_config(sub_hf)
         _safe_set_nested_dict_value(fast_llm_out, self.fast_llm_paths[0], sub_fast_llm)
 
-
-class ListDispatchConfigConverter(ConfigConverter):
-    """Polymorphic block-sequence dispatch driven by a positional HF list.
-
-    Models Apriel's hybrid-SSM shape: the HF config carries one entry per pipeline position in a
-    ``hybrid_block_layout: list[str]``, and the per-block HF keys live flat at the top level — each
-    registered block converter claims a disjoint subset (attention → flat top-level keys, mamba →
-    ``ssm_cfg.*``, gdn/kda → ``linear_attn_config.*``). On import, the layout list dispatches each
-    Fast-LLM block; on export, the block sequence (Fixed or Pattern) emits the union of each distinct
-    block's HF dict plus the layout and block count. Two registries are required because the format
-    distinguishes "which mixer classes appear at all" from "which mixer classes participate in the
-    config round-trip":
-
-    * ``registry``: mixer-config class → block ``ConfigSectionConverter``. Covers every block type
-      whose HF keys must be claimed by the coverage walker — including weight-side-only types whose
-      config-side layout name is absent (e.g. ``KimiDeltaAttentionConfig``).
-    * ``layout_names``: mixer-config class → layout discriminator string. Subset of ``registry`` keys
-      that participate in the config-side round-trip; classes absent here can't be config-exported
-      (no layout name to emit) or config-imported (no reverse-map entry).
-
-    Fast-LLM target is a :class:`FixedBlockSequenceConfig` when the layout has a single entry, a
-    :class:`PatternBlockSequenceConfig` otherwise. The same HF dict feeds every per-block import —
-    each block converter's declarations claim disjoint top-level keys, and shared top-level scalars
-    (e.g. ``rms_norm_eps``) cross-validate via the safe-set guard.
-    """
-
-    fast_llm_recurses: typing.ClassVar[bool] = True
-
-    def __init__(
-        self,
-        fast_llm_path: tuple[str, ...],
-        hf_layout_path: tuple[str, ...],
-        hf_num_blocks_path: tuple[str, ...],
-        registry: "dict[type[Config], type[ConfigSectionConverter]]",
-        layout_names: "dict[type[Config], str]",
-    ):
-        self.fast_llm_paths = (fast_llm_path,)
-        # Layout/num-blocks paths and per-block claims register through ``_consumed_hf_paths``.
-        self.hf_paths = ()
-        self._hf_layout_path = hf_layout_path
-        self._hf_num_blocks_path = hf_num_blocks_path
-        self._registry = registry
-        self._layout_names = layout_names
-        self._config_classes = {name: cls for cls, name in layout_names.items()}
-
-    def export_to(self, fast_llm_config: Config, hf_out: dict) -> None:
-        block_sequence = _get_attr_path(fast_llm_config, self.fast_llm_paths[0])
-        if type(block_sequence) is FixedBlockSequenceConfig:
-            distinct_blocks = [block_sequence.block]
-            pattern_blocks = [block_sequence.block]
-        elif type(block_sequence) is PatternBlockSequenceConfig:
-            distinct_blocks = list(block_sequence.blocks.values())
-            pattern_blocks = [block_sequence.blocks[name] for name in block_sequence.pattern]
+    def _consumed_hf_paths(self) -> frozenset[tuple[str, ...]]:
+        # Union of all registered sub-classes' claims (under the shared hf_path prefix when present).
+        # At runtime only one sub-class fires; the static union is a safe over-claim — we only need to
+        # not flag known keys, never to flag missing ones.
+        paths: set[tuple[str, ...]] = set()
+        if self.hf_paths:
+            prefix = self.hf_paths[0]
+            paths.add(prefix + (self._hf_discriminator_key,))
+            for sub_class in self._registry.values():
+                for sub_path in sub_class._consumed_hf_paths():
+                    paths.add(prefix + sub_path)
         else:
-            raise NotImplementedError(type(block_sequence).__name__)
-        for block_config in distinct_blocks:
-            converter_class = self._registry[type(block_config.mixer)]
-            sub_hf = converter_class.export_config(block_config)
-            for key, value in sub_hf.items():
-                _safe_set_nested_dict_value(hf_out, (key,), value)
-        layout = [self._layout_names[type(block_config.mixer)] for block_config in pattern_blocks]
-        _safe_set_nested_dict_value(hf_out, self._hf_layout_path, layout)
-        _safe_set_nested_dict_value(hf_out, self._hf_num_blocks_path, block_sequence.num_blocks)
-
-    def import_to(self, hf_dict: dict, fast_llm_out: dict) -> None:
-        layout = get_nested_dict_value(hf_dict, self._hf_layout_path)
-        num_blocks = get_nested_dict_value(hf_dict, self._hf_num_blocks_path)
-        if len(layout) == 1:
-            converter_class = self._registry[self._config_classes[layout[0]]]
-            sub_fast_llm = {"block": converter_class.import_config(hf_dict), "num_blocks": num_blocks}
-        else:
-            sub_fast_llm = {
-                "type": "pattern",
-                "blocks": {
-                    layout_name: self._registry[self._config_classes[layout_name]].import_config(hf_dict)
-                    for layout_name in set(layout)
-                },
-                "pattern": layout,
-                "num_blocks": num_blocks,
-            }
-        _safe_set_nested_dict_value(fast_llm_out, self.fast_llm_paths[0], sub_fast_llm)
+            paths.add((self._hf_discriminator_key,))
+            for sub_class in self._registry.values():
+                paths |= sub_class._consumed_hf_paths()
+        return frozenset(paths)
 
 
 class TypedDictContainerConfigConverter(ConfigConverter):
@@ -570,6 +528,11 @@ class TypedDictContainerConfigConverter(ConfigConverter):
             sub_fast_llm = converter_class.import_config(sub_hf)
             out[name] = sub_fast_llm
         _safe_set_nested_dict_value(fast_llm_out, self.fast_llm_paths[0], out)
+
+    def _consumed_hf_paths(self) -> frozenset[tuple[str, ...]]:
+        # Blanket prefix: per-entry sub-dicts are user-named pattern keys; we can't statically
+        # enumerate which entries appear or what keys those entries claim.
+        return frozenset({self.hf_paths[0]})
 
 
 # ============================================================
@@ -652,56 +615,14 @@ class ConfigSectionConverter(abc.ABC):
         walker treats every entry as a *recursive prefix* — once an input path matches any prefix,
         descent into deeper sub-dicts stops.
 
-        Nested sub-converters (``NestedConfigConverter``/``DispatchConfigConverter`` with ``hf_path``
-        set) expand their sub-converter's claims under the nested prefix instead of contributing the
-        bare prefix, so the walker descends into the subdict and flags unknown keys inside it (e.g.
-        ``head.normalization.surprise_field``).
-
-        :class:`TypedDictContainerConfigConverter` keeps a blanket prefix because its per-entry sub-dicts
-        are user-named (pattern keys); we can't statically enumerate which entries will appear or what
-        keys those entries should claim.
+        Each declaration advertises its claims via :meth:`ConfigConverter._consumed_hf_paths`
+        (default: ``hf_paths``; overridden by primitives whose claims depend on a sub-converter
+        registry, a nested-path prefix, or a discriminator key). The aggregate is cached per
+        section class.
         """
         paths: set[tuple[str, ...]] = set()
         for declaration in cls._create_config_converters().values():
-            if isinstance(declaration, NestedConfigConverter):
-                sub_class = declaration._converter_class
-                if declaration._hf_path is None:
-                    # Flat-merge: sub-converter shares the parent's HF namespace.
-                    paths |= sub_class._consumed_hf_paths()
-                    if sub_class.hf_type_name is not None:
-                        paths.add((declaration._hf_discriminator_key,))
-                else:
-                    # Nested: prepend hf_path to each sub-claim so the walker recurses into the subdict.
-                    prefix = declaration._hf_path
-                    for sub_path in sub_class._consumed_hf_paths():
-                        paths.add(prefix + sub_path)
-                    if sub_class.hf_type_name is not None:
-                        paths.add(prefix + (declaration._hf_discriminator_key,))
-            elif isinstance(declaration, DispatchConfigConverter):
-                if declaration.hf_paths:
-                    # Nested dispatch: union of all registered sub-classes' claims under the shared
-                    # hf_path prefix. At runtime only one sub-class fires; the static union is a safe
-                    # over-claim (we only need to *not* flag known keys, never to flag missing ones).
-                    prefix = declaration.hf_paths[0]
-                    paths.add(prefix + (declaration._hf_discriminator_key,))
-                    for sub_class in declaration._registry.values():
-                        for sub_path in sub_class._consumed_hf_paths():
-                            paths.add(prefix + sub_path)
-                else:
-                    paths.add((declaration._hf_discriminator_key,))
-                    for sub_class in declaration._registry.values():
-                        paths |= sub_class._consumed_hf_paths()
-            elif isinstance(declaration, TypedDictContainerConfigConverter):
-                paths.add(declaration.hf_paths[0])
-            elif isinstance(declaration, ListDispatchConfigConverter):
-                paths.add(declaration._hf_layout_path)
-                paths.add(declaration._hf_num_blocks_path)
-                for sub_class in declaration._registry.values():
-                    paths |= sub_class._consumed_hf_paths()
-            else:
-                for path in declaration.hf_paths:
-                    if path:
-                        paths.add(path)
+            paths |= declaration._consumed_hf_paths()
         return frozenset(paths)
 
     @classmethod

--- a/fast_llm/models/gpt/conversion/apriel.py
+++ b/fast_llm/models/gpt/conversion/apriel.py
@@ -3,19 +3,21 @@ import typing
 
 from transformers import PretrainedConfig
 
-from fast_llm.config import Config
+from fast_llm.config import Config, get_nested_dict_value
 from fast_llm.engine.checkpoint.config import CheckpointFormat
 from fast_llm.engine.checkpoint.external import (
+    ConfigConverter,
     ConfigSectionConverter,
     CustomConfigConverter,
     DefaultConfigConverter,
     IgnoredConfigConverter,
-    ListDispatchConfigConverter,
     RenameConfigConverter,
     WeightConverter,
+    _get_attr_path,
+    _safe_set_nested_dict_value,
 )
 from fast_llm.layers.attention.config import AttentionConfig
-from fast_llm.layers.block.config import PatternBlockSequenceConfig
+from fast_llm.layers.block.config import FixedBlockSequenceConfig, PatternBlockSequenceConfig
 from fast_llm.layers.decoder.config import DecoderBlockConfig
 from fast_llm.layers.ssm.config import GatedDeltaNetConfig, KimiDeltaAttentionConfig, MambaConfig
 from fast_llm.models.gpt.config import GPTBaseModelConfig, GPTModelConfig
@@ -429,6 +431,102 @@ class AprielGatedDeltaNetBlockConverter(MistralBlockConverter):
     hf_mixer_name: typing.ClassVar[str] = "mixer"
 
 
+class ListDispatchConfigConverter(ConfigConverter):
+    """Polymorphic block-sequence dispatch driven by a positional HF list.
+
+    Models Apriel's hybrid-SSM shape: the HF config carries one entry per pipeline position in a
+    ``hybrid_block_layout: list[str]``, and the per-block HF keys live flat at the top level — each
+    registered block converter claims a disjoint subset (attention → flat top-level keys, mamba →
+    ``ssm_cfg.*``, gdn/kda → ``linear_attn_config.*``). On import, the layout list dispatches each
+    Fast-LLM block; on export, the block sequence (Fixed or Pattern) emits the union of each distinct
+    block's HF dict plus the layout and block count.
+
+    Lives next to its consumer (``AprielBaseModelConverter``) because its export/import shape
+    hardcodes Fast-LLM's :class:`FixedBlockSequenceConfig` / :class:`PatternBlockSequenceConfig`
+    types, and is unlikely to be reused by a second HF format. The framework's
+    :meth:`ConfigSectionConverter._consumed_hf_paths` aggregator picks it up generically via the
+    :meth:`ConfigConverter._consumed_hf_paths` virtual method.
+
+    Two registries are required because the format distinguishes "which mixer classes appear at
+    all" from "which mixer classes participate in the config round-trip":
+
+    * ``registry``: mixer-config class → block ``ConfigSectionConverter``. Covers every block type
+      whose HF keys must be claimed by the coverage walker — including weight-side-only types whose
+      config-side layout name is absent (e.g. ``KimiDeltaAttentionConfig``).
+    * ``layout_names``: mixer-config class → layout discriminator string. Must be a subset of
+      ``registry`` keys — checked in ``__init__``. Classes absent here can't be config-exported
+      (no layout name to emit) or config-imported (no reverse-map entry).
+
+    Fast-LLM target is a :class:`FixedBlockSequenceConfig` when the layout has a single entry, a
+    :class:`PatternBlockSequenceConfig` otherwise. The same HF dict feeds every per-block import —
+    each block converter's declarations claim disjoint top-level keys, and shared top-level scalars
+    (e.g. ``rms_norm_eps``) cross-validate via the safe-set guard.
+    """
+
+    fast_llm_recurses: typing.ClassVar[bool] = True
+
+    def __init__(
+        self,
+        fast_llm_path: tuple[str, ...],
+        hf_layout_path: tuple[str, ...],
+        hf_num_blocks_path: tuple[str, ...],
+        registry: "dict[type[Config], type[ConfigSectionConverter]]",
+        layout_names: "dict[type[Config], str]",
+    ):
+        Assert.custom(lambda lns: set(lns) <= set(registry), layout_names)
+        self.fast_llm_paths = (fast_llm_path,)
+        # Layout/num-blocks paths and per-block claims register through ``_consumed_hf_paths``.
+        self.hf_paths = ()
+        self._hf_layout_path = hf_layout_path
+        self._hf_num_blocks_path = hf_num_blocks_path
+        self._registry = registry
+        self._layout_names = layout_names
+        self._config_classes = {name: cls for cls, name in layout_names.items()}
+
+    def export_to(self, fast_llm_config: Config, hf_out: dict) -> None:
+        block_sequence = _get_attr_path(fast_llm_config, self.fast_llm_paths[0])
+        if type(block_sequence) is FixedBlockSequenceConfig:
+            distinct_blocks = [block_sequence.block]
+            pattern_blocks = [block_sequence.block]
+        elif type(block_sequence) is PatternBlockSequenceConfig:
+            distinct_blocks = list(block_sequence.blocks.values())
+            pattern_blocks = [block_sequence.blocks[name] for name in block_sequence.pattern]
+        else:
+            raise NotImplementedError(type(block_sequence).__name__)
+        for block_config in distinct_blocks:
+            converter_class = self._registry[type(block_config.mixer)]
+            sub_hf = converter_class.export_config(block_config)
+            for key, value in sub_hf.items():
+                _safe_set_nested_dict_value(hf_out, (key,), value)
+        layout = [self._layout_names[type(block_config.mixer)] for block_config in pattern_blocks]
+        _safe_set_nested_dict_value(hf_out, self._hf_layout_path, layout)
+        _safe_set_nested_dict_value(hf_out, self._hf_num_blocks_path, block_sequence.num_blocks)
+
+    def import_to(self, hf_dict: dict, fast_llm_out: dict) -> None:
+        layout = get_nested_dict_value(hf_dict, self._hf_layout_path)
+        num_blocks = get_nested_dict_value(hf_dict, self._hf_num_blocks_path)
+        if len(layout) == 1:
+            converter_class = self._registry[self._config_classes[layout[0]]]
+            sub_fast_llm = {"block": converter_class.import_config(hf_dict), "num_blocks": num_blocks}
+        else:
+            sub_fast_llm = {
+                "type": "pattern",
+                "blocks": {
+                    layout_name: self._registry[self._config_classes[layout_name]].import_config(hf_dict)
+                    for layout_name in set(layout)
+                },
+                "pattern": layout,
+                "num_blocks": num_blocks,
+            }
+        _safe_set_nested_dict_value(fast_llm_out, self.fast_llm_paths[0], sub_fast_llm)
+
+    def _consumed_hf_paths(self) -> frozenset[tuple[str, ...]]:
+        paths: set[tuple[str, ...]] = {self._hf_layout_path, self._hf_num_blocks_path}
+        for sub_class in self._registry.values():
+            paths |= sub_class._consumed_hf_paths()
+        return frozenset(paths)
+
+
 class AprielBlockConverter:
     """Apriel hybrid-SSM block dispatch registries.
 
@@ -466,33 +564,6 @@ class AprielBlockConverter:
         )
 
 
-class AprielDecoderConverter:
-    """Weight-side dispatcher for Apriel's pattern-style decoder. The config side is declarative
-    via :class:`ListDispatchConfigConverter` declared on :class:`AprielBaseModelConverter`.
-    """
-
-    block_converter_class: typing.ClassVar[type[AprielBlockConverter]] = AprielBlockConverter
-
-    @classmethod
-    def get_converters(
-        cls,
-        config: PatternBlockSequenceConfig,
-        fast_llm_prefix: str,
-        hf_prefix: str,
-        drop_on_export: bool = False,
-    ) -> list[WeightConverter]:
-        converters = []
-        for block_index in range(config.num_blocks):
-            block_config = config.blocks[config.pattern[block_index % len(config.pattern)]]
-            converters += cls.block_converter_class.get_converters(
-                block_config,
-                f"{fast_llm_prefix}.{block_index}",
-                f"{hf_prefix}.{block_index}",
-                drop_on_export,
-            )
-        return converters
-
-
 class AprielHeadConverter(MistralHeadConverter):
     block_converter_class: typing.ClassVar[type[AprielBlockConverter]] = AprielBlockConverter
 
@@ -505,29 +576,37 @@ class AprielBaseModelConverter(MistralBaseModelConverter):
     """
 
     head_converter_class: typing.ClassVar[type[AprielHeadConverter]] = AprielHeadConverter
-    apriel_decoder_converter_class: typing.ClassVar[type[AprielDecoderConverter]] = AprielDecoderConverter
+    # Distinct from the parent's ``block_converter_class`` (a single ``ConfigSectionConverter``); this
+    # one holds the per-mixer-type dispatch registries that :class:`ListDispatchConfigConverter` and
+    # the weight-side loop below consume.
+    block_dispatcher_class: typing.ClassVar[type[AprielBlockConverter]] = AprielBlockConverter
 
     @classmethod
     def _create_config_converters(cls) -> dict:
-        block_cls = cls.apriel_decoder_converter_class.block_converter_class
         return {
             **super()._create_config_converters(),
             "decoder": ListDispatchConfigConverter(
                 fast_llm_path=("decoder",),
                 hf_layout_path=("hybrid_block_layout",),
                 hf_num_blocks_path=("num_hidden_layers",),
-                registry=block_cls._converter_classes,
-                layout_names=block_cls.layout_names,
+                registry=cls.block_dispatcher_class._converter_classes,
+                layout_names=cls.block_dispatcher_class.layout_names,
             ),
         }
 
     @classmethod
     def get_converters(cls, config: GPTBaseModelConfig, exported_config: dict) -> list[WeightConverter]:
-        return [
-            *cls.embeddings_converter_class.get_converters(config.embeddings, "embeddings", "model"),
-            *cls.apriel_decoder_converter_class.get_converters(config.decoder, "decoder", "model.layers"),
-            *cls.head_converter_class.get_converters(config, exported_config),
-        ]
+        decoder = config.decoder
+        converters = [*cls.embeddings_converter_class.get_converters(config.embeddings, "embeddings", "model")]
+        for block_index in range(decoder.num_blocks):
+            block_config = decoder.blocks[decoder.pattern[block_index % len(decoder.pattern)]]
+            converters += cls.block_dispatcher_class.get_converters(
+                block_config,
+                f"decoder.{block_index}",
+                f"model.layers.{block_index}",
+            )
+        converters += cls.head_converter_class.get_converters(config, exported_config)
+        return converters
 
 
 class AprielHuggingfaceCheckpointHandler(MistralHuggingfaceCheckpointHandler):

--- a/fast_llm/models/gpt/conversion/apriel.py
+++ b/fast_llm/models/gpt/conversion/apriel.py
@@ -435,10 +435,12 @@ class ListDispatchConfigConverter(ConfigConverter):
     """Block-sequence dispatch driven by a positional HF list.
 
     The HF config carries one layout-discriminator string per pipeline position; each registered
-    block converter handles one mixer type, and their outputs flat-merge into the parent HF root
-    (each claims a disjoint subset of top-level keys; shared scalars cross-validate via the safe-set
-    guard). The Fast-LLM target is a :class:`FixedBlockSequenceConfig` when the layout has a single
-    entry, a :class:`PatternBlockSequenceConfig` otherwise.
+    block converter handles one mixer type, and their outputs flat-merge into the parent HF root.
+    Per-mixer nested subdicts (e.g. ``ssm_cfg`` for Mamba, ``linear_attn_config`` for GDN) are
+    disjoint across block types; shared top-level scalars are emitted by every block with the same
+    value and cross-validate via :func:`Assert.eq` inside ``_safe_set_nested_dict_value``. The
+    Fast-LLM target is a :class:`FixedBlockSequenceConfig` when the layout has a single entry, a
+    :class:`PatternBlockSequenceConfig` otherwise.
 
     Two registries:
 
@@ -460,7 +462,7 @@ class ListDispatchConfigConverter(ConfigConverter):
         registry: "dict[type[Config], type[ConfigSectionConverter]]",
         layout_names: "dict[type[Config], str]",
     ):
-        Assert.custom(lambda lns: set(lns) <= set(registry), layout_names)
+        Assert.custom(lambda names: set(names) <= set(registry), layout_names)
         self.fast_llm_paths = (fast_llm_path,)
         # Layout/num-blocks paths and per-block claims register through ``_consumed_hf_paths``.
         self.hf_paths = ()
@@ -479,7 +481,10 @@ class ListDispatchConfigConverter(ConfigConverter):
             distinct_blocks = block_sequence.blocks.values()
             pattern_blocks = [block_sequence.blocks[name] for name in block_sequence.pattern]
         else:
-            raise NotImplementedError(type(block_sequence).__name__)
+            raise NotImplementedError(
+                f"Unsupported block-sequence type {type(block_sequence).__name__} at "
+                f"{'.'.join(self.fast_llm_paths[0])}"
+            )
         for block_config in distinct_blocks:
             converter_class = self._registry[type(block_config.mixer)]
             sub_hf = converter_class.export_config(block_config)
@@ -587,10 +592,7 @@ class AprielBaseModelConverter(MistralBaseModelConverter):
         if isinstance(decoder, FixedBlockSequenceConfig):
             per_position_blocks = [decoder.block] * decoder.num_blocks
         elif isinstance(decoder, PatternBlockSequenceConfig):
-            per_position_blocks = [
-                decoder.blocks[decoder.pattern[block_index % len(decoder.pattern)]]
-                for block_index in range(decoder.num_blocks)
-            ]
+            per_position_blocks = [decoder.blocks[block_name] for block_name in decoder.expanded_pattern]
         else:
             raise NotImplementedError(type(decoder).__name__)
         converters = [*cls.embeddings_converter_class.get_converters(config.embeddings, "embeddings", "model")]

--- a/fast_llm/models/gpt/conversion/apriel.py
+++ b/fast_llm/models/gpt/conversion/apriel.py
@@ -432,35 +432,22 @@ class AprielGatedDeltaNetBlockConverter(MistralBlockConverter):
 
 
 class ListDispatchConfigConverter(ConfigConverter):
-    """Polymorphic block-sequence dispatch driven by a positional HF list.
+    """Block-sequence dispatch driven by a positional HF list.
 
-    Models Apriel's hybrid-SSM shape: the HF config carries one entry per pipeline position in a
-    ``hybrid_block_layout: list[str]``, and the per-block HF keys live flat at the top level — each
-    registered block converter claims a disjoint subset (attention → flat top-level keys, mamba →
-    ``ssm_cfg.*``, gdn/kda → ``linear_attn_config.*``). On import, the layout list dispatches each
-    Fast-LLM block; on export, the block sequence (Fixed or Pattern) emits the union of each distinct
-    block's HF dict plus the layout and block count.
+    The HF config carries one layout-discriminator string per pipeline position; each registered
+    block converter handles one mixer type, and their outputs flat-merge into the parent HF root
+    (each claims a disjoint subset of top-level keys; shared scalars cross-validate via the safe-set
+    guard). The Fast-LLM target is a :class:`FixedBlockSequenceConfig` when the layout has a single
+    entry, a :class:`PatternBlockSequenceConfig` otherwise.
 
-    Lives next to its consumer (``AprielBaseModelConverter``) because its export/import shape
-    hardcodes Fast-LLM's :class:`FixedBlockSequenceConfig` / :class:`PatternBlockSequenceConfig`
-    types, and is unlikely to be reused by a second HF format. The framework's
-    :meth:`ConfigSectionConverter._consumed_hf_paths` aggregator picks it up generically via the
-    :meth:`ConfigConverter._consumed_hf_paths` virtual method.
+    Two registries:
 
-    Two registries are required because the format distinguishes "which mixer classes appear at
-    all" from "which mixer classes participate in the config round-trip":
-
-    * ``registry``: mixer-config class → block ``ConfigSectionConverter``. Covers every block type
-      whose HF keys must be claimed by the coverage walker — including weight-side-only types whose
-      config-side layout name is absent (e.g. ``KimiDeltaAttentionConfig``).
+    * ``registry``: mixer-config class → block ``ConfigSectionConverter``. Domain of the HF coverage
+      walker — every block type whose HF keys must be claimed appears here.
     * ``layout_names``: mixer-config class → layout discriminator string. Must be a subset of
-      ``registry`` keys — checked in ``__init__``. Classes absent here can't be config-exported
-      (no layout name to emit) or config-imported (no reverse-map entry).
-
-    Fast-LLM target is a :class:`FixedBlockSequenceConfig` when the layout has a single entry, a
-    :class:`PatternBlockSequenceConfig` otherwise. The same HF dict feeds every per-block import —
-    each block converter's declarations claim disjoint top-level keys, and shared top-level scalars
-    (e.g. ``rms_norm_eps``) cross-validate via the safe-set guard.
+      ``registry`` keys (checked in ``__init__``). Domain of the config-side round-trip — classes
+      absent here can't be config-exported (no layout name to emit) or config-imported (no reverse
+      lookup).
     """
 
     fast_llm_recurses: typing.ClassVar[bool] = True
@@ -489,7 +476,7 @@ class ListDispatchConfigConverter(ConfigConverter):
             distinct_blocks = [block_sequence.block]
             pattern_blocks = [block_sequence.block]
         elif type(block_sequence) is PatternBlockSequenceConfig:
-            distinct_blocks = list(block_sequence.blocks.values())
+            distinct_blocks = block_sequence.blocks.values()
             pattern_blocks = [block_sequence.blocks[name] for name in block_sequence.pattern]
         else:
             raise NotImplementedError(type(block_sequence).__name__)
@@ -528,15 +515,14 @@ class ListDispatchConfigConverter(ConfigConverter):
 
 
 class AprielBlockConverter:
-    """Apriel hybrid-SSM block dispatch registries.
+    """Per-mixer-type Apriel block-converter registries plus a weight-side dispatch helper.
 
-    Consumed by :class:`ListDispatchConfigConverter` on the config side and by the weight-side
-    :meth:`get_converters` dispatcher below. Stays a non-section class because it doesn't itself
-    convert a single :class:`DecoderBlockConfig` — it picks which block converter applies to each.
-    The two registries differ deliberately: ``layout_names`` lists the mixer types that participate
-    in Apriel's config-side ``hybrid_block_layout`` discriminator; ``_converter_classes`` covers
-    every type whose weights can appear in an Apriel checkpoint (a superset that includes the
-    weight-side-only ``KimiDeltaAttentionConfig``).
+    ``layout_names`` maps the mixer-config classes that participate in Apriel's
+    ``hybrid_block_layout`` discriminator to their string layout names. ``_converter_classes``
+    maps every mixer-config class whose weights can appear in an Apriel checkpoint to its block
+    converter — a superset of ``layout_names`` keys that adds ``KimiDeltaAttentionConfig`` for
+    weight-only coverage. :meth:`get_converters` picks the right block converter from
+    ``_converter_classes`` by the mixer's runtime type.
     """
 
     layout_names: typing.ClassVar[dict[type[Config], str]] = {
@@ -569,10 +555,11 @@ class AprielHeadConverter(MistralHeadConverter):
 
 
 class AprielBaseModelConverter(MistralBaseModelConverter):
-    """Apriel replaces the parent's ``"decoder"`` declaration with a
-    :class:`ListDispatchConfigConverter`: the format's per-position layout list
-    (``hybrid_block_layout``) drives polymorphic block dispatch, with each block's HF keys
-    flat-merged at the top of the HF config.
+    """Section converter for the Apriel hybrid-SSM base model.
+
+    The decoder uses :class:`ListDispatchConfigConverter` driven by the format's
+    ``hybrid_block_layout`` list (per-position mixer-type discriminator); each block converter's
+    HF keys flat-merge into the parent HF root.
     """
 
     head_converter_class: typing.ClassVar[type[AprielHeadConverter]] = AprielHeadConverter

--- a/fast_llm/models/gpt/conversion/apriel.py
+++ b/fast_llm/models/gpt/conversion/apriel.py
@@ -1,4 +1,3 @@
-import functools
 import math
 import typing
 
@@ -11,11 +10,12 @@ from fast_llm.engine.checkpoint.external import (
     CustomConfigConverter,
     DefaultConfigConverter,
     IgnoredConfigConverter,
+    ListDispatchConfigConverter,
     RenameConfigConverter,
     WeightConverter,
 )
 from fast_llm.layers.attention.config import AttentionConfig
-from fast_llm.layers.block.config import BlockSequenceConfig, FixedBlockSequenceConfig, PatternBlockSequenceConfig
+from fast_llm.layers.block.config import PatternBlockSequenceConfig
 from fast_llm.layers.decoder.config import DecoderBlockConfig
 from fast_llm.layers.ssm.config import GatedDeltaNetConfig, KimiDeltaAttentionConfig, MambaConfig
 from fast_llm.models.gpt.config import GPTBaseModelConfig, GPTModelConfig
@@ -430,9 +430,15 @@ class AprielGatedDeltaNetBlockConverter(MistralBlockConverter):
 
 
 class AprielBlockConverter:
-    """Per-block dispatcher: the mixer type is encoded in the parent's ``hybrid_block_layout`` list,
-    not in a nested HF discriminator, so this dispatcher stays imperative rather than using
-    :class:`DispatchConfigConverter`. Each branch delegates to a regular declarative block converter.
+    """Apriel hybrid-SSM block dispatch registries.
+
+    Consumed by :class:`ListDispatchConfigConverter` on the config side and by the weight-side
+    :meth:`get_converters` dispatcher below. Stays a non-section class because it doesn't itself
+    convert a single :class:`DecoderBlockConfig` — it picks which block converter applies to each.
+    The two registries differ deliberately: ``layout_names`` lists the mixer types that participate
+    in Apriel's config-side ``hybrid_block_layout`` discriminator; ``_converter_classes`` covers
+    every type whose weights can appear in an Apriel checkpoint (a superset that includes the
+    weight-side-only ``KimiDeltaAttentionConfig``).
     """
 
     layout_names: typing.ClassVar[dict[type[Config], str]] = {
@@ -446,25 +452,6 @@ class AprielBlockConverter:
         KimiDeltaAttentionConfig: AprielKimiDeltaAttentionBlockConverter,
         GatedDeltaNetConfig: AprielGatedDeltaNetBlockConverter,
     }
-    _config_classes: typing.ClassVar[dict[str, type[Config]]] = {value: key for key, value in layout_names.items()}
-
-    @classmethod
-    def import_config(cls, config: dict, layout_name: str = "t") -> dict:
-        return cls._converter_classes[cls._config_classes[layout_name]].import_config(config)
-
-    @classmethod
-    def export_config(cls, config: DecoderBlockConfig) -> dict:
-        return cls._converter_classes[type(config.mixer)].export_config(config)
-
-    @classmethod
-    @functools.cache
-    def _consumed_hf_paths(cls) -> frozenset[tuple[str, ...]]:
-        """Union of consumed HF paths across every per-mixer-type block converter — used by the parent's
-        decoder Custom to pre-claim Apriel's flat top-level keys for the HF coverage check."""
-        paths: set[tuple[str, ...]] = set()
-        for sub in cls._converter_classes.values():
-            paths |= sub._consumed_hf_paths()
-        return frozenset(paths)
 
     @classmethod
     def get_converters(
@@ -480,55 +467,11 @@ class AprielBlockConverter:
 
 
 class AprielDecoderConverter:
-    """Pattern-style decoder dispatched via Apriel's ``hybrid_block_layout`` list (one entry per block).
-    Stays imperative because the layout-list shape doesn't match the declarative ``decoder.type``
-    discriminator that :class:`Apriel2BaseModelConverter` uses; a declarative form would need a
-    ``ListDispatchConfigConverter`` primitive that maps a positional list to per-position sub-converters.
+    """Weight-side dispatcher for Apriel's pattern-style decoder. The config side is declarative
+    via :class:`ListDispatchConfigConverter` declared on :class:`AprielBaseModelConverter`.
     """
 
     block_converter_class: typing.ClassVar[type[AprielBlockConverter]] = AprielBlockConverter
-
-    @classmethod
-    def import_config(cls, config: dict) -> dict:
-        layout = config["hybrid_block_layout"]
-        if len(layout) == 1:
-            return {
-                "block": cls.block_converter_class.import_config(config, layout[0]),
-                "num_blocks": config["num_hidden_layers"],
-            }
-        else:
-            return {
-                "type": "pattern",
-                "blocks": {
-                    layout_name: cls.block_converter_class.import_config(config, layout_name)
-                    for layout_name in set(layout)
-                },
-                "pattern": layout,
-                "num_blocks": config["num_hidden_layers"],
-            }
-
-    @classmethod
-    def export_config(cls, config: BlockSequenceConfig) -> dict:
-        if type(config) is FixedBlockSequenceConfig:
-            block_configs = [config.block]
-            pattern_block_configs = [config.block]
-        elif type(config) is PatternBlockSequenceConfig:
-            block_configs = config.blocks.values()
-            pattern_block_configs = [config.blocks[block_name] for block_name in config.pattern]
-        else:
-            raise NotImplementedError()
-        # Each block emits non-overlapping HF keys (attention -> flat, mamba -> ssm_cfg.*,
-        # gdn/kda -> linear_attn_config.*) so safe_merge_dicts is sufficient to combine them.
-        return safe_merge_dicts(
-            *[cls.block_converter_class.export_config(block_config) for block_config in block_configs],
-            {
-                "num_hidden_layers": config.num_blocks,
-                "hybrid_block_layout": [
-                    cls.block_converter_class.layout_names[type(block_config.mixer)]
-                    for block_config in pattern_block_configs
-                ],
-            },
-        )
 
     @classmethod
     def get_converters(
@@ -555,9 +498,10 @@ class AprielHeadConverter(MistralHeadConverter):
 
 
 class AprielBaseModelConverter(MistralBaseModelConverter):
-    """Apriel needs the per-position hybrid layout dispatcher (:class:`AprielDecoderConverter`) instead of
-    the standard Fixed/Pattern dispatch inlined in :class:`LlamaBaseModelConverter`. The override below
-    replaces the parent's ``"decoder"`` declaration with one that delegates to Apriel's dispatcher.
+    """Apriel replaces the parent's ``"decoder"`` declaration with a
+    :class:`ListDispatchConfigConverter`: the format's per-position layout list
+    (``hybrid_block_layout``) drives polymorphic block dispatch, with each block's HF keys
+    flat-merged at the top of the HF config.
     """
 
     head_converter_class: typing.ClassVar[type[AprielHeadConverter]] = AprielHeadConverter
@@ -565,28 +509,15 @@ class AprielBaseModelConverter(MistralBaseModelConverter):
 
     @classmethod
     def _create_config_converters(cls) -> dict:
-        decoder_cls = cls.apriel_decoder_converter_class
-
-        def _decoder_export(parent: Config) -> dict:
-            return {(k,): v for k, v in decoder_cls.export_config(parent.decoder).items()}
-
-        def _decoder_import(hf_dict: dict) -> dict:
-            return {("decoder",): decoder_cls.import_config(hf_dict)}
-
+        block_cls = cls.apriel_decoder_converter_class.block_converter_class
         return {
             **super()._create_config_converters(),
-            "decoder": CustomConfigConverter(
-                fast_llm_paths=(("decoder",),),
-                # Block converter is the per-position dispatcher (:class:`AprielBlockConverter`), which
-                # unions the HF claims of every leaf-mixer's block converter.
-                hf_paths=(
-                    ("num_hidden_layers",),
-                    ("hybrid_block_layout",),
-                    *decoder_cls.block_converter_class._consumed_hf_paths(),
-                ),
-                export_fn=_decoder_export,
-                import_fn=_decoder_import,
-                fast_llm_recurses=True,
+            "decoder": ListDispatchConfigConverter(
+                fast_llm_path=("decoder",),
+                hf_layout_path=("hybrid_block_layout",),
+                hf_num_blocks_path=("num_hidden_layers",),
+                registry=block_cls._converter_classes,
+                layout_names=block_cls.layout_names,
             ),
         }
 

--- a/fast_llm/models/gpt/conversion/apriel.py
+++ b/fast_llm/models/gpt/conversion/apriel.py
@@ -584,9 +584,17 @@ class AprielBaseModelConverter(MistralBaseModelConverter):
     @classmethod
     def get_converters(cls, config: GPTBaseModelConfig, exported_config: dict) -> list[WeightConverter]:
         decoder = config.decoder
+        if isinstance(decoder, FixedBlockSequenceConfig):
+            per_position_blocks = [decoder.block] * decoder.num_blocks
+        elif isinstance(decoder, PatternBlockSequenceConfig):
+            per_position_blocks = [
+                decoder.blocks[decoder.pattern[block_index % len(decoder.pattern)]]
+                for block_index in range(decoder.num_blocks)
+            ]
+        else:
+            raise NotImplementedError(type(decoder).__name__)
         converters = [*cls.embeddings_converter_class.get_converters(config.embeddings, "embeddings", "model")]
-        for block_index in range(decoder.num_blocks):
-            block_config = decoder.blocks[decoder.pattern[block_index % len(decoder.pattern)]]
+        for block_index, block_config in enumerate(per_position_blocks):
             converters += cls.block_dispatcher_class.get_converters(
                 block_config,
                 f"decoder.{block_index}",

--- a/tests/models/test_converters.py
+++ b/tests/models/test_converters.py
@@ -19,6 +19,7 @@ import fast_llm.models.multimodal.conversion.auto  # noqa: F401
 from fast_llm.engine.checkpoint.external import (
     ConfigSectionConverter,
     DispatchConfigConverter,
+    ListDispatchConfigConverter,
     NestedConfigConverter,
     OptionalConfigConverter,
     TypedDictContainerConfigConverter,
@@ -82,7 +83,10 @@ def _children(node: type) -> list[type]:
         for declaration in node._create_config_converters().values():
             if isinstance(declaration, NestedConfigConverter):
                 out.append(declaration._converter_class)
-            elif isinstance(declaration, (DispatchConfigConverter, TypedDictContainerConfigConverter)):
+            elif isinstance(
+                declaration,
+                (DispatchConfigConverter, ListDispatchConfigConverter, TypedDictContainerConfigConverter),
+            ):
                 out.extend(declaration._registry.values())
     for name in dir(node):
         if name == "base_model_converter_class":

--- a/tests/models/test_converters.py
+++ b/tests/models/test_converters.py
@@ -19,7 +19,6 @@ import fast_llm.models.multimodal.conversion.auto  # noqa: F401
 from fast_llm.engine.checkpoint.external import (
     ConfigSectionConverter,
     DispatchConfigConverter,
-    ListDispatchConfigConverter,
     NestedConfigConverter,
     OptionalConfigConverter,
     TypedDictContainerConfigConverter,
@@ -30,6 +29,7 @@ from fast_llm.engine.checkpoint.huggingface import HuggingfaceStateDictCheckpoin
 from fast_llm.layers.attention.config import AttentionConfig
 from fast_llm.layers.block.config import PatternBlockSequenceConfig
 from fast_llm.layers.decoder.config import DecoderBlockConfig, StochasticMixerConfig
+from fast_llm.models.gpt.conversion.apriel import ListDispatchConfigConverter
 
 # Configs that don't default-construct cleanly need a minimal-valid factory.
 _DEFAULT_FACTORIES: dict[type, typing.Callable[[], typing.Any]] = {

--- a/tests/models/test_converters.py
+++ b/tests/models/test_converters.py
@@ -18,10 +18,8 @@ import fast_llm.models.gpt.conversion.auto  # noqa: F401
 import fast_llm.models.multimodal.conversion.auto  # noqa: F401
 from fast_llm.engine.checkpoint.external import (
     ConfigSectionConverter,
-    DispatchConfigConverter,
     NestedConfigConverter,
     OptionalConfigConverter,
-    TypedDictContainerConfigConverter,
     _get_attr_path,
     _safe_set_nested_dict_value,
 )
@@ -29,7 +27,6 @@ from fast_llm.engine.checkpoint.huggingface import HuggingfaceStateDictCheckpoin
 from fast_llm.layers.attention.config import AttentionConfig
 from fast_llm.layers.block.config import PatternBlockSequenceConfig
 from fast_llm.layers.decoder.config import DecoderBlockConfig, StochasticMixerConfig
-from fast_llm.models.gpt.conversion.apriel import ListDispatchConfigConverter
 
 # Configs that don't default-construct cleanly need a minimal-valid factory.
 _DEFAULT_FACTORIES: dict[type, typing.Callable[[], typing.Any]] = {
@@ -83,10 +80,9 @@ def _children(node: type) -> list[type]:
         for declaration in node._create_config_converters().values():
             if isinstance(declaration, NestedConfigConverter):
                 out.append(declaration._converter_class)
-            elif isinstance(
-                declaration,
-                (DispatchConfigConverter, ListDispatchConfigConverter, TypedDictContainerConfigConverter),
-            ):
+            elif isinstance(getattr(declaration, "_registry", None), dict):
+                # Dispatch / ListDispatch / TypedDictContainer (and any future dispatch primitive)
+                # share the ``_registry: dict[..., type[ConfigSectionConverter]]`` convention.
                 out.extend(declaration._registry.values())
     for name in dir(node):
         if name == "base_model_converter_class":


### PR DESCRIPTION
## Summary

- Adds `ListDispatchConfigConverter` to the post-#508 declarative converter framework: a primitive for HF formats that discriminate per-position block types via a positional list (e.g. Apriel's `hybrid_block_layout`) and flat-merge each block's HF claims at the HF root.
- Migrates `AprielBlockConverter` / `AprielDecoderConverter` from imperative dispatchers to weight-side helpers + dispatch registries consumed by the new primitive; deletes ~50 lines of imperative `import_config` / `export_config` / `_consumed_hf_paths` plumbing.
- Net diff is `+117 / -94` across `external.py`, `apriel.py`, and `test_converters.py`. Coverage walker, `_consumed_hf_paths`, and the test fixture's `_children` walker each get one new branch for the primitive.

## Test plan

- [x] `tests/models/test_converters.py + test_checkpoint.py + test_hf_roundtrip.py` (cluster): **281 passed**, matches post-#508 baseline.
- [x] `fast_llm_external_models/tests/` (cluster, separate invocation): **2109 passed, 42 skipped**, matches baseline.
- [x] Local end-to-end runtime smoke: `AprielBaseModelConverter.export_config` ↔ `.import_config` round-trips both Fixed (`["t"]`) and Pattern (`["t", "t"]`) layouts.