### PR TITLE
Broadcast documents_seen as the model version in weights_ready

### DIFF
--- a/fast_llm/engine/training/config.py
+++ b/fast_llm/engine/training/config.py
@@ -388,7 +388,7 @@ class TrainerConfig(PretrainedFastLLMModelConfig, ExperimentConfig):
 
 class TrainerCallback[ConfigType: TrainerCallbackConfig](Configurable[ConfigType]):
     # TODO: Make a more exhaustive set of events and arguments.
-    def run_begin(self, step: int):
+    def run_begin(self, step: int, documents_seen: int):
         pass
 
     def step_end(
@@ -397,6 +397,7 @@ class TrainerCallback[ConfigType: TrainerCallbackConfig](Configurable[ConfigType
         reduced_losses: dict[str, float | int],
         update_successful: bool,
         train_metrics: dict[str, typing.Any] | None,
+        documents_seen: int,
     ):
         pass
 

--- a/fast_llm/engine/training/streaming.py
+++ b/fast_llm/engine/training/streaming.py
@@ -72,13 +72,13 @@ class StreamingTrainerCallback[ConfigType: StreamingTrainerCallbackConfig](Train
 
     def _broadcast_weights(self, step: int, documents_seen: int):
         if self._do_broadcast:
-            # `document_count` is the model version consumers stamp onto rollouts (aligning staleness
-            # with DeepSpeed's document clock); `step` is kept so consumers can also log the raw step.
+            # `documents_seen` is the cumulative document count, which doubles as the model version;
+            # `step` is the raw training step.
             self._client.xadd(
                 REDIS_TRAINING_STREAM,
                 {
                     REDIS_TRAINING_FIELD: json.dumps(
-                        {"type": "weights_ready", "step": step, "document_count": documents_seen}
+                        {"type": "weights_ready", "step": step, "documents_seen": documents_seen}
                     )
                 },
             )

--- a/fast_llm/engine/training/streaming.py
+++ b/fast_llm/engine/training/streaming.py
@@ -40,9 +40,9 @@ class StreamingTrainerCallback[ConfigType: StreamingTrainerCallbackConfig](Train
             self._process_group = self._pool.get_process_group(range(world_size), 0)
             logger.info(f"Weights broadcast rendezvous at {init_method} connected")
 
-    def run_begin(self, step: int):
+    def run_begin(self, step: int, documents_seen: int):
         # TODO: ====== Send a train / run begin signal? ======
-        self._broadcast_weights(step)
+        self._broadcast_weights(step, documents_seen)
 
     def step_end(
         self,
@@ -50,9 +50,10 @@ class StreamingTrainerCallback[ConfigType: StreamingTrainerCallbackConfig](Train
         reduced_losses: dict[str, float | int],
         update_successful: bool,
         train_metrics: dict[str, typing.Any] | None,
+        documents_seen: int,
     ):
         if update_successful:
-            self._broadcast_weights(step)
+            self._broadcast_weights(step, documents_seen)
 
     def train_end(self, step: int):
         # TODO: ====== Send something on unsuccessful ends? ======
@@ -69,10 +70,17 @@ class StreamingTrainerCallback[ConfigType: StreamingTrainerCallbackConfig](Train
             del self._pool
             del self._process_group
 
-    def _broadcast_weights(self, step: int):
+    def _broadcast_weights(self, step: int, documents_seen: int):
         if self._do_broadcast:
+            # `document_count` is the model version consumers stamp onto rollouts (aligning staleness
+            # with DeepSpeed's document clock); `step` is kept so consumers can also log the raw step.
             self._client.xadd(
-                REDIS_TRAINING_STREAM, {REDIS_TRAINING_FIELD: json.dumps({"type": "weights_ready", "step": step})}
+                REDIS_TRAINING_STREAM,
+                {
+                    REDIS_TRAINING_FIELD: json.dumps(
+                        {"type": "weights_ready", "step": step, "document_count": documents_seen}
+                    )
+                },
             )
         for shard_name, layer_name, tensor in self._model.iter_checkpoint(self._config.export, {}):
             if self._do_broadcast:

--- a/fast_llm/engine/training/streaming.py
+++ b/fast_llm/engine/training/streaming.py
@@ -96,8 +96,6 @@ class StreamingTrainerCallback[ConfigType: StreamingTrainerCallbackConfig](Train
 
     def _broadcast_weights(self, step: int, documents_seen: int):
         if self._do_broadcast:
-            # `documents_seen` is the cumulative document count, which doubles as the model version;
-            # `step` is the raw training step.
             self._client.xadd(
                 REDIS_TRAINING_STREAM,
                 {

--- a/fast_llm/engine/training/trainer.py
+++ b/fast_llm/engine/training/trainer.py
@@ -203,7 +203,7 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
         safe_barrier(self._distributed.world_group, "train begin")
 
         for callback in self._callbacks.values():
-            callback.run_begin(self._completed_steps)
+            callback.run_begin(self._completed_steps, self._documents_seen)
 
         if torch.cuda.is_available():
             torch.cuda.synchronize()
@@ -237,7 +237,13 @@ class Trainer[ConfigType: TrainerConfig](Configurable[ConfigType], abc.ABC):
                     nan_iters += not all(math.isfinite(loss) for loss in reduced_losses.values())
 
                 for callback in self._callbacks.values():
-                    callback.step_end(self._completed_steps, reduced_losses, update_successful, train_metrics)
+                    callback.step_end(
+                        self._completed_steps,
+                        reduced_losses,
+                        update_successful,
+                        train_metrics,
+                        self._documents_seen,
+                    )
                 # Logging.
                 metrics = {}
                 if is_logging:

--- a/tests/models/test_streaming.py
+++ b/tests/models/test_streaming.py
@@ -112,6 +112,8 @@ def _run_event_consumer(
                 if message["type"] == "training_finished":
                     return
                 elif message["type"] == "weights_ready":
+                    Assert.incl("documents_seen", message)
+                    Assert.geq(message["documents_seen"], 0)
                     weights = {}
                     while True:
                         meta = _broadcast_object(None, process_group, src=0)

--- a/tests/models/test_streaming.py
+++ b/tests/models/test_streaming.py
@@ -93,6 +93,7 @@ def _run_event_consumer(
         process_group = pool.get_process_group(range(world_size), consumer_rank)
         timeout_ms = int(streaming_config.timeout * 1000)
         last_id = "0-0"
+        last_documents_seen = 0
         while True:
             result = client.xread(
                 streams={REDIS_TRAINING_STREAM: last_id},
@@ -113,7 +114,8 @@ def _run_event_consumer(
                     return
                 elif message["type"] == "weights_ready":
                     Assert.incl("documents_seen", message)
-                    Assert.geq(message["documents_seen"], 0)
+                    Assert.geq(message["documents_seen"], last_documents_seen)
+                    last_documents_seen = message["documents_seen"]
                     weights = {}
                     while True:
                         meta = _broadcast_object(None, process_group, src=0)


### PR DESCRIPTION
_Claude Opus 4.8, on behalf of @jlamypoirier._

## Summary

Extracted from #553. Split from the reward / per-token-`model_version` piece (briefly combined in
#557, now closed) since the two have no code dependency — this is purely the producer-side
broadcast; the other PR is a data-pipeline consumer of a different field.

- The `weights_ready` event now carries `documents_seen` (the cumulative document count, which
  doubles as the model version) alongside the existing `step` (= completed step). A consumer can
  stamp `documents_seen` onto rollouts so staleness is measured in documents, aligning with the
  document clock; `step` remains available for logging. Keeping `step` makes this
  backward-compatible.
- Threads `documents_seen` through the `TrainerCallback.run_begin` / `step_end` hooks.

The counter itself (`Trainer._documents_seen`) landed in #559 and is now on `main`; this branch is
merged up to current `main` (which also carries the weight-sync-time metric from #560, with which
`step_end` integrates cleanly). The paired PipelineRL change (reading `documents_seen` as the model
version) is a separate PR against PipelineRL's `fast-llm` branch.

## Tests

- `tests/data/test_streaming.py`: passes (CPU).
- `tests/models/test_streaming.py` (GPU end-to-end) now asserts each `weights_ready` message carries
  a non-decreasing `documents_seen`; not run here (no GPU) — worth running in CI before merge.
