### PR TITLE
Pin wandb to 0.27.0 in the PipelineRL image

### DIFF
--- a/Dockerfile.pipelinerl
+++ b/Dockerfile.pipelinerl
@@ -99,6 +99,14 @@ RUN python -c "import torch, transformers, vllm; print('before torch', torch.__v
     && python -c "import fast_llm, pipelinerl, torch, transformers, vllm; print('after torch', torch.__version__); print('after transformers', transformers.__version__); print('after vllm', vllm.__version__)" \
     && pip check
 
+# Pin wandb to 0.27.0. wandb 0.27.1 moved its internal work onto an asyncio event loop running in a background
+# thread (wandb.sdk.lib.asyncio_manager); its run_in_loop deadlocks inside the PipelineRL actor — an asyncio +
+# heavily-multithreaded process — so the actor stops producing rollouts and the run hangs at startup. 0.27.0 is
+# the last good version. Done here (not in setup.cfg's wandb>=0.24.0) so only the PipelineRL image is pinned;
+# the trainer's own wandb is unaffected. Revisit when wandb fixes the regression.
+RUN pip install --no-cache-dir "wandb==0.27.0" \
+    && python -c "import wandb; assert wandb.__version__ == '0.27.0', wandb.__version__; print('wandb', wandb.__version__)"
+
 # Copy the remaining source code (read-only for non-root, see the note on dependency files above).
 COPY ./Megatron-LM Megatron-LM
 COPY ./examples examples


### PR DESCRIPTION
Claude Opus 4.8 note: root-caused and authored with Joel.

## Summary
Pin `wandb==0.27.0` in `Dockerfile.pipelinerl` (PipelineRL image only). wandb 0.27.1 hangs the PipelineRL actor at startup.

## Why
A recent base-image rebuild bumped wandb 0.27.0 → 0.27.2 and PipelineRL runs began hanging: the actor spins up, generates ~98 test rollouts, then wedges — no train rollouts are produced and the trainer hits its 600s "No document received" timeout.

Root-caused by diffing the working vs. broken images (only 8 pure-Python packages changed; torch / vllm / aiohttp / transformers / deepspeed identical) plus an A/B/A + version bisect, same config and only the wandb version changed:

| wandb | result |
|---|---|
| 0.27.0 | runs (test samples climb freely) |
| 0.27.1 | hang (stalls ~98–123) |
| 0.27.2 | hang (stalls ~98–100) |

So the regression landed in **0.27.1**; 0.27.2 inherits it. 0.27.0 is the last good version.

**Mechanism (best current understanding):** wandb 0.27.1 moved its internal work onto an asyncio event loop in a background thread (`wandb.sdk.lib.asyncio_manager`); callers block on it via `run_in_loop` / `run_coroutine_threadsafe`. wandb's own `asyncio_manager` docstring documents a deadlock for exactly this pattern (a lock held across threads while concurrent `run_in_loop` calls happen), and `asyncio_compat` notes wandb "was not originally designed with asyncio in mind." The PipelineRL actor is an asyncio + heavily-multithreaded process that logs from several threads, which is the hostile environment wandb warns about. A captured actor stack shows the rollout scheduler busy-spinning while both the rollout event loop and wandb's loop sit idle, consistent with rollout completion being wedged.

*Caveat:* the bisect → 0.27.1 and the asyncio re-architecture are solid; the deadlock itself is strongly inferred from wandb's own docs + the bisect rather than caught mid-deadlock in a stack sample. The trainer uses the same wandb version without issue (separate, non-asyncio process), which matches this picture.

Two independent fixes were verified to work with wandb 0.27.1 left in place: (a) keeping wandb out of the actor process, and (b) — chosen here — pinning wandb to 0.27.0, which preserves all metrics with no code changes.

## Scope
Pinned in `Dockerfile.pipelinerl`, after the Fast-LLM extras and PipelineRL installs that pull wandb (via `setup.cfg`'s `wandb>=0.24.0`), so it is the final installed version. `setup.cfg` and the main `Dockerfile` are untouched — only the PipelineRL image is constrained. Revisit when wandb fixes the regression upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)