### PR TITLE
Log documents_seen / num_documents and offer it as a W&B x-axis

### DIFF
--- a/fast_llm/data/document/config.py
+++ b/fast_llm/data/document/config.py
@@ -32,7 +32,7 @@ class LengthPreprocessingConfig(BatchPreprocessingConfig):
 
 @config_class()
 class TokenPreprocessingConfig(LengthPreprocessingConfig):
-    return_document_count: bool = Field(default=True)
+    pass
 
 
 @config_class()

--- a/fast_llm/data/document/config.py
+++ b/fast_llm/data/document/config.py
@@ -32,7 +32,7 @@ class LengthPreprocessingConfig(BatchPreprocessingConfig):
 
 @config_class()
 class TokenPreprocessingConfig(LengthPreprocessingConfig):
-    return_document_count: bool = Field(default=False)
+    return_document_count: bool = Field(default=True)
 
 
 @config_class()

--- a/fast_llm/data/document/config.py
+++ b/fast_llm/data/document/config.py
@@ -31,11 +31,6 @@ class LengthPreprocessingConfig(BatchPreprocessingConfig):
 
 
 @config_class()
-class TokenPreprocessingConfig(LengthPreprocessingConfig):
-    pass
-
-
-@config_class()
 class ImageNormalizationConfig(Config):
     scale: float = Field(default=255.0)
     # Default values from OpenAI Clip.
@@ -68,7 +63,7 @@ class PatchPreprocessingConfig(LengthPreprocessingConfig):
 
 
 @config_class()
-class LanguageModelBatchPreprocessingConfig(TokenPreprocessingConfig):
+class LanguageModelBatchPreprocessingConfig(LengthPreprocessingConfig):
     _abstract = False
     phase: PhaseType = Field(default=PhaseType.training)
     micro_batch_splits: int = Field(default=1)

--- a/fast_llm/data/document/token.py
+++ b/fast_llm/data/document/token.py
@@ -6,7 +6,7 @@ import torch
 from fast_llm.core.distributed import allreduce_scalar
 from fast_llm.data.document.abstract import Batch, Document
 from fast_llm.data.document.block import BlockModelInput, LengthModelInputPreprocessor
-from fast_llm.data.document.config import TokenPreprocessingConfig
+from fast_llm.data.document.config import LengthPreprocessingConfig
 from fast_llm.engine.distributed.distributed import Distributed
 from fast_llm.layers.language_model.config import LanguageModelKwargs
 from fast_llm.tensor import TensorMeta
@@ -98,7 +98,7 @@ class TokenBatch(Batch, TokenDocument):
 
         return lengths, first_document_begin, document_end
 
-    def _get_model_input(self, begin: int, end: int, config: TokenPreprocessingConfig, *, is_first_for_rank: bool):
+    def _get_model_input(self, begin: int, end: int, config: LengthPreprocessingConfig, *, is_first_for_rank: bool):
         model_input = self._model_input_class(tokens=self.tokens[begin:end])
         lengths, first_document_begin, last_document_end = self._get_cropped_lengths(begin, end)
 

--- a/fast_llm/data/document/token.py
+++ b/fast_llm/data/document/token.py
@@ -36,7 +36,7 @@ class TokenModelInput(BlockModelInput, TokenDocument):
 
     @classmethod
     def share_batch_data(cls, model_inputs: "list[TokenModelInput]", distributed: "Distributed"):
