### PR TITLE
Add configurable train_on_eos for conversation data preparation

### DIFF
--- a/fast_llm/data/preparation/gpt_memmap/config.py
+++ b/fast_llm/data/preparation/gpt_memmap/config.py
@@ -170,6 +170,12 @@ class ConversationSourceConfig(LanguageModelSourceConfig):
         desc="Field containing the conversation messages list. Each message should have 'role' and 'content' keys.",
         hint=FieldHint.core,
     )
+    train_on_eos: bool = Field(
+        default=False,
+        desc="Include the end-of-sequence token appended after the final message in the training loss."
+        " When disabled, that token is masked from the loss.",
+        hint=FieldHint.optional,
+    )
 
     @functools.cached_property
     def columns(self) -> list[str]:

--- a/fast_llm/data/preparation/gpt_memmap/prepare.py
+++ b/fast_llm/data/preparation/gpt_memmap/prepare.py
@@ -220,6 +220,7 @@ class GPTMemmapDatasetPreparator[ConfigType: GPTMemmapDatasetPreparatorConfig](D
                 sample[self._source_schema.messages],
                 True,
                 True,
+                train_on_eos=self._source_schema.train_on_eos,
                 data_type=self._data_type,
             )
             token_spans_by_type[SpanType.loss_masking] = loss_masking_spans

--- a/fast_llm/data/preparation/tokenizer.py
+++ b/fast_llm/data/preparation/tokenizer.py
@@ -264,6 +264,7 @@ class Tokenizer[ConfigType: TokenizerConfig](Configurable[ConfigType]):
         messages: list[dict[str, str]],
         begin: bool = True,
         end: bool = True,
+        train_on_eos: bool = False,
         data_type: DataType = DataType.int64,
     ) -> tuple["torch.Tensor", list[tuple[int, int]]]:
         """
@@ -291,7 +292,7 @@ class Tokenizer[ConfigType: TokenizerConfig](Configurable[ConfigType]):
         prepend_bos = begin and self.bod_id not in tokens
         append_eos = end and self.eod_id not in tokens
         tokens = [self.bod_id] * prepend_bos + list(tokens) + [self.eod_id] * append_eos
-        train_mask = [False] * prepend_bos + [bool(m) for m in train_mask] + [False] * append_eos
+        train_mask = [False] * prepend_bos + [bool(m) for m in train_mask] + [train_on_eos] * append_eos
 
         # Convert boolean train mask to loss masking spans (spans where train_mask[i] == False)
         loss_masking_spans = _train_mask_to_loss_spans(train_mask)

--- a/tests/data/test_tokenizer.py
+++ b/tests/data/test_tokenizer.py
@@ -278,6 +278,20 @@ def test_tokenize_chat(common_tokenizer, messages, expected_tokens, expected_los
     Assert.eq(loss_masking_spans, expected_loss_masking_spans)
 
 
+def test_tokenize_chat_train_on_eos(common_tokenizer):
+    common_tokenizer.tokenizer.chat_template = CHAT_TEMPLATE
+    messages = [{"role": "user", "content": "Hi"}, {"role": "assistant", "content": "Hello"}]
+    tokens, spans = common_tokenizer.tokenize_chat(messages)
+    tokens_eos, spans_eos = common_tokenizer.tokenize_chat(messages, train_on_eos=True)
+
+    # `train_on_eos` changes only the loss mask of the appended EOS, not the tokens.
+    Assert.eq(tokens_eos.tolist(), tokens.tolist())
+    Assert.eq(tokens[-1].item(), common_tokenizer.eod_id)
+    # By default the trailing EOS is its own masked span; `train_on_eos` trains on it instead.
+    Assert.eq(spans[-1], (len(tokens) - 1, len(tokens)))
+    Assert.eq(spans_eos, spans[:-1])
+
+
 @pytest.mark.parametrize(
     ("train_mask", "expected_loss_spans"),
     (


### PR DESCRIPTION
_Authored by Claude Opus 4.8 (with @jlamypoirier)._

Splits out — as a standalone, opt-in flag — the loss-masking change that was bundled into #473.

## What

Add `train_on_eos: bool = False` to `ConversationSourceConfig`. It controls whether the end-of-sequence token that `tokenize_chat` appends after the final message is included in the training loss:

- `false` (default): the appended EOS is masked from the loss — **unchanged behavior**.
- `true`: the appended EOS becomes a training target.

Threaded through `Tokenizer.tokenize_chat` as a `train_on_eos` parameter. Per-turn terminators emitted by the chat template (e.g. ChatML `<|im_end|>`) are unaffected — they remain governed by the template's `{% generation %}` markers. This flag only touches the single sequence-terminating EOS that the tokenizer appends when no EOS already appears in the conversation.

## Why

Masking the terminal EOS means the model never gets a loss signal to emit end-of-sequence — a well-known cause of models that don't stop generating at inference. Training on the final/assistant EOS is the common recommendation, and frameworks expose it as a knob (Axolotl `train_on_eos: turn|all|last`; TRL `assistant_only_loss`, which includes the assistant turn's EOS). It's also an asymmetry within Fast-LLM today: the document path already trains on its appended EOS (unmasked tokens all contribute to the loss), while the conversation path masks it. This flag lets conversation prep opt into the same behavior.

Kept off by default so existing datasets' loss masking is unchanged.

## Testing

`tests/data/test_tokenizer.py` (incl. the new `test_tokenize_chat_train_on_eos`) and `test_preparator.py` pass (41). The new test asserts that `train_on_eos` changes only the appended EOS's loss mask, not the tokens.

## Note

Touches the same `tokenize_chat` call site as #534 (no-BOS prep); whichever merges first, the other needs a one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
