### PR TITLE
Benchmark kernel GPU time via profiler

### DIFF
--- a/tools/benchmark/triton_kernels/__main__.py
+++ b/tools/benchmark/triton_kernels/__main__.py
@@ -33,6 +33,9 @@ torch._dynamo.config.cache_size_limit = 64
 # mutated inputs" when using max-autotune. The fallback is correct; suppress noise.
 warnings.filterwarnings("ignore", message=".*[Ss]kipping (cuda|CUDA)[Gg]raphs.*")
 logging.getLogger("torch._inductor.cudagraph_trees").setLevel(logging.ERROR)
+# The per-measurement profiler session emits a one-time note about event cycles; the
+# runner reads key_averages right after each session, so it doesn't apply here.
+warnings.filterwarnings("ignore", message=".*Profiler clears events.*")
 
 _BENCHMARKS = {
     "entropy_loss": bench_entropy_loss,

--- a/tools/benchmark/triton_kernels/runner.py
+++ b/tools/benchmark/triton_kernels/runner.py
@@ -4,18 +4,19 @@ Core benchmarking infrastructure for Fast-LLM Triton kernels.
 Each benchmark file defines a list of `Case` objects (input shape/dtype
 sweep) and a list of `Variant` objects (implementations to compare — e.g.
 pytorch eager, pytorch compiled, Triton). The runner invokes each variant
-on each case, measures timing (median + mean + percentiles via CUDA events),
-measures peak/final memory, and compares outputs against an fp32 reference
-using RMS error. Results are printed as a table per case.
+on each case, measures GPU kernel time (summed per-kernel device time via the
+profiler), measures peak/final memory, and compares outputs against an fp32
+reference using RMS error. Results are printed as a table per case.
 """
 
 import dataclasses
 import math
-import statistics
 import time
 import typing
 
 import torch
+from torch.autograd import DeviceType
+from torch.profiler import ProfilerActivity, profile
 
 from fast_llm.utils import header
 from tools.benchmark.triton_kernels.gpu_specs import GpuSpec, detect_gpu_spec
@@ -163,8 +164,15 @@ def bench_fn(
     """Benchmark `fn` — it should be a no-arg callable that invokes the kernel
     being timed (close over inputs). Returns timing statistics in ms.
 
-    Mirrors `triton.testing.do_bench` logic but returns raw per-rep list so we
-    can compute {median, mean, min, max, std} from one set of runs.
+    Reports GPU kernel time: the profiler's summed per-kernel device self-time,
+    not a wall-clock window around `fn`. A CUDA-event window also counts GPU-idle
+    bubbles from per-call allocation and (for autograd variants) Python/engine
+    launch overhead — benchmarking artifacts that don't occur in a real run where
+    the CPU runs ahead and the allocator serves cached buffers, and which vary
+    by variant (the eager C++ engine starves the GPU far less than a Python
+    autograd Function). Summing device self-time isolates the work the GPU
+    actually does. Device time is deterministic to <1% run-to-run, so the
+    per-rep mean is reported across all stat fields.
     """
     if not torch.cuda.is_available():
         # CPU / Triton interpret: single timed run with wall clock. min_reps,
@@ -217,28 +225,32 @@ def bench_fn(
 
     num_reps = max(min_reps, min(max_reps, int(rep_ms / one_rep_ms)))
 
-    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_reps)]
-    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_reps)]
-    for i in range(num_reps):
-        if reset is not None:
-            reset()
-        # The L2 flush is enqueued before start_events[i] on the same stream, so
-        # the timed window starts after the zero completes — only fn() is timed.
+    # The L2 flush is itself a device kernel (a fill); profile it alone to learn
+    # its kernel key so it can be excluded from the measured sum below.
+    with profile(activities=[ProfilerActivity.CUDA]) as flush_prof:
         flush_buffer.zero_()
-        start_events[i].record()
-        fn()
-        end_events[i].record()
-    torch.cuda.synchronize()
+        torch.cuda.synchronize()
+    flush_keys = {k.key for k in flush_prof.key_averages() if k.device_type == DeviceType.CUDA}
 
-    times = [start_events[i].elapsed_time(end_events[i]) for i in range(num_reps)]
-    return TimingStats(
-        median_ms=statistics.median(times),
-        mean_ms=statistics.fmean(times),
-        min_ms=min(times),
-        max_ms=max(times),
-        std_ms=statistics.pstdev(times) if len(times) > 1 else 0.0,
-        num_reps=num_reps,
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+        for _ in range(num_reps):
+            if reset is not None:
+                reset()
+            # Cold L2 between reps so each kernel re-reads from DRAM. Its fill
+            # kernel is excluded from the sum via `flush_keys`.
+            flush_buffer.zero_()
+            fn()
+        torch.cuda.synchronize()
+
+    # Sum only CUDA-device entries: custom-autograd CPU nodes carry their
+    # children's device time and would double-count.
+    kernel_us = sum(
+        k.self_device_time_total
+        for k in prof.key_averages()
+        if k.device_type == DeviceType.CUDA and k.key not in flush_keys
     )
+    per_rep_ms = kernel_us / num_reps / 1000
+    return TimingStats(per_rep_ms, per_rep_ms, per_rep_ms, per_rep_ms, 0.0, num_reps)
 
 
 # --------------------------------------------------------------------------- memory

--- a/tools/benchmark/triton_kernels/runner.py
+++ b/tools/benchmark/triton_kernels/runner.py
@@ -16,8 +16,6 @@ import time
 import typing
 
 import torch
-from torch.autograd import DeviceType
-from torch.profiler import ProfilerActivity, profile
 
 from fast_llm.utils import header
 from tools.benchmark.triton_kernels.gpu_specs import GpuSpec, detect_gpu_spec
@@ -241,10 +239,12 @@ def bench_fn(
             reset()
         flush_buffer.zero_()
         torch.cuda.synchronize()
-        with profile(activities=[ProfilerActivity.CUDA]) as prof:
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CUDA]) as prof:
             fn()
             torch.cuda.synchronize()
-        kernel_us = sum(k.self_device_time_total for k in prof.key_averages() if k.device_type == DeviceType.CUDA)
+        kernel_us = sum(
+            k.self_device_time_total for k in prof.key_averages() if k.device_type == torch.autograd.DeviceType.CUDA
+        )
         samples_ms.append(kernel_us / 1000)
 
     return TimingStats(

--- a/tools/benchmark/triton_kernels/runner.py
+++ b/tools/benchmark/triton_kernels/runner.py
@@ -11,6 +11,7 @@ reference using RMS error. Results are printed as a table per case.
 
 import dataclasses
 import math
+import statistics
 import time
 import typing
 
@@ -153,31 +154,34 @@ class VariantResult:
 # --------------------------------------------------------------------------- timing
 
 
+# Per-rep samples for the timing distribution. Device kernel time is stable, so a
+# small fixed count gives tight stats without profiling thousands of reps.
+_MAX_PROFILE_REPS = 50
+
+
 def bench_fn(
     fn: typing.Callable[[], typing.Any],
     reset: typing.Callable[[], None] | None = None,
     warmup_ms: float = 25.0,
     rep_ms: float = 100.0,
     min_reps: int = 5,
-    max_reps: int = 10_000,
 ) -> TimingStats:
     """Benchmark `fn` — it should be a no-arg callable that invokes the kernel
     being timed (close over inputs). Returns timing statistics in ms.
 
-    Reports GPU kernel time: the profiler's summed per-kernel device self-time,
-    not a wall-clock window around `fn`. A CUDA-event window also counts GPU-idle
-    bubbles from per-call allocation and (for autograd variants) Python/engine
-    launch overhead — benchmarking artifacts that don't occur in a real run where
-    the CPU runs ahead and the allocator serves cached buffers, and which vary
-    by variant (the eager C++ engine starves the GPU far less than a Python
-    autograd Function). Summing device self-time isolates the work the GPU
-    actually does. Device time is deterministic to <1% run-to-run, so the
-    per-rep mean is reported across all stat fields.
+    Reports GPU kernel time: each rep sums the profiler's per-kernel device
+    self-time, and stats are computed over the per-rep samples. A CUDA-event
+    window around `fn` instead counts GPU-idle bubbles from per-call allocation
+    and (for autograd variants) Python/engine launch overhead — benchmarking
+    artifacts that don't occur in a real run where the CPU runs ahead and the
+    allocator serves cached buffers, and which vary by variant (the eager C++
+    engine starves the GPU far less than a Python autograd Function). Summing
+    device self-time isolates the work the GPU actually does.
     """
     if not torch.cuda.is_available():
         # CPU / Triton interpret: single timed run with wall clock. min_reps,
-        # max_reps, warmup_ms, rep_ms are ignored — this path is for smoke
-        # testing kernel correctness, not measurement.
+        # warmup_ms, rep_ms are ignored — this path is for smoke testing kernel
+        # correctness, not measurement.
         if reset is not None:
             reset()
         fn()  # warmup
@@ -223,34 +227,32 @@ def bench_fn(
     torch.cuda.synchronize()
     one_rep_ms = max(post_start.elapsed_time(post_end), 0.001)
 
-    num_reps = max(min_reps, min(max_reps, int(rep_ms / one_rep_ms)))
+    num_reps = max(min_reps, min(_MAX_PROFILE_REPS, int(rep_ms / one_rep_ms)))
 
-    # The L2 flush is itself a device kernel (a fill); profile it alone to learn
-    # its kernel key so it can be excluded from the measured sum below.
-    with profile(activities=[ProfilerActivity.CUDA]) as flush_prof:
+    # Profile each rep separately and sum its kernels' device self-time, building a
+    # per-rep sample distribution. The L2 flush stays outside the profiled region so
+    # its fill kernel isn't measured; it still runs before `fn` on the same stream,
+    # so each kernel reads cold. Only CUDA-device entries contribute — runtime/launch
+    # entries carry no device time, and a single fn() call has no autograd CPU node.
+    samples_ms: list[float] = []
+    for _ in range(num_reps):
+        if reset is not None:
+            reset()
         flush_buffer.zero_()
-        torch.cuda.synchronize()
-    flush_keys = {k.key for k in flush_prof.key_averages() if k.device_type == DeviceType.CUDA}
-
-    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
-        for _ in range(num_reps):
-            if reset is not None:
-                reset()
-            # Cold L2 between reps so each kernel re-reads from DRAM. Its fill
-            # kernel is excluded from the sum via `flush_keys`.
-            flush_buffer.zero_()
+        with profile(activities=[ProfilerActivity.CUDA]) as prof:
             fn()
-        torch.cuda.synchronize()
+            torch.cuda.synchronize()
+        kernel_us = sum(k.self_device_time_total for k in prof.key_averages() if k.device_type == DeviceType.CUDA)
+        samples_ms.append(kernel_us / 1000)
 
-    # Sum only CUDA-device entries: custom-autograd CPU nodes carry their
-    # children's device time and would double-count.
-    kernel_us = sum(
-        k.self_device_time_total
-        for k in prof.key_averages()
-        if k.device_type == DeviceType.CUDA and k.key not in flush_keys
+    return TimingStats(
+        median_ms=statistics.median(samples_ms),
+        mean_ms=statistics.fmean(samples_ms),
+        min_ms=min(samples_ms),
+        max_ms=max(samples_ms),
+        std_ms=statistics.pstdev(samples_ms) if len(samples_ms) > 1 else 0.0,
+        num_reps=num_reps,
     )
-    per_rep_ms = kernel_us / num_reps / 1000
-    return TimingStats(per_rep_ms, per_rep_ms, per_rep_ms, per_rep_ms, 0.0, num_reps)
 
 
 # --------------------------------------------------------------------------- memory

--- a/tools/benchmark/triton_kernels/runner.py
+++ b/tools/benchmark/triton_kernels/runner.py
@@ -230,15 +230,17 @@ def bench_fn(
     num_reps = max(min_reps, min(_MAX_PROFILE_REPS, int(rep_ms / one_rep_ms)))
 
     # Profile each rep separately and sum its kernels' device self-time, building a
-    # per-rep sample distribution. The L2 flush stays outside the profiled region so
-    # its fill kernel isn't measured; it still runs before `fn` on the same stream,
-    # so each kernel reads cold. Only CUDA-device entries contribute — runtime/launch
-    # entries carry no device time, and a single fn() call has no autograd CPU node.
+    # per-rep sample distribution. The L2 flush stays outside the profiled region and
+    # is synced before the profiler opens, so its fill kernel can't land in the capture
+    # window while each kernel still reads cold. CUDA-only profiling records no CPU op
+    # nodes (which would otherwise carry their children's device time and double-count);
+    # the device_type == CUDA filter drops the zero-device-time runtime/launch entries.
     samples_ms: list[float] = []
     for _ in range(num_reps):
         if reset is not None:
             reset()
         flush_buffer.zero_()
+        torch.cuda.synchronize()
         with profile(activities=[ProfilerActivity.CUDA]) as prof:
             fn()
             torch.cuda.synchronize()


### PR DESCRIPTION
## Summary

The Triton kernel benchmark suite (`tools/benchmark/triton_kernels/`) timed each variant with a CUDA-event window around the whole call. That window measures the GPU-*timeline* span, which includes GPU-idle bubbles from per-call allocation and — for autograd variants — Python/engine launch overhead between kernels.

Those bubbles are **benchmarking artifacts**: in a real training step the CPU runs ahead of the GPU and the caching allocator serves buffers without syncs, so the GPU never sees them. They also vary by variant — the eager C++ autograd engine starves the GPU far less than a Python autograd `Function` — so they unfairly penalized the Triton path relative to eager/compiled. And because backward time is derived as `fwd_bwd − fwd`, the variance landed in the `bwd` column: on a fixed shape the same kernel swung ~190% run-to-run (normalization backward reported anywhere from ~200µs to ~580µs across runs).

This measures **GPU kernel time** instead: each rep sums per-kernel device self-time from `torch.profiler` — the work the GPU actually does, which is both the artifact-free number and the realistic one.

## How it works

- Profile **each rep in its own CUDA-only `torch.profiler` session**; sum `self_device_time_total` over `device_type == CUDA` entries → one per-rep sample.
- The **L2 flush runs outside** each rep's profiler context, so its fill kernel isn't recorded (no kernel needs to be excluded from the sum) while each kernel still reads cold.
- Compute real **median / mean / min / max / std** over the per-rep samples — so the harness demonstrates stability rather than asserting it, and `--verbose` min/max reflect measured spread.
- Profiled rep count is capped at a small fixed number (device time is stable; no need to profile thousands).
- Warmup / rep-estimate machinery is unchanged (still needed for compile/autotune/alloc).

## Validation (H100)

- Matches isolated single-kernel `do_bench` ground truth (e.g. normalization backward: profiler `k1+k2` ≈ the per-kernel sum measured separately).
- Headline (median) reproduces to **<0.5%** run-to-run, vs ~190% with the event method; measured per-rep spread is ~2–4%.
- Generalizes across benchmark families (normalization, cross_entropy, z_loss, rotary) and variant types (Triton, eager, `torch.compile`).

## Notes / out of scope

- `reverse_kl` shows a `fwd > total` inconsistency at one size (→ negative derived `bwd`). This is a pre-existing property of the `bwd = total − fwd` derivation for that kernel's forward measurement (related to #497), not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)