### PR TITLE
Log weight-sync time as a streaming-trainer metric

### DIFF
--- a/fast_llm/engine/training/config.py
+++ b/fast_llm/engine/training/config.py
@@ -397,8 +397,9 @@ class TrainerCallback[ConfigType: TrainerCallbackConfig](Configurable[ConfigType
         reduced_losses: dict[str, float | int],
         update_successful: bool,
         train_metrics: dict[str, typing.Any] | None,
-    ):
-        pass
+    ) -> dict[str, typing.Any] | None:
+        """Optionally return a dict of scalar metrics to merge into the step's training logs."""
+        return None
 
     def train_end(self, step: int):
         pass

--- a/fast_llm/engine/training/streaming.py
+++ b/fast_llm/engine/training/streaming.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 import typing
 
 import torch
@@ -23,6 +24,19 @@ class StreamingTrainerCallback[ConfigType: StreamingTrainerCallbackConfig](Train
         super().__init__(config)
         self._model = model
         self._do_broadcast = self._model.config.distributed.rank == 0
+        # Weight-sync timing, measured on the broadcasting rank only. On CUDA we bracket the sync with
+        # events and read the result one step later (`_weight_sync_pending`), so the always-on timer
+        # never forces a CPU stall on the broadcast, which otherwise overlaps the next step's compute.
+        self._use_cuda_timing = (
+            self._do_broadcast
+            and self._config.broadcast.backend == DistributedBackend.nccl
+            and torch.cuda.is_available()
+        )
+        self._weight_sync_time_ms: float | None = None
+        self._weight_sync_pending = False
+        if self._use_cuda_timing:
+            self._weight_sync_start = torch.cuda.Event(enable_timing=True)
+            self._weight_sync_end = torch.cuda.Event(enable_timing=True)
         if self._do_broadcast:
             self._client = self._config.get_client()
             init_method = f"tcp://{config.broadcast.host}:{config.broadcast.port}"
@@ -50,9 +64,16 @@ class StreamingTrainerCallback[ConfigType: StreamingTrainerCallbackConfig](Train
         reduced_losses: dict[str, float | int],
         update_successful: bool,
         train_metrics: dict[str, typing.Any] | None,
-    ):
+    ) -> dict[str, typing.Any] | None:
+        # Harvest the previous broadcast's timing before re-recording the events on this step's sync.
+        if self._weight_sync_pending and self._weight_sync_end.query():
+            self._weight_sync_time_ms = self._weight_sync_start.elapsed_time(self._weight_sync_end)
+            self._weight_sync_pending = False
         if update_successful:
             self._broadcast_weights(step)
+        if self._weight_sync_time_ms is None:
+            return None
+        return {"weight_sync_time_ms": self._weight_sync_time_ms}
 
     def train_end(self, step: int):
         # TODO: ====== Send something on unsuccessful ends? ======