-        if model_inputs[0].num_documents is not None and model_inputs[0].num_documents_in_batch is None:
+        if model_inputs[0].num_documents_in_batch is None:
             # We sum over sequences but not within a sequence.
             num_documents_in_batch = allreduce_scalar(
                 sum(model_input.num_documents for model_input in model_inputs),

--- a/fast_llm/data/document/token.py
+++ b/fast_llm/data/document/token.py
@@ -102,13 +102,13 @@ class TokenBatch(Batch, TokenDocument):
         model_input = self._model_input_class(tokens=self.tokens[begin:end])
         lengths, first_document_begin, last_document_end = self._get_cropped_lengths(begin, end)
 
-        # Set the global whole-batch count on every rank's first microbatch; `share_batch_data`
-        # will sum across DP via `batch_data_group`. (`begin == 0` would only set it on the
-        # SDP rank-0 first microbatch, leaving other SDP ranks with 0 after the DP-only sum.)
-        # Exclude the padding "length" from the document count.
-        model_input.num_documents = (
-            len(self.lengths) - (1 if self.unpadded_length < len(self.tokens) else 0) if is_first_for_rank else 0
-        )
+        # Number of real documents on this rank (excluding the padding "length").
+        num_documents = len(self.lengths) - (1 if self.unpadded_length < len(self.tokens) else 0)
+
+        # Set this rank's document count on its first microbatch; `share_batch_data` DP-sums these
+        # contributions into the whole-batch count. (`begin == 0` would only set it on the SDP
+        # rank-0 first microbatch, leaving other SDP ranks with 0 after the DP-only sum.)
+        model_input.num_documents = num_documents if is_first_for_rank else 0
 
         if config.return_document_index:
             # Globally-consistent 1-based document index per token, computed from the unsliced
@@ -123,10 +123,7 @@ class TokenBatch(Batch, TokenDocument):
                 side="right",
                 out_int32=True,
             )
-            # Exclude the padding "length" from the count.
-            model_input.num_documents_in_sequence = len(self.lengths) - (
-                1 if self.unpadded_length < len(self.tokens) else 0
-            )
+            model_input.num_documents_in_sequence = num_documents
 
         LengthModelInputPreprocessor(
             lengths=lengths,

--- a/fast_llm/data/document/token.py
+++ b/fast_llm/data/document/token.py
@@ -102,14 +102,13 @@ class TokenBatch(Batch, TokenDocument):
         model_input = self._model_input_class(tokens=self.tokens[begin:end])
         lengths, first_document_begin, last_document_end = self._get_cropped_lengths(begin, end)
 
-        if config.return_document_count:
-            # Set the global whole-batch count on every rank's first microbatch; `share_batch_data`
-            # will sum across DP via `batch_data_group`. (`begin == 0` would only set it on the
-            # SDP rank-0 first microbatch, leaving other SDP ranks with 0 after the DP-only sum.)
-            # Exclude the padding "length" from the document count.
-            model_input.num_documents = (
-                len(self.lengths) - (1 if self.unpadded_length < len(self.tokens) else 0) if is_first_for_rank else 0
-            )
+        # Set the global whole-batch count on every rank's first microbatch; `share_batch_data`
+        # will sum across DP via `batch_data_group`. (`begin == 0` would only set it on the
+        # SDP rank-0 first microbatch, leaving other SDP ranks with 0 after the DP-only sum.)
+        # Exclude the padding "length" from the document count.
+        model_input.num_documents = (
+            len(self.lengths) - (1 if self.unpadded_length < len(self.tokens) else 0) if is_first_for_rank else 0
+        )
 
         if config.return_document_index:
             # Globally-consistent 1-based document index per token, computed from the unsliced

--- a/fast_llm/engine/evaluation/evaluator.py
+++ b/fast_llm/engine/evaluation/evaluator.py
@@ -121,7 +121,7 @@ class LossEvaluator[ConfigType: LossEvaluatorConfig](Evaluator[ConfigType]):
         begin_time = time.perf_counter()
         total_losses = {loss_def.name: 0.0 for loss_def in self._loss_definitions}
         for iter_ in range(self._config.iterations):
-            iter_losses, _, _ = self._runner.run_step(
+            iter_losses, _, _, _ = self._runner.run_step(
                 self._data_iterator, self._schedule, iteration=completed_evaluation_steps + iter_
             )
             for name, value in iter_losses.items():

--- a/fast_llm/engine/inference/runner.py
+++ b/fast_llm/engine/inference/runner.py
@@ -61,7 +61,7 @@ class InferenceRunner(abc.ABC):
         self, model_input: ModelInput, *, iteration: int = 1, return_metrics: bool = False
     ) -> tuple[dict[str, float | int], dict[str, typing.Any] | None]:
         # TODO: Return an actual model output.
-        reduced_losses, update_successful, metrics = self._runner.run_step(
+        reduced_losses, update_successful, metrics, _ = self._runner.run_step(
             iter(((model_input,),)),
             self._schedule,
             iteration=iteration,

--- a/fast_llm/engine/schedule/runner.py
+++ b/fast_llm/engine/schedule/runner.py
@@ -151,7 +151,7 @@ class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
         *,
         iteration: int = 1,
         return_metrics: bool = False,
-    ) -> tuple[dict[str, float | int], bool, dict[str, typing.Any] | None]:
+    ) -> tuple[dict[str, float | int], bool, dict[str, typing.Any] | None, int | None]:
         assert self._is_setup
         assert schedule._config is self._config  # Noqa
         if schedule.phase.is_training:
@@ -225,7 +225,7 @@ class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
         self._record_event(context, EventType.compute_wait_data, None)
 
         if not context.is_training or self._config.skip_step:
-            return self._reduce_losses(context), True, metrics
+            return self._reduce_losses(context), True, metrics, self._num_documents_in_batch
 
         for name, tied_parameter in self._tied_parameters.items():
             if tied_parameter.group is not None:
@@ -284,7 +284,7 @@ class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
                 lambda: log_memory_usage(f"End of {context.phase} iteration {iteration}", str)
             )
 
