### PR TITLE
Apply lengthy-operation timeout to state-dict checkpoint save/export

### DIFF
--- a/fast_llm/engine/checkpoint/state_dict.py
+++ b/fast_llm/engine/checkpoint/state_dict.py
@@ -7,7 +7,7 @@ import safetensors.torch
 import torch
 import yaml
 
-from fast_llm.core.distributed import safe_barrier
+from fast_llm.core.distributed import safe_barrier, set_timeout
 from fast_llm.engine.checkpoint.config import (
     CheckpointFormat,
     CheckpointHandler,
@@ -52,23 +52,26 @@ class StateDictCheckpointHandler(CheckpointHandler):
         #   If converting a tensor requires another one that is not yet available (e.g. for concatenation),
         #   it will remain in `state_dict` until that tensor is available.
         state_dict = {}
-        for parameter_name, shard_name, tensor in self._model.get_state_tensor_iterator(
-            self.get_shard_names(config), config.data_type
-        ):
-            if shard_name not in state_dict:
-                state_dict[shard_name] = {}
-            shard_state_dict = state_dict[shard_name]
-            assert parameter_name not in shard_state_dict
-            shard_state_dict[parameter_name] = tensor
-            for exported_name, exported_tensor in self._convert_state_dict(shard_state_dict, True).items():
-                saver.add_tensor(self._get_key(exported_name, shard_name), exported_tensor)
+        # Saving is rank-0-serialized and can be slow (large model, slow storage), so the interleaved
+        # gather collectives need the lengthy-operation timeout, same as the load path (`SafeLoad`).
+        with set_timeout(self._model.distributed.world_group, config.timeout):
+            for parameter_name, shard_name, tensor in self._model.get_state_tensor_iterator(
+                self.get_shard_names(config), config.data_type
+            ):
+                if shard_name not in state_dict:
+                    state_dict[shard_name] = {}
+                shard_state_dict = state_dict[shard_name]
+                assert parameter_name not in shard_state_dict
+                shard_state_dict[parameter_name] = tensor
+                for exported_name, exported_tensor in self._convert_state_dict(shard_state_dict, True).items():
+                    saver.add_tensor(self._get_key(exported_name, shard_name), exported_tensor)
 
-        for shard_name, shard_state_dict in state_dict.items():
-            assert (
-                not shard_state_dict
-            ), f"Un-handled entries after conversion: {({k: list(v) for k, v in state_dict.items()})}"
+            for shard_name, shard_state_dict in state_dict.items():
+                assert (
+                    not shard_state_dict
+                ), f"Un-handled entries after conversion: {({k: list(v) for k, v in state_dict.items()})}"
 
-        index = saver.finalize()
+            index = saver.finalize()
         if self._model.config.distributed.rank == 0:
             self._save_serialized_metadata(config, serialized_metadata, index)
 


### PR DESCRIPTION
*Authored by Claude Opus 4.8 (via Claude Code), reviewed by @jlamypoirier.*

## Problem

`StateDictCheckpointHandler.save()` (used for `fast_llm`- and HuggingFace-format checkpoint **export** via `Trainer` and the offline `convert`) runs its per-parameter weight-gather collectives under the **default `DistributedConfig.timeout` (60 s)** instead of the lengthy-operation `training.timeout` (default 3600 s).

The load path does not have this problem: `load()` wraps its collectives in `SafeLoad(timeout=config.timeout)`, and `_save_checkpoint` already passes `training.timeout` to the surrounding barriers and to `get_save_config(...)` — but nothing applied that timeout to the gather collectives *inside* `save()`.

Saving a state-dict checkpoint is rank-0-serialized (rank 0 writes the `model_*.safetensors` files while the other ranks wait, with gathers interleaved between files). On a large model and/or slow/networked storage, a gather on the waiting ranks can exceed 60 s, at which point the NCCL collective watchdog fires and training aborts with:

```
RuntimeError: Desync detected for barrier export <step> exit (...)
```

The distributed (`distributed`-format) checkpoint is unaffected because every rank writes its own shard in parallel, so no single collective stalls past 60 s.

Observed multi-node (16×H100, 2 nodes) exporting a ~7B model to networked storage: the step-200 distributed checkpoint completed fine, while the `fast_llm` export at step 400 aborted ~60 s into the save.

## Fix

Wrap the gather loop in `save()` with `set_timeout(world_group, config.timeout)`, mirroring the load path. No config change is needed — `training.timeout` already defaults to 3600 s and flows into `config.timeout`.

## Notes / scope

- Verified by re-running the same multi-node export with the fix: the export at the previously-failing step completes and training continues.
- `iter_tensors()` / `iter_checkpoint()` (the streaming weight-broadcast consumer) shares the same gather pattern but has different control flow (a generator driven by an external consumer) and its own timeout handling; left out of scope here. Worth a follow-up look.