@@ -74,6 +95,10 @@ class StreamingTrainerCallback[ConfigType: StreamingTrainerCallbackConfig](Train
             self._client.xadd(
                 REDIS_TRAINING_STREAM, {REDIS_TRAINING_FIELD: json.dumps({"type": "weights_ready", "step": step})}
             )
+        if self._use_cuda_timing:
+            self._weight_sync_start.record()
+        elif self._do_broadcast:
+            sync_start_time = time.perf_counter()
         for shard_name, layer_name, tensor in self._model.iter_checkpoint(self._config.export, {}):
             if self._do_broadcast:
                 # TODO: ====== Broadcast metadata in advance =======
@@ -82,3 +107,8 @@ class StreamingTrainerCallback[ConfigType: StreamingTrainerCallbackConfig](Train
         # Broadcast end of weights broadcast
         if self._do_broadcast:
             _broadcast_object(None, self._process_group, src=0)
+        if self._use_cuda_timing:
+            self._weight_sync_end.record()
+            self._weight_sync_pending = True
+        elif self._do_broadcast:
+            self._weight_sync_time_ms = (time.perf_counter() - sync_start_time) * 1000

--- a/fast_llm/engine/training/streaming.py
+++ b/fast_llm/engine/training/streaming.py
@@ -71,6 +71,9 @@ class StreamingTrainerCallback[ConfigType: StreamingTrainerCallbackConfig](Train
             self._weight_sync_pending = False
         if update_successful:
             self._broadcast_weights(step)
+        # Report the last measured sync (not reset between steps): a broadcast runs on ~every step so
+        # this stays current, and holding the value keeps a skipped or not-yet-harvested step from
+        # dropping the metric.
         if self._weight_sync_time_ms is None:
             return None
         return {"weight_sync_time_ms": self._weight_sync_time_ms}
@@ -95,10 +98,11 @@ class StreamingTrainerCallback[ConfigType: StreamingTrainerCallbackConfig](Train
             self._client.xadd(
                 REDIS_TRAINING_STREAM, {REDIS_TRAINING_FIELD: json.dumps({"type": "weights_ready", "step": step})}
             )
+        weight_sync_start_time = None
         if self._use_cuda_timing:
             self._weight_sync_start.record()
         elif self._do_broadcast:
-            sync_start_time = time.perf_counter()
+            weight_sync_start_time = time.perf_counter()
         for shard_name, layer_name, tensor in self._model.iter_checkpoint(self._config.export, {}):
             if self._do_broadcast:
                 # TODO: ====== Broadcast metadata in advance =======
@@ -111,4 +115,4 @@ class StreamingTrainerCallback[ConfigType: StreamingTrainerCallbackConfig](Train
             self._weight_sync_end.record()
             self._weight_sync_pending = True
         elif self._do_broadcast:
-            self._weight_sync_time_ms = (time.perf_counter() - sync_start_time) * 1000
+            self._weight_sync_time_ms = (time.perf_counter() - weight_sync_start_time) * 1000

--- a/fast_llm/engine/training/trainer.py
+++ b/fast_llm/engine/training/trainer.py
@@ -236,8 +236,13 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
                     skipped_iters += 1
                     nan_iters += not all(math.isfinite(loss) for loss in reduced_losses.values())
 
+                callback_metrics = {}
                 for callback in self._callbacks.values():
-                    callback.step_end(self._completed_steps, reduced_losses, update_successful, train_metrics)
+                    returned_metrics = callback.step_end(
+                        self._completed_steps, reduced_losses, update_successful, train_metrics
+                    )
+                    if returned_metrics:
+                        callback_metrics.update(returned_metrics)
                 # Logging.
                 metrics = {}
                 if is_logging:
@@ -274,6 +279,7 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
                             ),
                             "run": self._run.index,
                             **train_metrics,
+                            **callback_metrics,
                             **get_and_reset_memory_usage_mib(),
                         }
 


### PR DESCRIPTION
## What

The streaming trainer callback broadcasts the full model to the inference actor on every successful step — synchronously, inside the training loop (so it's part of `step_time_ms`) — but nothing measured how long that takes. This logs it as `weight_sync_time_ms`, so the share of step time spent shipping weights is visible in the training logs and W&B.

Part of the RL-diagnostics initiative (making the Fast-LLM trainer the single source of truth for RL metrics); shipped as an independent PR since it's self-contained and touches no wire schema.

## How

- **Timing**: bracket the broadcast (`iter_checkpoint` ZeRO-gather + NCCL push) with CUDA events on the broadcasting rank. The result is read **one step later** (`_weight_sync_pending` + `Event.query()`), so the always-on timer never forces a CPU stall — the broadcast otherwise overlaps the next step's compute, and reading `elapsed_time` immediately would serialize them. `broadcast()` runs with `async_op=False` (`work.wait()`), so the current stream is ordered after the transfer and the `end` event captures true completion. The CPU/gloo broadcast path (non-NCCL) falls back to a plain `perf_counter` measurement, which needs no deferral.
- **Plumbing**: `TrainerCallback.step_end` may now return a `dict[str, Any] | None` of scalar metrics; the trainer merges any returned dicts into the step's training metrics alongside `**train_metrics`. Base callback returns `None`.
- Scope is **trainer-side broadcast only** — actor receive/load time is out of scope.

## Cost

Zero on the disabled path (non-streaming runs never construct the callback). On the streaming path: two reusable CUDA events and one deferred `elapsed_time` read per logging step — negligible against a full-model gather+broadcast, and no added GPU sync.

## Testing

No unit test: the path requires a live Redis + external-world rendezvous + CUDA, there's no streaming-callback test harness, and the only logic is the CUDA-event deferral state machine. Verified imports + black locally; the metric is validated on a live streaming RL run (the new key appears under `training/*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)