-        return self._reduce_losses(context), update_successful, metrics
+        return self._reduce_losses(context), update_successful, metrics, self._num_documents_in_batch
 
     def _reduce_losses(self, context: BatchContext) -> dict[str, float | int]:
         reduced_losses = {
@@ -325,7 +325,7 @@ class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
         model_inputs[0][0].share_batch_data(
             [model_input for model_inputs_ in model_inputs for model_input in model_inputs_], self._distributed
         )
-        # Whole-step DP-summed document count (the loss-normalization divisor), for `documents_seen`.
+        # Whole-step DP-summed document count (the loss-normalization divisor).
         self._num_documents_in_batch = model_inputs[0][0].num_documents_in_batch
 
         for micro_batch, model_inputs_ in enumerate(model_inputs):

--- a/fast_llm/engine/schedule/runner.py
+++ b/fast_llm/engine/schedule/runner.py
@@ -67,7 +67,7 @@ class BatchContext:
 class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
     _is_setup: bool = False
     # Whole-step document count (DP-summed) from the last `run_step`, or None when the data does not
-    # provide document counts (i.e. no loss requested `return_document_count`).
+    # provide document counts (i.e. non-token data).
     _num_documents_in_batch: int | None = None
     _compute_stream: torch.cuda.Stream | MockStream
     _data_stream: torch.cuda.Stream | MockStream

--- a/fast_llm/engine/schedule/runner.py
+++ b/fast_llm/engine/schedule/runner.py
@@ -66,9 +66,8 @@ class BatchContext:
 
 class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
     _is_setup: bool = False
-    # Whole-step document count (DP-summed) from the last `run_step`, or None when the data does not
-    # provide document counts (i.e. non-token data).
-    _num_documents_in_batch: int | None = None
+    # Whole-step document count (DP-summed) from the last `run_step`.
+    _num_documents_in_batch: int
     _compute_stream: torch.cuda.Stream | MockStream
     _data_stream: torch.cuda.Stream | MockStream
     _pipeline_stream: torch.cuda.Stream | MockStream
@@ -151,7 +150,7 @@ class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
         *,
         iteration: int = 1,
         return_metrics: bool = False,
-    ) -> tuple[dict[str, float | int], bool, dict[str, typing.Any] | None, int | None]:
+    ) -> tuple[dict[str, float | int], bool, dict[str, typing.Any] | None, int]:
         assert self._is_setup
         assert schedule._config is self._config  # Noqa
         if schedule.phase.is_training:
@@ -325,7 +324,6 @@ class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
         model_inputs[0][0].share_batch_data(
             [model_input for model_inputs_ in model_inputs for model_input in model_inputs_], self._distributed
         )
-        # Whole-step DP-summed document count (the loss-normalization divisor).
         self._num_documents_in_batch = model_inputs[0][0].num_documents_in_batch
 
         for micro_batch, model_inputs_ in enumerate(model_inputs):

--- a/fast_llm/engine/schedule/runner.py
+++ b/fast_llm/engine/schedule/runner.py
@@ -66,6 +66,9 @@ class BatchContext:
 
 class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
     _is_setup: bool = False
+    # Whole-step document count (DP-summed) from the last `run_step`, or None when the data does not
+    # provide document counts (i.e. no loss requested `return_document_count`).
+    _num_documents_in_batch: int | None = None
     _compute_stream: torch.cuda.Stream | MockStream
     _data_stream: torch.cuda.Stream | MockStream
     _pipeline_stream: torch.cuda.Stream | MockStream
