### PR TITLE
Data preparation: no-BOS tokenizer support and configurable train_on_eos

### DIFF
--- a/fast_llm/data/dataset/gpt/fim.py
+++ b/fast_llm/data/dataset/gpt/fim.py
@@ -32,6 +32,8 @@ class GPTFimDataset[DocumentType: LanguageModelDocument](SampledDataset[Document
         self._tokenizer = self._config.tokenizer.get_tokenizer()
         if self._tokenizer is None:
             raise ValueError("Fim requires a tokenizer")
+        if self._tokenizer.bod_id is None or self._tokenizer.eod_id is None:
+            raise ValueError("FIM requires the tokenizer to define both BOS and EOS tokens.")
         self._suffix_tok_id, self._prefix_tok_id, self._middle_tok_id, self._pad_tok_id = (
             self._tokenizer.vocab[tok]
             for tok in [config.suffix_token, config.prefix_token, config.middle_token, config.pad_token]

--- a/fast_llm/data/preparation/gpt_memmap/config.py
+++ b/fast_llm/data/preparation/gpt_memmap/config.py
@@ -314,12 +314,12 @@ class GPTMemmapDatasetPreparatorConfig(DatasetPreparatorConfig):
     )
     add_bos: bool = Field(
         default=True,
-        desc="Prepend the tokenizer's BOS token at the beginning of each document.",
+        desc="Prepend the tokenizer's BOS token to each document.",
         hint=FieldHint.optional,
     )
     add_eos: bool = Field(
         default=True,
-        desc="Append the tokenizer's EOS token at the end of each document.",
+        desc="Append the tokenizer's EOS token to each document.",
         hint=FieldHint.optional,
     )
     image_patches: ImagePreparationConfig = Field(

--- a/fast_llm/data/preparation/gpt_memmap/config.py
+++ b/fast_llm/data/preparation/gpt_memmap/config.py
@@ -306,6 +306,16 @@ class GPTMemmapDatasetPreparatorConfig(DatasetPreparatorConfig):
         desc="Configuration for the tokenizer.",
         hint=FieldHint.feature,
     )
+    add_bos: bool = Field(
+        default=True,
+        desc="Prepend the tokenizer's BOS token at the beginning of each document.",
+        hint=FieldHint.optional,
+    )
+    add_eos: bool = Field(
+        default=True,
+        desc="Append the tokenizer's EOS token at the end of each document.",
+        hint=FieldHint.optional,
+    )
     image_patches: ImagePreparationConfig = Field(
         desc="Configuration for the image patches, if enabled.",
         hint=FieldHint.feature,

--- a/fast_llm/data/preparation/gpt_memmap/config.py
+++ b/fast_llm/data/preparation/gpt_memmap/config.py
@@ -170,6 +170,12 @@ class ConversationSourceConfig(LanguageModelSourceConfig):
         desc="Field containing the conversation messages list. Each message should have 'role' and 'content' keys.",
         hint=FieldHint.core,
     )
+    train_on_eos: bool = Field(
+        default=False,
+        desc="Include the end-of-sequence token appended after the final message in the training loss."
+        " When disabled, that token is masked from the loss.",
+        hint=FieldHint.optional,
+    )
 
     @functools.cached_property
     def columns(self) -> list[str]:

--- a/fast_llm/data/preparation/gpt_memmap/prepare.py
+++ b/fast_llm/data/preparation/gpt_memmap/prepare.py
@@ -228,6 +228,7 @@ class GPTMemmapDatasetPreparator[ConfigType: GPTMemmapDatasetPreparatorConfig](D
                 sample[self._source_schema.messages],
                 self._config.add_bos,
                 self._config.add_eos,
+                train_on_eos=self._source_schema.train_on_eos,
                 data_type=self._data_type,
             )
             token_spans_by_type[SpanType.loss_masking] = loss_masking_spans

--- a/fast_llm/data/preparation/gpt_memmap/prepare.py
+++ b/fast_llm/data/preparation/gpt_memmap/prepare.py
@@ -134,6 +134,14 @@ class GPTMemmapDatasetPreparator[ConfigType: GPTMemmapDatasetPreparatorConfig](D
         # Load tokenizer
         self._tokenizer = self._config.tokenizer.get_tokenizer()
 
+        if self._config.add_bos and self._tokenizer.bod_id is None:
+            raise ValueError(
+                "`add_bos` is set but the tokenizer does not define a BOS token;"
+                " set `add_bos=False` or specify `tokenizer.bos_token`."
+            )
+        if self._config.add_eos and self._tokenizer.eod_id is None:
+            raise ValueError("`add_eos` is set but the tokenizer does not define an EOS token; set `add_eos=False`.")
+
         # Validate chat template for conversation format
         if isinstance(self._source_schema, ConversationSourceConfig):
             self._tokenizer.validate_chat_template()
@@ -218,8 +226,8 @@ class GPTMemmapDatasetPreparator[ConfigType: GPTMemmapDatasetPreparatorConfig](D
             # Conversation format: tokenize messages and get loss masking spans from chat template
             tokens, loss_masking_spans = self._tokenizer.tokenize_chat(
                 sample[self._source_schema.messages],
-                True,
-                True,
+                self._config.add_bos,
+                self._config.add_eos,
                 data_type=self._data_type,
             )
             token_spans_by_type[SpanType.loss_masking] = loss_masking_spans
@@ -289,7 +297,7 @@ class GPTMemmapDatasetPreparator[ConfigType: GPTMemmapDatasetPreparatorConfig](D
             span_types, spans = zip(*_sort_spans(all_spans)) if all_spans else ([], [])
             # Tokenize the text, and determine the span locations in the tokenized text.
             tokens, token_spans = self._tokenizer.tokenize_with_spans(
-                text, True, True, text_spans=spans, data_type=self._data_type
+                text, self._config.add_bos, self._config.add_eos, text_spans=spans, data_type=self._data_type
             )
 
             # Gather token spans by type.

--- a/fast_llm/data/preparation/gpt_memmap/prepare.py
+++ b/fast_llm/data/preparation/gpt_memmap/prepare.py
@@ -141,6 +141,11 @@ class GPTMemmapDatasetPreparator[ConfigType: GPTMemmapDatasetPreparatorConfig](D
             )
         if self._config.add_eos and self._tokenizer.eod_id is None:
             raise ValueError("`add_eos` is set but the tokenizer does not define an EOS token; set `add_eos=False`.")
+        if self._source_schema.has_preference_spans and self._tokenizer.bod_id is None:
+            raise ValueError(
+                "Preference-span preparation requires a tokenizer that defines a BOS token (used as a separator);"
+                " specify `tokenizer.bos_token` or use a tokenizer that has one."
+            )
 
         # Validate chat template for conversation format
         if isinstance(self._source_schema, ConversationSourceConfig):

--- a/fast_llm/data/preparation/tokenizer.py
+++ b/fast_llm/data/preparation/tokenizer.py
@@ -69,10 +69,6 @@ class Tokenizer[ConfigType: TokenizerConfig](Configurable[ConfigType]):
         )
         if self._config.bos_token is not None:
             self.tokenizer.bos_token = self._config.bos_token
-        if self.tokenizer.eos_token_id is None:
-            raise ValueError("Tokenizer does not have an EOS token.")
-        if self.tokenizer.bos_token_id is None:
-            raise ValueError("Tokenizer does not have an BOS token.")
         self.eod_id = self.tokenizer.eos_token_id
         self.bod_id = self.tokenizer.bos_token_id
 

--- a/fast_llm/data/preparation/tokenizer.py
+++ b/fast_llm/data/preparation/tokenizer.py
@@ -260,6 +260,7 @@ class Tokenizer[ConfigType: TokenizerConfig](Configurable[ConfigType]):
         messages: list[dict[str, str]],
         begin: bool = True,
         end: bool = True,
+        train_on_eos: bool = False,
         data_type: DataType = DataType.int64,
     ) -> tuple["torch.Tensor", list[tuple[int, int]]]:
         """
@@ -287,7 +288,7 @@ class Tokenizer[ConfigType: TokenizerConfig](Configurable[ConfigType]):
         prepend_bos = begin and self.bod_id not in tokens
         append_eos = end and self.eod_id not in tokens
         tokens = [self.bod_id] * prepend_bos + list(tokens) + [self.eod_id] * append_eos
-        train_mask = [False] * prepend_bos + [bool(m) for m in train_mask] + [False] * append_eos
+        train_mask = [False] * prepend_bos + [bool(m) for m in train_mask] + [train_on_eos] * append_eos
 
         # Convert boolean train mask to loss masking spans (spans where train_mask[i] == False)
         loss_masking_spans = _train_mask_to_loss_spans(train_mask)

--- a/tests/data/test_tokenizer.py
+++ b/tests/data/test_tokenizer.py
@@ -278,6 +278,20 @@ def test_tokenize_chat(common_tokenizer, messages, expected_tokens, expected_los
     Assert.eq(loss_masking_spans, expected_loss_masking_spans)
 
 
+def test_tokenize_chat_train_on_eos(common_tokenizer):
+    common_tokenizer.tokenizer.chat_template = CHAT_TEMPLATE
+    messages = [{"role": "user", "content": "Hi"}, {"role": "assistant", "content": "Hello"}]
+    tokens, spans = common_tokenizer.tokenize_chat(messages)
+    tokens_eos, spans_eos = common_tokenizer.tokenize_chat(messages, train_on_eos=True)
+
+    # `train_on_eos` changes only the loss mask of the appended EOS, not the tokens.
+    Assert.eq(tokens_eos.tolist(), tokens.tolist())
+    Assert.eq(tokens[-1].item(), common_tokenizer.eod_id)
+    # By default the trailing EOS is its own masked span; `train_on_eos` trains on it instead.
+    Assert.eq(spans[-1], (len(tokens) - 1, len(tokens)))
+    Assert.eq(spans_eos, spans[:-1])
+
+
 @pytest.mark.parametrize(
     ("train_mask", "expected_loss_spans"),
     (

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -6,6 +6,7 @@ from fast_llm.functional.triton import triton_available
 from fast_llm.functional.triton.mlp import mlp_autograd, mlp_autograd_looped, torch_mlp_activation
 from fast_llm.functional.triton.sparse_copy import get_sparse_map
 from fast_llm.utils import Assert
+from tests.utils.utils import requires_cuda
 
 
 def _get_target_log_probability_for_spans(log_probabilities: torch.Tensor, spans: list[list[tuple[int, int]]]):
@@ -86,6 +87,7 @@ def test_mlp_recomputation(gated, activation, testing_device):
 
 
 # Takes ~6s, much more if it needs to compile, reducing the hidden size doesn't help.
+@requires_cuda  # The dropless MoE kernel is Triton-only and has no CPU fallback.
 @pytest.mark.slow
 def test_dropless_mlp(testing_device):
     device = torch.device(testing_device)


### PR DESCRIPTION
_Authored by Claude Opus 4.8 (with @jlamypoirier)._

Consolidates the salvageable parts of #473 (closed) and #535 (closed), plus a CPU CI fix. Three changes:

## 1. No-BOS tokenizer support in data preparation

Allow data preparation with tokenizers that don't define a BOS token (e.g. the Qwen family).

- Symmetric `add_bos` / `add_eos` flags on `GPTMemmapDatasetPreparatorConfig` (both default `True`, reproducing current behavior), driving the tokenizer's existing `begin` / `end` arguments.
- A missing BOS/EOS token raises **only when the corresponding delimiter is requested** (validated in the preparator), instead of unconditionally at `Tokenizer` construction.
- The delimiter-presence requirement moves out of `Tokenizer.__init__` to the consumers that need it: the preparator (gated on the flags) and FIM (which uses both). The lm_eval wrapper uses the HF tokenizer directly and was already no-BOS-tolerant.

For a no-BOS tokenizer, set `add_bos: false`; EOS document separators are kept via the default `add_eos: true`. Reimplemented on `main` per the review on #473 (which used an `allow_no_bos` flag on `TokenizerConfig` and silently skipped missing tokens).

## 2. Configurable `train_on_eos` for conversation data

Add `train_on_eos: bool = False` to `ConversationSourceConfig`, controlling whether the EOS token appended after the final message is included in the training loss:

- `false` (default): the appended EOS is masked — **unchanged behavior**.
- `true`: it becomes a training target.

Threaded through `tokenize_chat`. Only affects the single appended sequence terminator; per-turn `{% generation %}` markers are unchanged. Masking the terminal EOS is a known cause of models that don't learn to stop generating, and frameworks expose the same knob (Axolotl `train_on_eos`, TRL `assistant_only_loss`). This was the loss-masking change originally bundled into #473, now opt-in and off by default.

## 3. Skip the dropless MoE test without CUDA

`test_dropless_mlp` (re-enabled in #532) is a Triton-only kernel with no CPU fallback, so it errored with `RuntimeError: 0 active drivers` on the CPU-only CI runner. Marked `@requires_cuda` so it runs on GPU and skips otherwise.

## Testing

`tests/data/{test_tokenizer,test_preparator,test_fim}.py` and `tests/functional/test_functional.py` pass locally (50 passed, 1 skipped — the CUDA-gated dropless test), including the new `test_tokenize_chat_train_on_eos`.

Supersedes #473 and #535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
