### PR TITLE
Fix Apriel2 mask call for transformers 5.9.0

### DIFF
--- a/fast_llm_external_models/apriel2/modeling_apriel2.py
+++ b/fast_llm_external_models/apriel2/modeling_apriel2.py
@@ -937,11 +937,13 @@ class Apriel2Attention(nn.Module):
             )
 
             embeds_kwarg = "inputs_embeds" if not _TRANSFORMERS_V4 else "input_embeds"
+            # `cache_position` is required in transformers v4, deprecated in early v5, and removed in v5.9.
+            extra_mask_kwargs = {"cache_position": kwargs["cache_position"]} if _TRANSFORMERS_V4 else {}
             mask = mask_function(
                 config=mask_config,
                 **{embeds_kwarg: hidden_states},
                 attention_mask=kwargs.get("attention_mask"),
-                cache_position=kwargs["cache_position"],
+                **extra_mask_kwargs,
                 past_key_values=kwargs.get("past_key_values"),
                 position_ids=position_ids,
             )


### PR DESCRIPTION
## Summary
- `transformers 5.9.0` removed the `cache_position` kwarg from `create_causal_mask` and `create_sliding_window_causal_mask`, causing all 60 Apriel2 modeling tests to fail on CI with `TypeError: ... unexpected keyword argument 'cache_position'`.
- The kwarg was already deprecated and unused since transformers 5.6 (`# not used anymore but kept for BC`). It is still required on transformers v4, where it remains functional.
- Gate the kwarg on the existing `_TRANSFORMERS_V4` flag at the single call site in `modeling_apriel2.py`: passed on v4, dropped on v5+.

## Test plan
Ran `fast_llm_external_models/tests/test_apriel2/` against three transformers releases — all match the pre-breakage baseline.

- [x] `transformers==4.57.1`: 2109 passed, 42 skipped
- [x] `transformers==5.8.1`: 2109 passed, 42 skipped
- [x] `transformers==5.9.0` (the CI-resolved version): 2109 passed, 42 skipped — previously 60 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)