### PR TITLE
Fix gradient accumulation with shared grad buffers (FSDP size 1)

### DIFF
--- a/fast_llm/engine/multi_stage/fsdp.py
+++ b/fast_llm/engine/multi_stage/fsdp.py
@@ -403,6 +403,8 @@ class FSDP:
                 triton_add(self._grad_shard, out, self._grad_shard)
             elif not full_precision_gradients:
                 triton_copy(self._grad_buffer_local_shard, self._grad_shard)
+        elif accumulate:
+            triton_add(self._grad_shard, self._grad_buffer_local_shard, self._grad_shard)
         else:
             triton_copy(self._grad_buffer_local_shard, self._grad_shard)
 

--- a/fast_llm/engine/schedule/runner.py
+++ b/fast_llm/engine/schedule/runner.py
@@ -183,8 +183,6 @@ class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
         self._record_event(context, EventType.pipe_wait_compute, None, self._pipeline_stream)
 
         # Reset gradients
-        # TODO: This is incorrect with shared buffers.
-        #   (still works because only the embedding layer doesn't share buffer)
         for stage in self._stages_on_device:
             if context.is_training:
                 stage.reset_gradients()

--- a/tests/utils/distributed_configs.py
+++ b/tests/utils/distributed_configs.py
@@ -193,7 +193,6 @@ _SINGLE_GPU_TESTING_CONFIGS = [
         compare_config=_compare_layer_match,
     ),
     # Gradient accumulation with grad buffers shared across stages.
-    # Shared buffers flush (and re-log) the grad shard once per micro-batch, so gradients appear as duplicates.
     DistributedTestingConfig(
         name="df4_z2",
         compare="df4",

--- a/tests/utils/distributed_configs.py
+++ b/tests/utils/distributed_configs.py
@@ -192,6 +192,19 @@ _SINGLE_GPU_TESTING_CONFIGS = [
         num_gpus=1,
         compare_config=_compare_layer_match,
     ),
+    # Gradient accumulation with grad buffers shared across stages.
+    # Shared buffers flush (and re-log) the grad shard once per micro-batch, so gradients appear as duplicates.
+    DistributedTestingConfig(
+        name="df4_z2",
+        compare="df4",
+        config_args=[
+            "schedule.depth_first_micro_batches=4",
+            "model.multi_stage.zero_stage=2",
+            "data.micro_batch_size=1024",
+        ],
+        num_gpus=1,
+        compare_config=_compare_layer_match_duplicate_gradients,
+    ),
 ]
 
 SINGLE_GPU_TESTING_CONFIGS = {config.name: config for config in _SINGLE_GPU_TESTING_CONFIGS}


### PR DESCRIPTION
*Claude Opus 4.8 (Claude Code) authored this PR.*

Fixes #550.

## Problem

`Fsdp.reduce_gradients` (`fast_llm/engine/multi_stage/fsdp.py`) reduces a stage's grad buffer and then writes the result into the persistent grad shard — **copy** on a stage's first flush, **add** on subsequent flushes (`accumulate` is passed in by the scheduler). The FSDP-size-1 branch implemented only the copy:

```python
else:
    triton_copy(self._grad_buffer_local_shard, self._grad_shard)   # always overwrites, ignores `accumulate`
```

With grad buffers **shared across stages** (`num_grad_buffers < num_stages`, e.g. anything that sets `zero_stage >= 2`) **and** more than one micro-batch per step, each shared-buffer stage is flushed once per micro-batch. Because the branch always overwrote, the grad shard ended up holding only the **last** micro-batch's gradient for those stages — silently scaling most parameters' gradients by ~`1/num_micro_batches`. The tied embedding (its own dedicated buffer, flushed once) was unaffected.

This is the path the old `runner.py` comment half-acknowledged ("still works because only the embedding layer doesn't share buffer") — which only held for a single micro-batch.

## Fix

Honor `accumulate` in the FSDP-size-1 branch, mirroring the sharded arm:

```python
elif accumulate:
    triton_add(self._grad_shard, self._grad_buffer_local_shard, self._grad_shard)
else:
    triton_copy(self._grad_buffer_local_shard, self._grad_shard)
```

Removed the now-incorrect `runner.py` TODO comment.

## Test

Added a single-GPU config `df4_z2` to `tests/utils/distributed_configs.py`: depth-first gradient accumulation (`depth_first_micro_batches=4`) with `zero_stage=2` (sets `num_grad_buffers=2`), compared against the dedicated-buffer `df4` baseline. The test model has 4 stages, so two of them share a grad buffer while the tied embedding keeps its own — exercising the previously-broken path. Shared buffers re-log the grad shard once per micro-batch, so the comparison uses the duplicate-tolerant config (last log = fully-accumulated shard).

Verified: with the fix, all single-GPU configs pass; reverting the fix makes `df4_z2` fail (the corrupted step-1 gradient produces a wrong weight update, so step 2's forward/backward diverge from baseline).

## Scope

The bug was specific to the `_fsdp_dim.size == 1` branch. With FSDP size > 1, `reduce_gradients` takes the sharded branch (reduce-scatter into a temp, then `triton_add`), which already honored `accumulate` — so data-parallel / grad-sharded configurations were not affected by this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)