### PR TITLE
Re-enable dropless MoE test; fix VISION extra on aarch64

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,9 @@ STREAMING =
 VISION =
     # Vision Tools
     webp>=0.4.0
-    pillow-simd>=9.5.0
+    # pillow-simd is an x86-only (SSE4) fork; fall back to stock Pillow on other architectures (e.g. aarch64).
+    pillow-simd>=9.5.0; platform_machine == "x86_64"
+    Pillow>=9.5.0; platform_machine != "x86_64"
     torchvision>=0.24.0
 
 DEV =

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -87,7 +87,6 @@ def test_mlp_recomputation(gated, activation, testing_device):
 
 # Takes ~6s, much more if it needs to compile, reducing the hidden size doesn't help.
 @pytest.mark.slow
-@pytest.mark.skip("Dropless MoE is broken")
 def test_dropless_mlp(testing_device):
     device = torch.device(testing_device)
     num_experts = 4


### PR DESCRIPTION
Claude Opus 4.8:

Two small, independent fixes surfaced while triaging the backlog.

**Re-enable dropless MoE test.** #489 fixed and reworked the dropless MoE kernel, but the standalone `tests/functional/test_functional.py::test_dropless_mlp` was left marked `@pytest.mark.skip("Dropless MoE is broken")`. Removed the skip — verified passing on a CUDA GPU (`1 passed in 9.41s`).

**Fix VISION extra install on aarch64 (closes #429).** `pillow-simd` is an x86-only (SSE4) fork with no aarch64 build, so `pip install ".[VISION]"` fails on ARM. Gated `pillow-simd` to `platform_machine == "x86_64"` and fall back to stock `Pillow` on other architectures. Using `!= "x86_64"` (rather than `== "aarch64"`) also covers macOS arm64.

Verified on arm64: pip skips pillow-simd (`Ignoring pillow-simd: markers ... don't match your environment`) and resolves/installs `Pillow`, which imports cleanly. No Linux-aarch64 box was available to exercise the real install, but `Pillow` ships manylinux-aarch64 wheels so no source build is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
