### PR TITLE
Workflow conventions: review headers and explanatory-text rule

### DIFF
--- a/.claude/commands/review-coarse.md
+++ b/.claude/commands/review-coarse.md
@@ -26,6 +26,8 @@ On a follow-up review after fixes have been pushed, run `git diff <last-reviewed
 
 ## Output
 
+Begin with a single-line header: `## /review-coarse @ <short-sha>` (use `git rev-parse --short HEAD`). This identifies the output when pasted into another session for triage.
+
 Each numbered item must stand on its own as a concrete, actionable finding — a specific change to make or a clear problem to fix, phrased so `fix N` is a complete instruction. Prefer a single recommendation; only present alternatives ("either X or Y") when both are genuinely viable and you can't justify picking one.
 
 Keep each item's lead to **1–3 sentences**: location, what's wrong, what to do. Trust the reader to read the code — don't explain how the bug would manifest, walk through the data flow, justify why the current code is wrong beyond a brief phrase, or compare fix options inside the lead.

--- a/.claude/commands/review-fine.md
+++ b/.claude/commands/review-fine.md
@@ -22,6 +22,8 @@ On a follow-up review after fixes have been pushed, run `git diff <last-reviewed
 
 ## Output
 
+Begin with a single-line header: `## /review-fine @ <short-sha>` (use `git rev-parse --short HEAD`). This identifies the output when pasted into another session for triage.
+
 Each numbered item must stand on its own as a concrete, actionable finding — a specific change to make or a clear problem to fix, phrased so `fix N` is a complete instruction. Prefer a single recommendation; only present alternatives ("either X or Y") when both are genuinely viable and you can't justify picking one.
 
 Keep each item's lead to **1–3 sentences**: location, what's wrong, what to do. Trust the reader to read the code — don't explain how the bug would manifest, walk through the data flow, justify why the current code is wrong beyond a brief phrase, or compare fix options inside the lead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,7 @@ Tests live in `tests/`. The following patterns work well in this codebase.
 ## Code Style
 
 - **Comments**: Write no comments by default. Only add one when the *why* is non-obvious — a hidden constraint, a subtle invariant, a workaround for a specific bug, behavior that would surprise a reader. Never restate what the code already says; well-named identifiers do that.
+- **Don't reference downstream consumers in explanatory text.** Comments, docstrings, `desc=` strings, error messages — describe what the thing does, not which model, algorithm, caller, or feature uses it. References like "used by X", "supports model Y", "applied to algorithm Z" rot when consumers change or new ones are added.
 - **Imports**: Third-party → `import package.module` (keep fully qualified). First-party → `from fast_llm.module import Thing`. No relative imports. Optional/slow imports inside methods or under `if typing.TYPE_CHECKING:`.
 - **Naming**: No abbreviations (use `batch_size` not `bs`). Non-public members (private or protected) get a single `_` prefix; never use `__`. Keep public interfaces lean.
 - **Types**: Always type-hint public interfaces. Use modern syntax (`X | Y`, `list[T]` not `List[T]`, PEP 695 generics like `class X[T: Bound]:` instead of `typing.TypeVar`).


### PR DESCRIPTION
## Summary

- `/review-coarse` and `/review-fine` now emit `## /review-<kind> @ <short-sha>` as the first line of their output, making review outputs identifiable when pasted into another Claude Code session for triage.
- Adds a Code Style rule to `CLAUDE.md`: comments, docstrings, `desc=` strings, and error messages should describe what the thing does, not which model/algorithm/caller/feature uses it — those references rot when consumers change.

Both changes are scoped to `.claude/` (slash-command definitions and project CLAUDE.md). No runtime code is affected.

## Test plan

- [ ] Next `/review-coarse` and `/review-fine` invocations include the `## /review-<kind> @ <short-sha>` header at the top of their output
- [ ] No-downstream-consumers rule is a convention enforced by reviewers (no automated check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)