### PR TITLE
Fix CI on torch 2.13: raw-process-group collectives + flaky GSPO metrics tolerance

### DIFF
--- a/fast_llm/core/distributed.py
+++ b/fast_llm/core/distributed.py
@@ -15,14 +15,13 @@ import typing
 
 import torch
 import torch.monitor
+from torch._C._distributed_c10d import AllgatherOptions, ReduceScatterOptions
 from torch.distributed import (  # noqa
     ProcessGroup,
     ReduceOp,
     all_gather,
-    all_gather_into_tensor,
     all_reduce,
     reduce_scatter,
-    reduce_scatter_tensor,
 )
 
 logger = logging.getLogger(__name__)
@@ -63,6 +62,47 @@ def broadcast(
     else:
         work.wait()
         return None
+
+
+def all_gather_into_tensor(
+    output_tensor: torch.Tensor, input_tensor: torch.Tensor, group: ProcessGroup, async_op: bool = False
+) -> torch.distributed.Work | None:
+    """
+    Same as torch.distributed.all_gather_into_tensor, but calling the group directly instead of going through
+    torch's deprecated public wrapper. As of torch 2.13, that wrapper only supports the generic `ProcessGroup`
+    returned by `torch.distributed.new_group` and raises an `AttributeError` on the raw `Backend` objects
+    (e.g. `ProcessGroupGloo`, `ProcessGroupNCCL`) used here.
+    """
+    assert group is not None
+    opts = AllgatherOptions()
+    opts.asyncOp = async_op
+    work = group._allgather_base(output_tensor, input_tensor, opts)
+    if async_op:
+        return work
+    elif work is not None:
+        work.wait()
+    return None
+
+
+def reduce_scatter_tensor(
+    output: torch.Tensor,
+    input_: torch.Tensor,
+    group: ProcessGroup,
+    op: ReduceOp.RedOpType = ReduceOp.SUM,
+    async_op: bool = False,
+) -> torch.distributed.Work | None:
+    """Same as torch.distributed.reduce_scatter_tensor, bypassing torch's deprecated wrapper for the same reason
+    as `all_gather_into_tensor` above."""
+    assert group is not None
+    opts = ReduceScatterOptions()
+    opts.reduceOp = op
+    opts.asyncOp = async_op
+    work = group._reduce_scatter_base(output, input_, opts)
+    if async_op:
+        return work
+    elif work is not None:
+        work.wait()
+    return None
 
 
 def check_parallel_match(tensor: torch.Tensor, group: ProcessGroup | None, name: str) -> None:
@@ -114,7 +154,7 @@ def all_gather_scalar(
         value = torch.full([1], value, dtype=dtype, device=_get_device(group))
         output_tensor = value.new_empty((group.size(),))
         with set_timeout(group, timeout):
-            torch.distributed.all_gather_into_tensor(output_tensor, value, group=group)
+            all_gather_into_tensor(output_tensor, value, group=group)
         return output_tensor.tolist()
     else:
         return value

--- a/fast_llm/engine/multi_stage/fsdp.py
+++ b/fast_llm/engine/multi_stage/fsdp.py
@@ -4,9 +4,8 @@ import math
 import typing
 
 import torch
-from torch.distributed import all_reduce, reduce_scatter_tensor
 
-from fast_llm.core.distributed import ProcessGroup
+from fast_llm.core.distributed import ProcessGroup, all_reduce, reduce_scatter_tensor
 from fast_llm.core.ops import gather_op
 from fast_llm.engine.config_utils.data_type import DataType
 from fast_llm.engine.config_utils.tensor_dim import TensorDim

--- a/tests/layers/test_lm_losses.py
+++ b/tests/layers/test_lm_losses.py
@@ -562,7 +562,7 @@ def _check_policy_metrics(ref: PolicyMetrics, got: PolicyMetrics, threshold: flo
         if ref_value is None:
             assert got_value is None, name
         else:
-            Assert.rms_close_relative(got_value, ref_value, threshold)
+            Assert.rms_close_relative(got_value, ref_value, threshold, 1e-6)
 
 
 def _test_grpo_metrics(


### PR DESCRIPTION
Claude Opus 4.8:

Two independent fixes needed to get CI green on `main` again. Both surfaced when CI auto-upgraded to torch 2.13.0 (`setup.cfg` pins `torch>=2.9.0`, unbounded), so they land together.

## Fix 1 — `all_gather`/`reduce_scatter` on raw process groups (torch 2.13)
CI was crashing on every `tests/models/test_model.py` distributed test (cascading through pytest-depends) with:
```
AttributeError: 'torch._C._distributed_c10d.ProcessGroupGloo' object has no attribute 'all_gather_single'
```
In torch 2.13, the deprecated `torch.distributed.all_gather_into_tensor`/`reduce_scatter_tensor` now dispatch through new `all_gather_single`/`reduce_scatter_single` methods. Those are only bound on the generic `ProcessGroup` wrapper from `torch.distributed.new_group()` — not on the raw `Backend`-derived objects (`ProcessGroupGloo`, `ProcessGroupNCCL`) that Fast-LLM constructs directly (`fast_llm/engine/distributed/distributed.py` deliberately bypasses `init_process_group`). Confirmed against PyTorch's C++ pybind bindings at the `v2.13.0` tag.

`fast_llm/core/distributed.py`: reimplement both to call `group._allgather_base(...)`/`group._reduce_scatter_base(...)` directly — the actual underlying virtual methods, with an identical signature on `Backend` across torch 2.9.0, 2.13.0, and current `main`, so no version check is needed. `fast_llm/engine/multi_stage/fsdp.py` imported `reduce_scatter_tensor` straight from `torch.distributed` (same bug, FSDP gradient reduce-scatter path) — now routed through `fast_llm.core.distributed` like everything else.

## Fix 2 — flaky GSPO/GRPO metrics tolerance (regression from #555)
Once Fix 1 let the distributed suite run, `test_lm_loss_distributed[...gspo_metrics...]` failed:
```
AssertionError: Rms diff too big (2.38e-07 > 2.21e-07, scale = 4.43e-03)
```
`_check_policy_metrics` (added in #555) compared each metric with a relative-only threshold (`min_threshold=0`). A near-zero-scale metric (e.g. `kl_new_old` ≈ 4e-3) got an effective bound of `5e-5 × scale ≈ 2.2e-7`, below the float32 accumulation noise floor. The reference (naive loop) and implementation (fused kernel + tensor-parallel all-reduce) sum in different orders and differ by a few e-7 absolute; torch 2.13's rounding shifted it just over the line. Add a `1e-6` absolute floor, matching every other `rms_close_relative` call in the file (loss + log-prob comparisons). The floor only engages when `5e-5 × scale < 1e-6` (scale < 2e-2), so O(1)-scale metrics keep the full relative tolerance.

## Test plan
- [x] `tests/models/test_model.py --models gpt_2` (30 tests, incl. `dp2`/`tp2`/`sdp2` on Gloo) passes locally on torch 2.11.0 — no regression on the previously-working version.
- [x] `tests/layers/test_lm_losses.py` (582 passed / 21 skipped, incl. the full distributed GSPO/GRPO metrics chain) passes locally on torch 2.11.0.
- [ ] CI on this PR runs torch 2.13.0 — the real test of both fixes (torch 2.13.0 isn't in the local dev venv).