### PR TITLE
Speed up from-distribution entropy-loss kernels (#497)

### DIFF
--- a/fast_llm/functional/triton/entropy_loss.py
+++ b/fast_llm/functional/triton/entropy_loss.py
@@ -19,7 +19,7 @@ if os.environ.get("FAST_LLM_SKIP_TRITON_AUTOTUNE"):
 _autotune_restore_stack: list = []
 
 
-def _save_for_restore(nargs, reset_only=False):
+def _save_for_restore(nargs: dict, reset_only: bool = False) -> None:
     # Autotune benchmarks each config by re-running the kernel, which corrupts buffers the kernel reads
     # and writes in place: the grad buffer on the accumulation path (a later loss adding into a shared
     # buffer), and `partial_losses` in the tensor-parallel path where it aliases the output. Snapshot
@@ -36,7 +36,7 @@ def _save_for_restore(nargs, reset_only=False):
     _autotune_restore_stack.append(saved)
 
 
-def _restore(nargs, exception):
+def _restore(nargs: dict, exception: Exception | None) -> None:
     for name, value in _autotune_restore_stack.pop().items():
         nargs[name].copy_(value)
 
@@ -768,8 +768,8 @@ def triton_entropy_loss_forward_backward(
         divisor = n_rows
     is_distribution = target_format != TargetFormat.labels
     if block_size is None:
-        # The from-distribution kernels run a softmax on both logits and target, so a smaller tile is
-        # needed to keep occupancy up; their `num_warps` is autotuned per vocab size rather than set here.
+        # Smaller tile for the distribution path to keep occupancy up; its `num_warps` is autotuned
+        # (see `_distribution_autotune_configs`).
         block_size = min(triton.next_power_of_2(n_cols), 16384 if is_distribution else 32768)
     kwargs = {
         "logits_stride_0": logits.stride(-2),

--- a/fast_llm/functional/triton/entropy_loss.py
+++ b/fast_llm/functional/triton/entropy_loss.py
@@ -1,8 +1,44 @@
+import os
+
 import torch
 
 from fast_llm.functional.config import EntropyLossType, TargetFormat
-from fast_llm.functional.triton import tl, tl_arange, tl_constexpr, triton, triton_jit
+from fast_llm.functional.triton import TritonConfig, tl, tl_arange, tl_constexpr, triton, triton_autotune, triton_jit
 from fast_llm.functional.utils import reduce_losses
+
+# The from-distribution kernels run a softmax on both the logits and the target, doubling register
+# pressure, so the best `num_warps` shifts with the number of column tiles. Autotune it per vocab size.
+_distribution_autotune_configs = (
+    TritonConfig({}, num_warps=8),
+    TritonConfig({}, num_warps=16),
+    TritonConfig({}, num_warps=32),
+)
+if os.environ.get("FAST_LLM_SKIP_TRITON_AUTOTUNE"):
+    _distribution_autotune_configs = (_distribution_autotune_configs[1],)
+
+_autotune_restore_stack: list = []
+
+
+def _save_for_restore(nargs, reset_only=False):
+    # Autotune benchmarks each config by re-running the kernel, which corrupts buffers the kernel reads
+    # and writes in place: the grad buffer on the accumulation path (a later loss adding into a shared
+    # buffer), and `partial_losses` in the tensor-parallel path where it aliases the output. Snapshot
+    # them so `_restore` can roll them back between trials. Forward-only calls pass neither.
+    if reset_only:
+        return
+    saved = {}
+    grad = nargs.get("grad_logits_ptr")
+    if grad is not None and nargs.get("accumulate"):
+        saved["grad_logits_ptr"] = grad.clone()
+    partial_losses = nargs.get("partial_losses_ptr")
+    if partial_losses is not None:
+        saved["partial_losses_ptr"] = partial_losses.clone()
+    _autotune_restore_stack.append(saved)
+
+
+def _restore(nargs, exception):
+    for name, value in _autotune_restore_stack.pop().items():
+        nargs[name].copy_(value)
 
 
 @triton_jit()
@@ -253,6 +289,7 @@ def triton_predicted_logits_from_distribution(
     return predicted_logits, exp_logits, sum_exp_logits, max_logits, target_sum_exp_logits, target_max_logits, target
 
 
+@triton_autotune(configs=_distribution_autotune_configs, key=["n_cols"])
 @triton_jit()
 def triton_cross_entropy_from_distribution_forward_parallel_kernel(
     logits_ptr,
@@ -308,6 +345,12 @@ def triton_cross_entropy_from_distribution_forward_parallel_kernel(
         tl.store(target_sum_exp_logits_ptr + block_idx, target_sum_exp_logits)
 
 
+@triton_autotune(
+    configs=_distribution_autotune_configs,
+    key=["n_cols"],
+    pre_hook=_save_for_restore,
+    post_hook=_restore,
+)
 @triton_jit()
 def triton_cross_entropy_from_distribution_forward_backward_kernel(
     logits_ptr,
@@ -479,6 +522,7 @@ def triton_reverse_kl_forward_from_distribution(
     return loss, logits, target, sum_exp_logits, max_logits, target_sum_exp_logits, target_max_logits
 
 
+@triton_autotune(configs=_distribution_autotune_configs, key=["n_cols"])
 @triton_jit()
 def triton_reverse_kl_forward_kernel_from_distribution(
     logits_ptr,
@@ -532,6 +576,12 @@ def triton_reverse_kl_forward_kernel_from_distribution(
         tl.store(target_sum_exp_logits_ptr + block_idx, target_sum_exp_logits)
 
 
+@triton_autotune(
+    configs=_distribution_autotune_configs,
+    key=["n_cols"],
+    pre_hook=_save_for_restore,
+    post_hook=_restore,
+)
 @triton_jit()
 def triton_reverse_kl_forward_backward_kernel_from_distribution(
     logits_ptr,
@@ -716,16 +766,16 @@ def triton_entropy_loss_forward_backward(
     n_cols = logits.size(-1)
     if divisor is None:
         divisor = n_rows
+    is_distribution = target_format != TargetFormat.labels
     if block_size is None:
-        block_size = min(triton.next_power_of_2(n_cols), 32768)
-    if num_warps is None:
-        num_warps = 4 if block_size < 2048 else (8 if block_size < 8192 else 16)
+        # The from-distribution kernels run a softmax on both logits and target, so a smaller tile is
+        # needed to keep occupancy up; their `num_warps` is autotuned per vocab size rather than set here.
+        block_size = min(triton.next_power_of_2(n_cols), 16384 if is_distribution else 32768)
     kwargs = {
         "logits_stride_0": logits.stride(-2),
         "n_cols": n_cols,
         "logits_scale_factor": logits_scale_factor,
         "block_size": block_size,
-        "num_warps": num_warps,
     }
     if grad_output is None:
         backward_kwargs = {}
@@ -740,6 +790,9 @@ def triton_entropy_loss_forward_backward(
         }
     if target_format == TargetFormat.labels:
         assert entropy_loss_type != EntropyLossType.reverse_kl
+        if num_warps is None:
+            num_warps = 4 if block_size < 2048 else (8 if block_size < 8192 else 16)
+        kwargs["num_warps"] = num_warps
         if group is None:
             losses = torch.empty(n_rows, dtype=torch.float, device=logits.device)
             triton_cross_entropy_forward_backward_from_labels_kernel[(n_rows,)](


### PR DESCRIPTION
Closes #497.

*Authored by Claude Opus 4.8 (1M context), reviewed by Joel Lamy-Poirier.*

## Problem

The fused `reverse_kl` / `cross_entropy`-from-distribution Triton kernels run a softmax on **both** logits and target in the forward, roughly doubling register pressure versus label-CE. At the old `block_size` cap of 32768 (vocab=32K → a single 32768-wide tile) only ~2 blocks fit per SM on H100 → ~50% occupancy → DRAM latency isn't hidden. Result: `reverse_kl` was ~2.9× slower than `torch.compile` at vocab=32K on a single GPU.

## Changes

- **Lower the block-size cap to 16384 for the distribution kernels** (label-CE has a single softmax and already hits 69–96% BW, so it keeps 32768). `block_size` still adapts as `min(next_pow2(vocab), cap)`, so the fused single-pass and its 3× lower activation memory are preserved — this is *not* a kernel split.
- **Autotune `num_warps` over {8, 16, 32}** keyed on vocab size. The best warp count shifts with the number of column tiles: the forward favors fewer warps, while the re-read-bound backward favors more, and the fused kernel uses one value — so a fixed heuristic left ~1.7× on the table at the largest vocab. Collapses to a single config under `FAST_LLM_SKIP_TRITON_AUTOTUNE` (so tests don't pay the benchmarking cost).
- **None-safe autotune restore hooks.** Autotune benchmarks each config by re-running the kernel, which would corrupt buffers the kernel reads and writes in place: the grad buffer on the accumulation path (a later loss adding into a shared buffer) and `partial_losses` in the tensor-parallel path (where it aliases the loss output). Triton's built-in `restore_value` can't be used here — its hook clones the named arg unconditionally, which fails on forward-only calls that pass no grad buffer — so the snapshot/rollback is done in custom hooks that skip absent buffers.

## Results (H100 SXM, bf16, 4096 tokens, fwd+bwd)

Total time vs **max-autotune** `torch.compile`:

| vocab | reverse_kl | cross_entropy (logits) |
|---|---|---|
| 32K | 2.7× | 1.7× |
| 65K | 2.3× | 1.6× |
| 131K | 2.1× | 1.4× |

Label-CE path unchanged. Numerics unchanged (~1e-7 rel-RMS vs fp32, vs ~1e-3 for compiled bf16). Activation memory stays ~3× below compiled.

## Testing

- `tests/layers/test_lm_losses.py`: 502 passed, 21 skipped.
- Separately verified, with autotune **active**, that the accumulate path and the tensor-parallel partial-loss path produce correct gradients (rel-RMS ~1.6e-3, bf16 precision) — i.e. the restore hooks work.

### Caveat / possible follow-up

The test suite runs with `FAST_LLM_SKIP_TRITON_AUTOTUNE`, so it uses a single config and the restore hooks never fire in CI. They only matter in production (autotune active + multi-loss accumulation or tensor parallelism). A regression dropping them would silently corrupt gradients with nothing catching it. Worth a dedicated test that re-enables autotune for one accumulate + TP case; happy to add it if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)