@@ -322,6 +325,8 @@ class ScheduleRunner[ConfigType: ScheduleConfig](Configurable[ConfigType]):
         model_inputs[0][0].share_batch_data(
             [model_input for model_inputs_ in model_inputs for model_input in model_inputs_], self._distributed
         )
+        # Whole-step DP-summed document count (the loss-normalization divisor), for `documents_seen`.
+        self._num_documents_in_batch = model_inputs[0][0].num_documents_in_batch
 
         for micro_batch, model_inputs_ in enumerate(model_inputs):
             Assert.eq(len(model_inputs_), self._config.micro_batch_splits)

--- a/fast_llm/engine/training/trainer.py
+++ b/fast_llm/engine/training/trainer.py
@@ -228,7 +228,6 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
                     return_metrics=is_logging,
                 )
 
-                # Cumulative document count across training steps.
                 self._documents_seen += step_num_documents
 
                 # Advanced, skipped, and Nan iterations.

--- a/fast_llm/engine/training/trainer.py
+++ b/fast_llm/engine/training/trainer.py
@@ -263,11 +263,8 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
                         metrics_key = PhaseType.training
                         metrics[metrics_key] = {
                             "batch_size": self._batch_size,
-                            **(
-                                {"num_documents": step_num_documents, "documents_seen": self._documents_seen}
-                                if step_num_documents is not None
-                                else {}
-                            ),
+                            "num_documents": step_num_documents,
+                            "documents_seen": self._documents_seen,
                             **{
                                 name: (value / advanced_iters if advanced_iters > 0 else float("nan"))
                                 for name, value in total_losses.items()

--- a/fast_llm/engine/training/trainer.py
+++ b/fast_llm/engine/training/trainer.py
@@ -39,6 +39,7 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
     _wandb: Wandb
     _optimizer: Optimizer | None
     _completed_steps: int
+    _documents_seen: int = 0
     _schedule: Schedule
 
     def __init__(self, config: TrainerConfig):
@@ -227,6 +228,12 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
                     return_metrics=is_logging,
                 )
 
+                # Cumulative document count (the RL x-axis / model-version clock); `None` when the
+                # data provides no document counts (non-RL runs).
+                step_num_documents = self._runner._num_documents_in_batch
+                if step_num_documents is not None:
+                    self._documents_seen += step_num_documents
+
                 # Advanced, skipped, and Nan iterations.
                 if update_successful:
                     advanced_iters += 1
@@ -257,6 +264,11 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
                         metrics_key = PhaseType.training
                         metrics[metrics_key] = {
                             "batch_size": self._batch_size,
+                            **(
+                                {"num_documents": step_num_documents, "documents_seen": self._documents_seen}
+                                if step_num_documents is not None
+                                else {}
+                            ),
                             **{
                                 name: (value / advanced_iters if advanced_iters > 0 else float("nan"))
                                 for name, value in total_losses.items()
@@ -350,6 +362,7 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
             if self._do_train:
                 self._optimizer.reset_state()
             self._completed_steps = 0
+            self._documents_seen = 0
         else:
             log_main_rank(lambda: f"Loading checkpoint from iteration {last_iteration}...")
             self._load_checkpoint(self._config.training.checkpoint, last_iteration)
@@ -387,6 +400,7 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
         metadata = {
             "optimizer": self._optimizer.save(),
             "completed_steps": self._completed_steps,
+            "documents_seen": self._documents_seen,
         }
         if metrics is not None:
             metadata["metrics"] = metrics
@@ -430,6 +444,7 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
             self._completed_steps = metadata["schedules"][PhaseType.training]["completed_steps"]
         else:
             self._completed_steps = metadata["completed_steps"]
+        self._documents_seen = metadata.get("documents_seen", 0)
         # TODO: Move barrier, ok file to FastLLMModel
         safe_barrier(
             self._distributed.world_group,

--- a/fast_llm/engine/training/trainer.py
+++ b/fast_llm/engine/training/trainer.py
@@ -39,7 +39,7 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
     _wandb: Wandb
     _optimizer: Optimizer | None
     _completed_steps: int
-    _documents_seen: int = 0
+    _documents_seen: int
     _schedule: Schedule
 
     def __init__(self, config: TrainerConfig):
@@ -228,10 +228,8 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
                     return_metrics=is_logging,
                 )
 
-                # Cumulative document count across training steps; `None` when the data provides no
-                # document counts.
-                if step_num_documents is not None:
-                    self._documents_seen += step_num_documents
+                # Cumulative document count across training steps.
+                self._documents_seen += step_num_documents
 
                 # Advanced, skipped, and Nan iterations.
                 if update_successful:

--- a/fast_llm/engine/training/trainer.py
+++ b/fast_llm/engine/training/trainer.py
@@ -221,16 +221,15 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
 
                 # TODO: Data loader hates getting all micro-batches at once.
                 #   (Also preprocessing adds overhead)
-                reduced_losses, update_successful, train_metrics = self._runner.run_step(
+                reduced_losses, update_successful, train_metrics, step_num_documents = self._runner.run_step(
                     train_iterator,
                     self._schedule,
                     iteration=self._completed_steps,
                     return_metrics=is_logging,
                 )
 
-                # Cumulative document count (the RL x-axis / model-version clock); `None` when the
-                # data provides no document counts (non-RL runs).
-                step_num_documents = self._runner._num_documents_in_batch
+                # Cumulative document count across training steps; `None` when the data provides no
+                # document counts.
                 if step_num_documents is not None:
                     self._documents_seen += step_num_documents
 

--- a/fast_llm/engine/training/wandb.py
+++ b/fast_llm/engine/training/wandb.py
@@ -14,9 +14,6 @@ class Wandb:
         self._config = config
         self._is_setup = True
         self._run = run
-        # Whether the `documents_seen` custom x-axis has been declared. Done lazily on the first log
-        # that carries a `documents_seen` value, since not every run produces one.
-        self._defined_documents_axis = False
         if self._config.entity_name is not None and self._run.is_main_rank:
             import wandb
             import wandb.sdk.lib.runid
@@ -47,6 +44,11 @@ class Wandb:
                     wandb_path.write_text(yaml.safe_dump(wandb_config))
             # TODO: Does wandb work with nested configs?
             self._wandb = wandb.init(config=experiment_config.to_dict(), **wandb_config)
+            # Offer `documents_seen` as an alternative (cross-run) x-axis for the training metrics.
+            # `wandb.log(step=...)` still records the global step, so both axes remain available.
+            documents_seen_metric = f"{PhaseType.training}/documents_seen"
+            self._wandb.define_metric(documents_seen_metric)
+            self._wandb.define_metric(f"{PhaseType.training}/*", step_metric=documents_seen_metric)
         else:
             self._wandb = None
 
@@ -54,14 +56,6 @@ class Wandb:
         # Note: metrics modified in-place
         if self._wandb is not None:
             import wandb
-
-            if not self._defined_documents_axis and any("documents_seen" in values for values in metrics.values()):
-                # Offer `documents_seen` as an alternative (cross-run) x-axis for the training metrics.
-                # `wandb.log(step=...)` still records the global step, so both axes remain available.
-                documents_seen_metric = f"{PhaseType.training}/documents_seen"
-                self._wandb.define_metric(documents_seen_metric)
-                self._wandb.define_metric(f"{PhaseType.training}/*", step_metric=documents_seen_metric)
-                self._defined_documents_axis = True
 
             wandb.log(metrics, step=completed_steps, commit=commit)  # noqa
 

--- a/fast_llm/engine/training/wandb.py
+++ b/fast_llm/engine/training/wandb.py
@@ -14,8 +14,8 @@ class Wandb:
         self._config = config
         self._is_setup = True
         self._run = run
-        # Whether the `documents_seen` custom x-axis has been declared (RL runs only, done lazily on
-        # the first log that carries it so non-RL runs are unaffected).
+        # Whether the `documents_seen` custom x-axis has been declared. Done lazily on the first log
+        # that carries a `documents_seen` value, since not every run produces one.
         self._defined_documents_axis = False
         if self._config.entity_name is not None and self._run.is_main_rank:
             import wandb
@@ -55,15 +55,12 @@ class Wandb:
         if self._wandb is not None:
             import wandb
 
-            if not self._defined_documents_axis and any(
-                isinstance(values, dict) and "documents_seen" in values for values in metrics.values()
-            ):
+            if not self._defined_documents_axis and any("documents_seen" in values for values in metrics.values()):
                 # Offer `documents_seen` as an alternative (cross-run) x-axis for the training metrics.
                 # `wandb.log(step=...)` still records the global step, so both axes remain available.
-                self._wandb.define_metric(f"{PhaseType.training}/documents_seen")
-                self._wandb.define_metric(
-                    f"{PhaseType.training}/*", step_metric=f"{PhaseType.training}/documents_seen"
-                )
+                documents_seen_metric = f"{PhaseType.training}/documents_seen"
+                self._wandb.define_metric(documents_seen_metric)
+                self._wandb.define_metric(f"{PhaseType.training}/*", step_metric=documents_seen_metric)
                 self._defined_documents_axis = True
 
             wandb.log(metrics, step=completed_steps, commit=commit)  # noqa

--- a/fast_llm/engine/training/wandb.py
+++ b/fast_llm/engine/training/wandb.py
@@ -5,6 +5,7 @@ import yaml
 
 from fast_llm.config import Config
 from fast_llm.engine.config_utils.run import Run
+from fast_llm.engine.distributed.config import PhaseType
 from fast_llm.engine.training.config import WandbConfig
 
 
@@ -13,6 +14,9 @@ class Wandb:
         self._config = config
         self._is_setup = True
         self._run = run
+        # Whether the `documents_seen` custom x-axis has been declared (RL runs only, done lazily on
+        # the first log that carries it so non-RL runs are unaffected).
+        self._defined_documents_axis = False
         if self._config.entity_name is not None and self._run.is_main_rank:
             import wandb
             import wandb.sdk.lib.runid
@@ -50,6 +54,17 @@ class Wandb:
         # Note: metrics modified in-place
         if self._wandb is not None:
             import wandb
+
+            if not self._defined_documents_axis and any(
+                isinstance(values, dict) and "documents_seen" in values for values in metrics.values()
+            ):
+                # Offer `documents_seen` as an alternative (cross-run) x-axis for the training metrics.
+                # `wandb.log(step=...)` still records the global step, so both axes remain available.
+                self._wandb.define_metric(f"{PhaseType.training}/documents_seen")
+                self._wandb.define_metric(
+                    f"{PhaseType.training}/*", step_metric=f"{PhaseType.training}/documents_seen"
+                )
+                self._defined_documents_axis = True
 
             wandb.log(metrics, step=completed_steps, commit=commit)  # noqa
 

--- a/fast_llm/engine/training/wandb.py
+++ b/fast_llm/engine/training/wandb.py
@@ -5,7 +5,6 @@ import yaml
 
 from fast_llm.config import Config
 from fast_llm.engine.config_utils.run import Run
-from fast_llm.engine.distributed.config import PhaseType
 from fast_llm.engine.training.config import WandbConfig
 
 
@@ -44,11 +43,6 @@ class Wandb:
                     wandb_path.write_text(yaml.safe_dump(wandb_config))
             # TODO: Does wandb work with nested configs?
             self._wandb = wandb.init(config=experiment_config.to_dict(), **wandb_config)
-            # Offer `documents_seen` as an alternative (cross-run) x-axis for the training metrics.
-            # `wandb.log(step=...)` still records the global step, so both axes remain available.
-            documents_seen_metric = f"{PhaseType.training}/documents_seen"
-            self._wandb.define_metric(documents_seen_metric)
-            self._wandb.define_metric(f"{PhaseType.training}/*", step_metric=documents_seen_metric)
         else:
             self._wandb = None
 

--- a/fast_llm/layers/language_model/loss/policy_gradient.py
+++ b/fast_llm/layers/language_model/loss/policy_gradient.py
@@ -136,7 +136,7 @@ class LanguageModelPolicyGradientLoss[ConfigType: LanguageModelPolicyGradientLos
         return defs
 
     def get_preprocessing_config(self) -> dict[str, typing.Any]:
-        return {"use_grpo_data": True, "return_label_counts": True, "return_document_count": True}
+        return {"use_grpo_data": True, "return_label_counts": True}
 
     @functools.cached_property
     def _logprob_metric_name(self) -> str:

--- a/tests/data/test_preprocessing.py
+++ b/tests/data/test_preprocessing.py
@@ -63,7 +63,6 @@ class PreprocessingTestConfig:
     return_prediction_mask: bool = False
     return_label_counts: bool = False
     return_position_index: bool = False
-    return_document_count: bool = False
     return_cumulative_sequence_lengths: bool = False
 
     @functools.cached_property
@@ -76,7 +75,6 @@ class PreprocessingTestConfig:
             "return_prediction_mask": self.return_prediction_mask,
             "return_label_counts": self.return_label_counts,
             "return_position_index": self.return_position_index,
-            "return_document_count": self.return_document_count,
             "return_cumulative_sequence_lengths": self.return_cumulative_sequence_lengths,
         }
 
@@ -237,11 +235,8 @@ class PreprocessingTestConfig:
         return result
 
     @functools.cached_property
-    def expected_num_documents(self) -> list[int | None]:
-        if self.return_document_count:
-            return [len(self.tokens) if split_index == 0 else 0 for split_index in range(self.micro_batch_splits)]
-        else:
-            return [None] * self.micro_batch_splits
+    def expected_num_documents(self) -> list[int]:
+        return [len(self.tokens) if split_index == 0 else 0 for split_index in range(self.micro_batch_splits)]
 
 
 _BASE_TEST_CASES = [
@@ -313,13 +308,11 @@ _RETURN_CONFIG_VARIANTS: dict[str, dict] = {
     "prediction_mask": {"return_prediction_mask": True},
     "label_counts": {"return_label_counts": True},
     "position_index": {"return_position_index": True},
-    "document_count": {"return_document_count": True},
     "cumulative_sequence_lengths": {"return_cumulative_sequence_lengths": True},
     "all": {
         "return_prediction_mask": True,
         "return_label_counts": True,
         "return_position_index": True,
-        "return_document_count": True,
         "return_cumulative_sequence_lengths": True,
     },
 }


### PR DESCRIPTION
_Claude Sonnet 5, on behalf of @jlamypoirier._

## Summary

Extracted from #553 as the first, independent piece of the RL diagnostics umbrella: the
`documents_seen` document-clock counter itself. Split out ahead of the `weights_ready`
document-count model version + reward/model_version staleness metrics (separate PRs) because
those both depend on this counter existing (the model version *is* `documents_seen`, and
staleness is computed as `documents_seen - model_version`) — this PR has no dependents-side
prerequisites and stands alone.

- `ScheduleRunner` exposes the whole-step DP-summed document count (`num_documents_in_batch`,
  the loss-normalization divisor) as `_num_documents_in_batch`, also returned as part of
  `run_step`'s return tuple.
- The trainer accumulates it into `_documents_seen` every step (persisted in checkpoint
  metadata, restored on resume) and logs `num_documents` + `documents_seen` in the step metrics
  (console + W&B) on every logging step.
- `Wandb` declares `training/documents_seen` as an alternative `step_metric` for `training/*` at
  setup, so it can be used as a cross-run x-axis. The global `wandb.log(step=...)` step is
  unchanged, so both axes remain available.
- **Document counting is unconditional**, not an opt-in loss preprocessing flag. It used to
  activate only as a side effect of GRPO/GSPO's loss preprocessing config requesting it (for
  their own, unrelated loss-normalization divisor) — an obscure, indirect enablement path for a
  training-level metric. Document counting is a real, DP-wide `all_reduce` per step, so this is a
  deliberate tradeoff (sync cost accepted for every run) rather than an oversight. The now-dead
  `return_document_count` flag and its now-empty `TokenPreprocessingConfig` host class were both
  removed, along with a couple of downstream now-always-true conditionals this uncovered
  (`TokenModelInput.share_batch_data`'s guard, the lazy W&B metric-definition dance, the
  metrics-dict presence check).

## Tests

- `tests/data/test_streaming.py`: 23 passed (CPU).
- Broader regression pass after making document counting unconditional: `test_preprocessing.py`,
  `test_streaming.py`, `test_random.py`, `test_attention.py`, `test_varlen.py`, `test_ssm.py`,
  `test_lm_losses.py`, `test_lm_head.py` — 1450 passed / 35 skipped, 0 failures.
- No dedicated unit test added for the `documents_seen` accumulator/checkpoint round-trip; would
  require new checkpoint-test infrastructure for GRPO/GSPO models (currently marked
  `not_implemented` in `tests/utils/model_configs.py`) — out of scope here, left as a known gap.
- The GPU end-to-end integration test (`tests/models/test_streaming.py::test_model_streaming`,
  which exercises `documents_seen`) was **not** run here (no GPU) — worth running in CI before
  merge.